### PR TITLE
Caching progression objects to avoid constant reinstantiation

### DIFF
--- a/src/Randomizer.App/Windows/TrackerWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/TrackerWindow.xaml.cs
@@ -512,6 +512,7 @@ namespace Randomizer.App
                         bow.Untrack();
                     else
                         bow.Track();
+                    Tracker.UpdateTrackerProgression = true;
                     RefreshGridItems();
                 };
 
@@ -531,6 +532,7 @@ namespace Randomizer.App
                         silverArrows.Untrack();
                     else
                         silverArrows.Track();
+                    Tracker.UpdateTrackerProgression = true;
                     RefreshGridItems();
                 };
 

--- a/src/Randomizer.SMZ3.Tracking/Tracker.cs
+++ b/src/Randomizer.SMZ3.Tracking/Tracker.cs
@@ -42,6 +42,12 @@ namespace Randomizer.SMZ3.Tracking
         private bool _disposed;
         private string? _mood;
         private string? _lastSpokenText;
+        private Dictionary<string, Progression> _progression = new();
+
+        /// <summary>
+        /// Set when the progression needs to be updated for the current tracker instance
+        /// </summary>
+        public bool UpdateTrackerProgression { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Tracker"/> class.
@@ -78,6 +84,7 @@ namespace Randomizer.SMZ3.Tracking
             World = worldAccessor.GetWorld();
             WorldInfo = locationConfig;
             GetTreasureCounts(WorldInfo.Dungeons, World);
+            UpdateTrackerProgression = true;
 
             // Initalize the timers used to trigger idle responses
             _idleTimers = Responses.Idle.ToDictionary(
@@ -622,6 +629,19 @@ namespace Randomizer.SMZ3.Tracking
         /// </returns>
         public Progression GetProgression(bool assumeKeys)
         {
+            if (UpdateTrackerProgression)
+            {
+                _progression.Clear();
+                UpdateTrackerProgression = false;
+            }
+
+            var mapKey = $"{assumeKeys}{!World.Config.Keysanity}";
+
+            if (_progression.ContainsKey(mapKey))
+            {
+                return _progression[mapKey];
+            }
+
             var progression = new Progression();
 
             if (!World.Config.Keysanity || assumeKeys)
@@ -636,6 +656,8 @@ namespace Randomizer.SMZ3.Tracking
                 if (item.TrackingState > 0)
                     progression.Add(Enumerable.Repeat(new SMZ3.Item(item.InternalItemType), item.TrackingState));
             }
+
+            _progression[mapKey] = progression;
             return progression;
         }
 
@@ -878,6 +900,7 @@ namespace Randomizer.SMZ3.Tracking
             var accessibleBefore = GetAccessibleLocations();
             var itemName = item.Name;
             var originalTrackingState = item.TrackingState;
+            UpdateTrackerProgression = true;
 
             if (item.HasStages)
             {
@@ -963,7 +986,7 @@ namespace Randomizer.SMZ3.Tracking
                 }
             }
 
-            Action undoTrack = () => item.TrackingState = originalTrackingState;
+            Action undoTrack = () => { item.TrackingState = originalTrackingState; UpdateTrackerProgression = true; };
             OnItemTracked(new ItemTrackedEventArgs(trackedAs, confidence));
 
             // Check if we can clear a location
@@ -999,6 +1022,7 @@ namespace Randomizer.SMZ3.Tracking
                 undoTrack();
                 undoClear?.Invoke();
                 undoTrackDungeonTreasure?.Invoke();
+                UpdateTrackerProgression = true;
             });
             GiveLocationHint(accessibleBefore);
             RestartIdleTimers();
@@ -1014,6 +1038,7 @@ namespace Randomizer.SMZ3.Tracking
         public void UntrackItem(ItemData item, float? confidence = null)
         {
             var originalTrackingState = item.TrackingState;
+            UpdateTrackerProgression = true;
 
             if (!item.Untrack())
             {
@@ -1044,7 +1069,7 @@ namespace Randomizer.SMZ3.Tracking
 
             IsDirty = true;
             OnItemTracked(new(null, confidence));
-            AddUndo(() => item.TrackingState = originalTrackingState);
+            AddUndo(() => { item.TrackingState = originalTrackingState; UpdateTrackerProgression = true; });
         }
 
         /// <summary>
@@ -1060,6 +1085,7 @@ namespace Randomizer.SMZ3.Tracking
         {
             var tracked = TrackItem(item, trackedAs, confidence, tryClear: false);
             var undoTrack = _undoHistory.Pop();
+            UpdateTrackerProgression = true;
 
             // Check if we can remove something from the remaining treasures in
             // a dungeon
@@ -1093,6 +1119,7 @@ namespace Randomizer.SMZ3.Tracking
                     undoTrack();
                     undoTrackTreasure?.Invoke();
                     location.Cleared = false;
+                    UpdateTrackerProgression = true;
                 });
             }
             else
@@ -1101,6 +1128,7 @@ namespace Randomizer.SMZ3.Tracking
                 {
                     undoTrack();
                     undoTrackTreasure?.Invoke();
+                    UpdateTrackerProgression = true;
                 });
             }
         }
@@ -1119,6 +1147,7 @@ namespace Randomizer.SMZ3.Tracking
             var locations = area.Locations
                 .Where(x => x.Item.Type == item.InternalItemType)
                 .ToImmutableList();
+            UpdateTrackerProgression = true;
 
             if (locations.Count == 0)
             {
@@ -1142,6 +1171,7 @@ namespace Randomizer.SMZ3.Tracking
                 {
                     undoClear();
                     undoTrack();
+                    UpdateTrackerProgression = true;
                 });
             }
         }
@@ -1161,6 +1191,7 @@ namespace Randomizer.SMZ3.Tracking
             TrackItem(item, trackedAs, confidence, tryClear: false);
             Clear(location);
 
+            UpdateTrackerProgression = true;
             IsDirty = true;
 
             var undoClear = _undoHistory.Pop();
@@ -1169,6 +1200,7 @@ namespace Randomizer.SMZ3.Tracking
             {
                 undoClear();
                 undoTrack();
+                UpdateTrackerProgression = true;
             });
         }
 
@@ -1182,6 +1214,8 @@ namespace Randomizer.SMZ3.Tracking
         /// <param name="confidence">The speech recognition confidence.</param>
         public void TrackItemAmount(ItemData item, int count, float confidence)
         {
+            UpdateTrackerProgression = true;
+
             var newItemCount = count;
             if (item.CounterMultiplier > 1
                 && count % item.CounterMultiplier == 0)
@@ -1212,7 +1246,7 @@ namespace Randomizer.SMZ3.Tracking
 
             IsDirty = true;
 
-            AddUndo(() => item.TrackingState = oldItemCount);
+            AddUndo(() => { item.TrackingState = oldItemCount; UpdateTrackerProgression = true; });
             OnItemTracked(new(null, confidence));
         }
 
@@ -1237,7 +1271,7 @@ namespace Randomizer.SMZ3.Tracking
         public void ClearArea(IHasLocations area, bool trackItems, bool includeUnavailable = false, float? confidence = null, bool assumeKeys = false)
         {
             Action? undoTrackDungeon = null;
-
+            
             var dungeon = WorldInfo.Dungeons.SingleOrDefault(x => area is Region region && x.Is(region));
             if (dungeon != null)
             {
@@ -1249,6 +1283,8 @@ namespace Randomizer.SMZ3.Tracking
                 .WhereIf(dungeon != null, x => x.Type != LocationType.NotInDungeon)
                 .WhereUnless(includeUnavailable, x => x.IsAvailable(GetProgression(assumeKeys)))
                 .ToImmutableList();
+
+            UpdateTrackerProgression = true;
 
             if (locations.Count == 0)
             {
@@ -1357,6 +1393,7 @@ namespace Randomizer.SMZ3.Tracking
                     location.Cleared = false;
                 }
                 undoTrackDungeon?.Invoke();
+                UpdateTrackerProgression = true;
             });
         }
 
@@ -1367,6 +1404,7 @@ namespace Randomizer.SMZ3.Tracking
         /// <param name="confidence">The speech recognition confidence.</param>
         public void Clear(Location location, float? confidence = null)
         {
+            UpdateTrackerProgression = true;
             location.Cleared = true;
 
             if (confidence != null)
@@ -1404,6 +1442,7 @@ namespace Randomizer.SMZ3.Tracking
                 location.Cleared = false;
                 undoTrackTreasure?.Invoke();
                 undoStopPegWorldMode?.Invoke();
+                UpdateTrackerProgression = true;
             });
             OnLocationCleared(new(location, confidence));
         }
@@ -1415,6 +1454,8 @@ namespace Randomizer.SMZ3.Tracking
         /// <param name="confidence">The speech recognition confidence.</param>
         public void MarkDungeonAsCleared(DungeonInfo dungeon, float? confidence = null)
         {
+            UpdateTrackerProgression = true;
+
             if (dungeon.Cleared)
             {
                 Say(Responses.DungeonAlreadyCleared.Format(dungeon.Name, dungeon.Boss));
@@ -1452,6 +1493,7 @@ namespace Randomizer.SMZ3.Tracking
             OnDungeonUpdated(new TrackerEventArgs(confidence));
             AddUndo(() =>
             {
+                UpdateTrackerProgression = true;
                 dungeon.Cleared = false;
                 undoTrack?.Invoke();
             });
@@ -1511,6 +1553,7 @@ namespace Randomizer.SMZ3.Tracking
                 return;
             }
 
+            UpdateTrackerProgression = true;
             dungeon.Cleared = false;
             Say(Responses.DungeonUncleared.Format(dungeon.Name, dungeon.Boss));
 
@@ -1554,6 +1597,7 @@ namespace Randomizer.SMZ3.Tracking
                 undoUntrack?.Invoke();
                 undoUntrackTreasure?.Invoke();
                 undoUnclear?.Invoke();
+                UpdateTrackerProgression = true;
             });
         }
 


### PR DESCRIPTION
I had noticed both personally and from betus's streams that tracker was sometimes pretty slow when tracking things, especially when doing larger things such as clearing large locations. When poking around I noticed each time the progression objects are retrieved for the location list and the map, it was being re-instantiated each time and repopulated for every single location in both spots. This change is to basically cache the progression and only reset it when items are tracked or untracked. While an extreme example, this has changed clearing Ganon's Tower being cleared on the map from around like 5 seconds to 1 second for me.