### PR TITLE
Added item-specific responses

### DIFF
--- a/src/Randomizer.SMZ3.Tracking/Configuration/ResponseConfig.cs
+++ b/src/Randomizer.SMZ3.Tracking/Configuration/ResponseConfig.cs
@@ -119,11 +119,6 @@ namespace Randomizer.SMZ3.Tracking.Configuration
             = new SchrodingersString("There are no items left in {0}.");
 
         /// <summary>
-        /// Gets the phrases to respond with when tracking a specific item.
-        /// </summary>
-        public Dictionary<string, SchrodingersString> TrackedSpecificItem { get; init; } = new();
-
-        /// <summary>
         /// Gets the phrases to respond with when untracking an item.
         /// </summary>
         /// <remarks>

--- a/src/Randomizer.SMZ3.Tracking/Tracker.cs
+++ b/src/Randomizer.SMZ3.Tracking/Tracker.cs
@@ -656,17 +656,35 @@ namespace Randomizer.SMZ3.Tracking
                     // to that stage specifically
                     var stageName = item.Stages[stage.Value].ToString();
                     if (item.Track(stage.Value))
-                        Say(Responses.TrackedItemByStage.Format(itemName, stageName));
+                    {
+                        if (item.TryGetTrackingResponse(out var response))
+                        {
+                            Say(response.Format(item.Counter));
+                        }
+                        else
+                        {
+                            Say(Responses.TrackedItemByStage.Format(itemName, stageName));
+                        }
+                    }
                     else
+                    {
                         Say(Responses.TrackedOlderProgressiveItem?.Format(itemName, item.Stages[item.TrackingState].ToString()));
+                    }
                 }
                 else
                 {
                     // Tracked by regular name, upgrade by one step
                     if (item.Track())
                     {
-                        var stageName = item.Stages[item.TrackingState].ToString();
-                        Say(Responses.TrackedProgressiveItem.Format(itemName, stageName));
+                        if (item.TryGetTrackingResponse(out var response))
+                        {
+                            Say(response.Format(item.Counter));
+                        }
+                        else
+                        {
+                            var stageName = item.Stages[item.TrackingState].ToString();
+                            Say(Responses.TrackedProgressiveItem.Format(itemName, stageName));
+                        }
                     }
                     else
                     {
@@ -677,7 +695,9 @@ namespace Randomizer.SMZ3.Tracking
             else if (item.Multiple)
             {
                 item.Track();
-                if (item.Counter == 1)
+                if (item.TryGetTrackingResponse(out var response))
+                    Say(response.Format(item.Counter));
+                else if (item.Counter == 1)
                     Say(Responses.TrackedItem.Format(itemName));
                 else if (item.Counter > 1)
                     Say(Responses.TrackedItemMultiple.Format(item.Plural ?? $"{itemName}s", item.Counter));
@@ -691,10 +711,9 @@ namespace Randomizer.SMZ3.Tracking
             {
                 if (item.Track())
                 {
-                    if (Responses.TrackedSpecificItem.TryGetValue(item.Name[0], out var responses)
-                        && responses.Count > 0)
+                    if (item.TryGetTrackingResponse(out var response))
                     {
-                        Say(responses);
+                        Say(response.Format(item.Counter));
                     }
                     else
                     {
@@ -918,7 +937,11 @@ namespace Randomizer.SMZ3.Tracking
 
             var oldItemCount = item.TrackingState;
             item.TrackingState = newItemCount;
-            if (newItemCount > oldItemCount)
+            if (item.TryGetTrackingResponse(out var response))
+            {
+                Say(response.Format(item.Counter));
+            }
+            else if (newItemCount > oldItemCount)
             {
                 Say(Responses.TrackedItemMultiple.Format(item.Plural ?? $"{item.Name}s", item.Counter));
             }

--- a/src/Randomizer.SMZ3.Tracking/tracker.json
+++ b/src/Randomizer.SMZ3.Tracking/tracker.json
@@ -13,8 +13,14 @@
       "Multiple": true
     },
     {
-      "Name": [ "Content" ],
-      "Plural": [ "Content" ],
+      "Name": [
+        [ "Content", 0 ],
+        "Con-tent"
+      ],
+      "Plural": [
+        [ "Content", 0 ],
+        "Con-tent"
+      ],
       "Article": "",
       "InternalItemType": 0,
       "Column": 10,
@@ -28,12 +34,23 @@
       "InternalItemType": 0,
       "Column": 10,
       "Row": 6,
-      "Multiple": true
+      "Multiple": true,
+      "WhenTracked": {
+        "1": [ "lawl, you died" ],
+        "2": [ "You've died {0} times." ],
+        "5": [
+          "You've died {0} times now.",
+          [ "Maybe I should take over", 0.1 ]
+        ]
+      }
     },
     {
       "Name": [ "Shaktool Go Mode" ],
       "Article": "",
-      "InternalItemType": 0
+      "InternalItemType": 0,
+      "WhenTracked": {
+        "1": [ "Toggled Shaktool Go Mode <break time='1s'/> on." ]
+      }
     },
     {
       "Name": [
@@ -42,7 +59,10 @@
       ],
       "InternalItemType": 0,
       "Column": 6,
-      "Row": 5
+      "Row": 5,
+      "WhenTracked": {
+        "1": [ "Toggled Kraid on. Watch out for his awful son on the way out." ]
+      }
     },
     {
       "Name": [ "Crocomire" ],
@@ -64,7 +84,13 @@
       "Name": [ "Shaktool", "The Shaktool" ],
       "InternalItemType": 0,
       "Column": 6,
-      "Row": 6
+      "Row": 6,
+      "WhenTracked": {
+        "1": [
+          "Toggled Shaktool on. Remember, killing Shaktool is bad for metrics.",
+          "Toggled Shaktool on. Did you get something nice?"
+        ]
+      }
     },
     {
       "Name": [ "Draygon" ],
@@ -268,7 +294,10 @@
       "Name": [ "One Rupee", "Green Rupee" ],
       "InternalItemType": 52,
       "Artice": "",
-      "Multiple": true
+      "Multiple": true,
+      "WhenTracked": {
+        "1": "Really?"
+      }
     },
     {
       "Name": [ "Five Rupees", "Blue Rupee" ],
@@ -280,7 +309,11 @@
       "Name": [ "Twenty Rupees", "Red Rupee", "Big 20" ],
       "InternalItemType": 54,
       "Artice": "",
-      "Multiple": true
+      "Multiple": true,
+      "WhenTracked": {
+        "1": [ "Seriously?", "This is not the con-tent you are looking for." ],
+        "2": null
+      }
     },
     {
       "Name": [
@@ -310,12 +343,12 @@
       "Multiple": true
     },
     {
-      "Name": "Single Arrow",
+      "Name": [ "Single Arrow", "Single Stick" ],
       "InternalItemType": 67,
       "Multiple": true
     },
     {
-      "Name": "Ten Arrows",
+      "Name": [ "Ten Arrows", "Ten Sticks", "Sticks" ],
       "InternalItemType": 68,
       "Artice": "",
       "Multiple": true
@@ -379,7 +412,11 @@
         "4": [ "Gold Sword", "Butter" ]
       },
       "Column": 4,
-      "Row": 4
+      "Row": 4,
+      "WhenTracked": {
+        "3": [ "Toggled Bacon on", "Hmm... Bacon" ],
+        "4": null
+      }
     },
     {
       "Name": [
@@ -660,7 +697,11 @@
       "Multiple": true,
       "CounterMultiplier": 5,
       "Column": 7,
-      "Row": 4
+      "Row": 4,
+      "WhenTracked": {
+        "69": "Nice",
+        "70": null
+      }
     },
     {
       "Name": [
@@ -973,11 +1014,6 @@
     "GoModeToggledOff": [
       "Toggled Go Mode off."
     ],
-    "TrackedSpecificItem": {
-      "Shaktool Go Mode": [
-        "Toggled Shaktool Go Mode <break time='1s'/> on."
-      ]
-    },
     "Idle": {
       "10m±2m": [ "Decreased content by one step.", "What's wrong? Am I not good enough for you anymore?" ]
     }


### PR DESCRIPTION
Added the ability to configure item-specific responses using a _WhenTracked_ property on each item in `tracker.json`.

It is a dictionary where each key is an int that represents the current tracking state. When tracking an item, it tries to find the closest key in the dictionary that is smaller. For example, in a dictionary that has entries for 1, 2 and 5, requesting 4 will return the entry for 2.

If `null` is encountered, it will default to generic item responses. You can use this to add responses for a specific stage or item count, but leave everything else the same. For example, in a dictionary that has an entry for 3 and a `null` entry for 4, requesting 5 will return `null`.
