### PR TITLE
"Give me a hint" fix

### DIFF
--- a/setup/randomizer.app.iss
+++ b/setup/randomizer.app.iss
@@ -4,7 +4,7 @@
 #include "CodeDependencies.iss"
 
 #define MyAppName "SMZ3 Cas' Randomizer"
-#define MyAppVersion "3.4.1"
+#define MyAppVersion "3.4.2"
 #define MyAppPublisher "Vivelin"
 #define MyAppURL "https://github.com/Vivelin/SMZ3Randomizer"
 #define MyAppExeName "Randomizer.App.exe"

--- a/src/Randomizer.App/Randomizer.App.csproj
+++ b/src/Randomizer.App/Randomizer.App.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net5.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>chozo20.ico</ApplicationIcon>
-    <Version>3.4.1</Version>
+    <Version>3.4.2</Version>
     <Title>SMZ3 Cas' Randomizer</Title>
     <AssemblyTitle>SMZ3 Cas' Randomizer</AssemblyTitle>
     <Authors>Vivelin</Authors>

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/SpoilerModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/SpoilerModule.cs
@@ -106,6 +106,7 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
             var locationWithProgressionItem = Tracker.World.Locations
                 .Where(x => !x.Cleared && x.IsAvailable(progression))
                 .Where(x => x.Item.Progression)
+                .Where(x => Tracker.FindItemByType(x.Item.Type)?.TrackingState == 0)
                 .Random();
 
             if (locationWithProgressionItem != null)


### PR DESCRIPTION
Fixed an issue where asking for a progression hint would cause Tracker to constantly point to Hyrule Castle. It's likely giving a hint for early progression missiles, but since "_track missiles from Hyrule Castle_" doesn't clear something if there's more than one, it would still be considered "untracked".

I added a condition to make sure the item in question hasn't already been tracked (regardless of whether or not the location itself was cleared or not.)