### PR TITLE
Fixed crash when using tracker.json from older version

### DIFF
--- a/src/Randomizer.SMZ3.Tracking/Configuration/TrackerConfig.cs
+++ b/src/Randomizer.SMZ3.Tracking/Configuration/TrackerConfig.cs
@@ -14,45 +14,37 @@ namespace Randomizer.SMZ3.Tracking.Configuration
         /// </summary>
         /// <param name="items">The item data to use.</param>
         /// <param name="pegs">The peg data.</param>
-        /// <param name="dungeons">The dungeon data.</param>
         /// <param name="responses">The responses to use.</param>
         /// <param name="requests">The basic requests and responses.</param>
         public TrackerConfig(IReadOnlyCollection<ItemData> items,
-            IReadOnlyCollection<Peg> pegs,
-            IReadOnlyCollection<DungeonInfo> dungeons,
-            ResponseConfig responses,
-            IReadOnlyCollection<BasicVoiceRequest> requests)
+            IReadOnlyCollection<Peg>? pegs,
+            ResponseConfig? responses,
+            IReadOnlyCollection<BasicVoiceRequest>? requests)
         {
-            Items = items;
-            Pegs = pegs;
-            Dungeons = dungeons;
-            Responses = responses;
-            Requests = requests;
+            Items = items ?? throw new ArgumentNullException(nameof(items));
+            Pegs = pegs ?? new List<Peg>();
+            Responses = responses ?? new ResponseConfig();
+            Requests = requests ?? new List<BasicVoiceRequest>();
         }
 
         /// <summary>
         /// Gets a collection of trackable items.
         /// </summary>
-        public IReadOnlyCollection<ItemData> Items { get; init; }
+        public IReadOnlyCollection<ItemData> Items { get; }
 
         /// <summary>
         /// Gets the peg world peg configuration.
         /// </summary>
-        public IReadOnlyCollection<Peg> Pegs { get; init; }
-
-        /// <summary>
-        /// Gets a collection of Zelda dungeons.
-        /// </summary>
-        public IReadOnlyCollection<DungeonInfo> Dungeons { get; init; }
+        public IReadOnlyCollection<Peg> Pegs { get; }
 
         /// <summary>
         /// Gets a collection of configured responses.
         /// </summary>
-        public ResponseConfig Responses { get; init; }
+        public ResponseConfig Responses { get; }
 
         /// <summary>
         /// Gets a collection of basic requests and responses.
         /// </summary>
-        public IReadOnlyCollection<BasicVoiceRequest> Requests { get; init; }
+        public IReadOnlyCollection<BasicVoiceRequest> Requests { get; }
     }
 }


### PR DESCRIPTION
Despite not being marked as nullable, JsonSerializer will still inject `null` without any warning or error. Now, it'll create a default instance for any missing parts, or throw if the items are missing (as those are pretty critical).