### PR TITLE
Community seeds

### DIFF
--- a/src/Randomizer.App/RomGenerator.cs
+++ b/src/Randomizer.App/RomGenerator.cs
@@ -190,11 +190,16 @@ namespace Randomizer.App
             log.AppendLine(Underline($"SMZ3 Cas’ spoiler log", '='));
             log.AppendLine($"Generated on {DateTime.Now:F}");
             log.AppendLine($"Seed: {options.SeedOptions.Seed} (actual: {seed.Seed})");
-            log.AppendLine($"Sword: {options.SeedOptions.SwordLocation}");
-            log.AppendLine($"Morph: {options.SeedOptions.MorphLocation}");
-            log.AppendLine($"Bombs: {options.SeedOptions.MorphBombsLocation}");
-            log.AppendLine($"Shaktool: {options.SeedOptions.ShaktoolItem}");
-            log.AppendLine($"Peg World: {options.SeedOptions.PegWorldItem}");
+            log.AppendLine($"Config String: {Config.ToConfigString(seed.Playthrough.Config, true)}");
+            log.AppendLine($"Early Items: {string.Join(',', seed.Playthrough.Config.EarlyItems.Select(x => x.ToString()).ToArray())}");
+
+            var locationPrefs = new List<string>();
+            foreach (var (locationId, value) in seed.Playthrough.Config.LocationItems)
+            {
+                var itemPref = value < Enum.GetValues(typeof(ItemPool)).Length ? ((ItemPool)value).ToString() : ((ItemType)value).ToString();
+                locationPrefs.Add($"{seed.Worlds[0].World.Locations.First(x => x.Id == locationId).Name} - {itemPref}");
+            }
+            log.AppendLine($"Location Preferences: {string.Join(',', locationPrefs.ToArray())}");
             log.AppendLine((options.SeedOptions.Keysanity ? "[Keysanity] " : "")
                          + (options.SeedOptions.Race ? "[Race] " : ""));
             if (File.Exists(options.PatchOptions.Msu1Path))

--- a/src/Randomizer.App/RomGenerator.cs
+++ b/src/Randomizer.App/RomGenerator.cs
@@ -190,7 +190,7 @@ namespace Randomizer.App
             log.AppendLine(Underline($"SMZ3 Cas’ spoiler log", '='));
             log.AppendLine($"Generated on {DateTime.Now:F}");
             log.AppendLine($"Seed: {options.SeedOptions.Seed} (actual: {seed.Seed})");
-            log.AppendLine($"Config String: {Config.ToConfigString(seed.Playthrough.Config, true)}");
+            log.AppendLine($"Settings String: {Config.ToConfigString(seed.Playthrough.Config, true)}");
             log.AppendLine($"Early Items: {string.Join(',', seed.Playthrough.Config.EarlyItems.Select(x => x.ToString()).ToArray())}");
 
             var locationPrefs = new List<string>();
@@ -200,6 +200,11 @@ namespace Randomizer.App
                 locationPrefs.Add($"{seed.Worlds[0].World.Locations.First(x => x.Id == locationId).Name} - {itemPref}");
             }
             log.AppendLine($"Location Preferences: {string.Join(',', locationPrefs.ToArray())}");
+
+            var type = options.LogicConfig.GetType();
+            var logicOptions = string.Join(',', type.GetProperties().Select(x => $"{x.Name}: {x.GetValue(seed.Playthrough.Config.LogicConfig)}"));
+            log.AppendLine($"Logic Options: {logicOptions}");
+
             log.AppendLine((options.SeedOptions.Keysanity ? "[Keysanity] " : "")
                          + (options.SeedOptions.Race ? "[Race] " : ""));
             if (File.Exists(options.PatchOptions.Msu1Path))

--- a/src/Randomizer.App/RomGenerator.cs
+++ b/src/Randomizer.App/RomGenerator.cs
@@ -69,7 +69,7 @@ namespace Randomizer.App
             catch (RandomizerGenerationException e)
             {
                 path = null;
-                error = "Error generating rom\n" + e.Message;
+                error = $"Error generating rom\n{e.Message}\nPlease try again. If it persists, try modifying your seed settings.";
                 rom = null;
                 return false;
             }

--- a/src/Randomizer.App/ViewModels/RandomizerOptions.cs
+++ b/src/Randomizer.App/ViewModels/RandomizerOptions.cs
@@ -122,7 +122,37 @@ namespace Randomizer.App.ViewModels
             }
             else
             {
-                return Config.FromConfigString(SeedOptions.ConfigString);
+                var oldConfig = Config.FromConfigString(SeedOptions.ConfigString);
+                return new Config()
+                {
+                    GameMode = GameMode.Normal,
+                    Z3Logic = Z3Logic.Normal,
+                    SMLogic = SMLogic.Normal,
+                    ItemLocations =
+                    {
+                        [ItemType.ProgressiveSword] = SeedOptions.SwordLocation,
+                        [ItemType.Morph] = SeedOptions.MorphLocation,
+                        [ItemType.Bombs] = SeedOptions.MorphBombsLocation,
+                        [ItemType.Boots] = SeedOptions.PegasusBootsLocation,
+                        [ItemType.SpaceJump] = SeedOptions.SpaceJumpLocation,
+                    },
+                    ShaktoolItemPool = SeedOptions.ShaktoolItem,
+                    PegWorldItemPool = SeedOptions.PegWorldItem,
+                    KeyShuffle = SeedOptions.Keysanity ? KeyShuffle.Keysanity : KeyShuffle.None,
+                    Race = SeedOptions.Race,
+                    ExtendedMsuSupport = PatchOptions.CanEnableExtendedSoundtrack && PatchOptions.EnableExtendedSoundtrack,
+                    ShuffleDungeonMusic = PatchOptions.ShuffleDungeonMusic,
+                    HeartColor = PatchOptions.HeartColor,
+                    LowHealthBeepSpeed = PatchOptions.LowHealthBeepSpeed,
+                    DisableLowEnergyBeep = PatchOptions.DisableLowEnergyBeep,
+                    CasualSMPatches = PatchOptions.CasualSuperMetroidPatches,
+                    MenuSpeed = PatchOptions.MenuSpeed,
+                    LinkName = PatchOptions.LinkSprite == Sprite.DefaultLink ? "Link" : PatchOptions.LinkSprite.Name,
+                    SamusName = PatchOptions.SamusSprite == Sprite.DefaultSamus ? "Samus" : PatchOptions.SamusSprite.Name,
+                    LocationItems = oldConfig.LocationItems,
+                    EarlyItems = oldConfig.EarlyItems,
+                    LogicConfig = oldConfig.LogicConfig
+                };
             }
         }
 

--- a/src/Randomizer.App/ViewModels/RandomizerOptions.cs
+++ b/src/Randomizer.App/ViewModels/RandomizerOptions.cs
@@ -27,21 +27,18 @@ namespace Randomizer.App.ViewModels
             SeedOptions = new SeedOptions();
             PatchOptions = new PatchOptions();
             LogicConfig = new LogicConfig();
-            LocationItems = new Dictionary<int, int>();
         }
 
         [JsonConstructor]
         public RandomizerOptions(GeneralOptions generalOptions,
             SeedOptions seedOptions,
             PatchOptions patchOptions,
-            LogicConfig logicConfig,
-            IDictionary<int, int> locationItems)
+            LogicConfig logicConfig)
         {
             GeneralOptions = generalOptions ?? new();
             SeedOptions = seedOptions ?? new();
             PatchOptions = patchOptions ?? new();
             LogicConfig = logicConfig ?? new();
-            LocationItems = locationItems ?? new Dictionary<int, int>();
         }
 
         public event PropertyChangedEventHandler PropertyChanged;
@@ -58,7 +55,7 @@ namespace Randomizer.App.ViewModels
         [JsonPropertyName("Logic")]
         public LogicConfig LogicConfig { get; set; }
 
-        public bool ItemLocationsExpanded { get; set; } = false;
+        public bool EarlyItemsExpanded { get; set; } = false;
 
         public bool CustomizationExpanded { get; set; } = false;
         public bool LogicExpanded { get; set; } = false;
@@ -69,7 +66,6 @@ namespace Randomizer.App.ViewModels
 
         public double WindowHeight { get; set; } = 600d;
 
-        public IDictionary<int, int> LocationItems { get; set; }
 
         public string RomOutputPath
         {
@@ -119,7 +115,8 @@ namespace Randomizer.App.ViewModels
                     MenuSpeed = PatchOptions.MenuSpeed,
                     LinkName = PatchOptions.LinkSprite == Sprite.DefaultLink ? "Link" : PatchOptions.LinkSprite.Name,
                     SamusName = PatchOptions.SamusSprite == Sprite.DefaultSamus ? "Samus" : PatchOptions.SamusSprite.Name,
-                    LocationItems = LocationItems,
+                    LocationItems = SeedOptions.LocationItems,
+                    EarlyItems = SeedOptions.EarlyItems,
                     LogicConfig = LogicConfig.Clone()
                 };
             }

--- a/src/Randomizer.App/ViewModels/SeedOptions.cs
+++ b/src/Randomizer.App/ViewModels/SeedOptions.cs
@@ -6,7 +6,7 @@ using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Windows;
-
+using Randomizer.Shared;
 using Randomizer.SMZ3;
 
 namespace Randomizer.App.ViewModels
@@ -39,5 +39,9 @@ namespace Randomizer.App.ViewModels
         public bool Keysanity { get; set; }
 
         public bool Race { get; set; }
+
+        public ISet<ItemType> EarlyItems { get; set; } = new HashSet<ItemType>();
+
+        public IDictionary<int, int> LocationItems { get; set; } = new Dictionary<int, int>();
     }
 }

--- a/src/Randomizer.App/ViewModels/SeedOptions.cs
+++ b/src/Randomizer.App/ViewModels/SeedOptions.cs
@@ -19,6 +19,9 @@ namespace Randomizer.App.ViewModels
         [JsonIgnore]
         public string Seed { get; set; }
 
+        [JsonIgnore]
+        public string ConfigString { get; set; }
+
         public ItemPlacement SwordLocation { get; set; }
 
         public ItemPlacement MorphLocation { get; set; }

--- a/src/Randomizer.App/Windows/GenerateRomWindow.xaml
+++ b/src/Randomizer.App/Windows/GenerateRomWindow.xaml
@@ -191,7 +191,7 @@
                          Text="{Binding Seed}" />
               </controls:LabeledControl>
 
-              <controls:LabeledControl Text="Config string (optional):">
+              <controls:LabeledControl Text="Import settings (optional):">
                 <TextBox x:Name="ConfigString"
                          Text="{Binding ConfigString}" />
               </controls:LabeledControl>

--- a/src/Randomizer.App/Windows/GenerateRomWindow.xaml
+++ b/src/Randomizer.App/Windows/GenerateRomWindow.xaml
@@ -140,6 +140,24 @@
             </StackPanel>
           </Expander>
 
+          <Expander Header="Locations"
+                    x:Name="Locations">
+            <StackPanel Orientation="Vertical"
+                        Margin="24,11,11,11">
+              <ComboBox Name="LocationsRegionFilter" SelectionChanged="LocationsRegionFilter_SelectionChanged" />
+              <ScrollViewer VerticalScrollBarVisibility="Auto"
+                    HorizontalScrollBarVisibility="Disabled" MaxHeight="200" Margin="0,10,0,10" VerticalAlignment="Top">
+                <Grid Name="LocationsGrid" VerticalAlignment="Top">
+                  <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"></ColumnDefinition>
+                    <ColumnDefinition></ColumnDefinition>
+                  </Grid.ColumnDefinitions>
+                </Grid>
+              </ScrollViewer>
+              <Button Content="Reset All" Click="ResetAllLocationsButton_Click" Name="ResetAllLocationsButton"/>
+            </StackPanel>
+          </Expander>
+          
           <Expander Header="Logic Options"
                     x:Name="LogicOptionsExpander"
                     IsExpanded="{Binding LogicExpanded}">
@@ -270,6 +288,11 @@
               <controls:LabeledControl Text="Seed (optional):">
                 <TextBox x:Name="SeedInput"
                          Text="{Binding Seed}" />
+              </controls:LabeledControl>
+
+              <controls:LabeledControl Text="Config string (optional):">
+                <TextBox x:Name="ConfigString"
+                         Text="{Binding ConfigString}" />
               </controls:LabeledControl>
             </StackPanel>
           </Expander>

--- a/src/Randomizer.App/Windows/GenerateRomWindow.xaml
+++ b/src/Randomizer.App/Windows/GenerateRomWindow.xaml
@@ -32,111 +32,12 @@
       <ScrollViewer VerticalScrollBarVisibility="Auto"
                     HorizontalScrollBarVisibility="Disabled">
         <StackPanel Orientation="Vertical">
-          <Expander Header="Item locations"
-                    x:Name="ItemLocationsExpander"
-                    IsExpanded="{Binding ItemLocationsExpanded}">
+          <Expander Header="Early Items"
+                    x:Name="EarlyItemsExpander"
+                    IsExpanded="{Binding EarlyItemsExpanded}">
             <StackPanel Orientation="Vertical"
-                        Margin="24,11,11,11"
-                        DataContext="{Binding SeedOptions}">
-              <controls:LabeledControl Text="Sword location:">
-                <StackPanel Style="{StaticResource RadioButtonGroup}">
-                  <RadioButton GroupName="SwordLocation"
-                               Content="Randomized"
-                               IsChecked="{Binding SwordLocation, Converter={StaticResource EnumBoolConverter}, ConverterParameter={x:Static smz3:ItemPlacement.Randomized}}" />
-                  <RadioButton GroupName="SwordLocation"
-                               Content="Early"
-                               IsChecked="{Binding SwordLocation, Converter={StaticResource EnumBoolConverter}, ConverterParameter={x:Static smz3:ItemPlacement.Early}}" />
-                  <RadioButton GroupName="SwordLocation"
-                               Content="Original location (Link's Uncle)"
-                               IsChecked="{Binding SwordLocation, Converter={StaticResource EnumBoolConverter}, ConverterParameter={x:Static smz3:ItemPlacement.Original}}" />
-                </StackPanel>
-              </controls:LabeledControl>
-
-              <controls:LabeledControl Text="Morph Ball location:">
-                <StackPanel Style="{StaticResource RadioButtonGroup}">
-                  <RadioButton GroupName="MorphLocation"
-                               Content="Randomized"
-                               IsChecked="{Binding MorphLocation, Converter={StaticResource EnumBoolConverter}, ConverterParameter={x:Static smz3:ItemPlacement.Randomized}}" />
-                  <RadioButton GroupName="MorphLocation"
-                               Content="Early"
-                               IsChecked="{Binding MorphLocation, Converter={StaticResource EnumBoolConverter}, ConverterParameter={x:Static smz3:ItemPlacement.Early}}" />
-                  <RadioButton GroupName="MorphLocation"
-                               Content="Original location (Blue Brinstar)"
-                               IsChecked="{Binding MorphLocation, Converter={StaticResource EnumBoolConverter}, ConverterParameter={x:Static smz3:ItemPlacement.Original}}" />
-                </StackPanel>
-              </controls:LabeledControl>
-
-              <controls:LabeledControl Text="Metroid bombs:">
-                <StackPanel Style="{StaticResource RadioButtonGroup}">
-                  <RadioButton GroupName="BombsLocation"
-                               Content="Randomized"
-                               IsChecked="{Binding MorphBombsLocation, Converter={StaticResource EnumBoolConverter}, ConverterParameter={x:Static smz3:ItemPlacement.Randomized}}" />
-                  <RadioButton GroupName="BombsLocation"
-                               Content="Early"
-                               IsChecked="{Binding MorphBombsLocation, Converter={StaticResource EnumBoolConverter}, ConverterParameter={x:Static smz3:ItemPlacement.Early}}" />
-                  <RadioButton GroupName="BombsLocation"
-                               Content="Original location (Torizo)"
-                               IsChecked="{Binding MorphBombsLocation, Converter={StaticResource EnumBoolConverter}, ConverterParameter={x:Static smz3:ItemPlacement.Original}}" />
-                </StackPanel>
-              </controls:LabeledControl>
-
-              <controls:LabeledControl Text="Pegasus Boots:">
-                <StackPanel Style="{StaticResource RadioButtonGroup}">
-                  <RadioButton GroupName="PegasusBootsLocation"
-                               Content="Randomized"
-                               IsChecked="{Binding PegasusBootsLocation, Converter={StaticResource EnumBoolConverter}, ConverterParameter={x:Static smz3:ItemPlacement.Randomized}}" />
-                  <RadioButton GroupName="PegasusBootsLocation"
-                               Content="Early"
-                               IsChecked="{Binding PegasusBootsLocation, Converter={StaticResource EnumBoolConverter}, ConverterParameter={x:Static smz3:ItemPlacement.Early}}" />
-                  <RadioButton GroupName="PegasusBootsLocation"
-                               Content="Original location (Sahasrahla)"
-                               IsChecked="{Binding PegasusBootsLocation, Converter={StaticResource EnumBoolConverter}, ConverterParameter={x:Static smz3:ItemPlacement.Original}}" />
-                </StackPanel>
-              </controls:LabeledControl>
-
-              <controls:LabeledControl Text="Space Jump:">
-                <StackPanel Style="{StaticResource RadioButtonGroup}">
-                  <RadioButton GroupName="SpaceJumpLocation"
-                               Content="Randomized"
-                               IsChecked="{Binding SpaceJumpLocation, Converter={StaticResource EnumBoolConverter}, ConverterParameter={x:Static smz3:ItemPlacement.Randomized}}" />
-                  <RadioButton GroupName="SpaceJumpLocation"
-                               Content="Early"
-                               IsChecked="{Binding SpaceJumpLocation, Converter={StaticResource EnumBoolConverter}, ConverterParameter={x:Static smz3:ItemPlacement.Early}}" />
-                  <RadioButton GroupName="SpaceJumpLocation"
-                               Content="Original location (Draygon)"
-                               IsChecked="{Binding SpaceJumpLocation, Converter={StaticResource EnumBoolConverter}, ConverterParameter={x:Static smz3:ItemPlacement.Original}}" />
-                </StackPanel>
-              </controls:LabeledControl>
-
-              <controls:LabeledControl Text="Shaktool item pool:">
-                <StackPanel Style="{StaticResource RadioButtonGroup}">
-                  <RadioButton GroupName="ShaktoolItemPool"
-                               Content="Randomized"
-                               IsChecked="{Binding ShaktoolItem, Converter={StaticResource EnumBoolConverter}, ConverterParameter={x:Static smz3:ItemPool.Any}}" />
-                  <RadioButton GroupName="ShaktoolItemPool"
-                               Content="Only progression items"
-                               IsChecked="{Binding ShaktoolItem, Converter={StaticResource EnumBoolConverter}, ConverterParameter={x:Static smz3:ItemPool.Progression}}" />
-                  <RadioButton GroupName="ShaktoolItemPool"
-                               Content="I want Shaktool to betray me every time"
-                               IsChecked="{Binding ShaktoolItem, Converter={StaticResource EnumBoolConverter}, ConverterParameter={x:Static smz3:ItemPool.Junk}}" />
-                </StackPanel>
-              </controls:LabeledControl>
-
-              <controls:LabeledControl Text="Peg World item pool:">
-                <StackPanel Style="{StaticResource RadioButtonGroup}">
-                  <RadioButton GroupName="PegWorldItemPool"
-                               Content="Randomized"
-                               IsChecked="{Binding PegWorldItem, Converter={StaticResource EnumBoolConverter}, ConverterParameter={x:Static smz3:ItemPool.Any}}" />
-                  <RadioButton GroupName="PegWorldItemPool"
-                               Content="Only progression items"
-                               ToolTip="Mom, can we go to Peg World? It has all the best progression items!"
-                               IsChecked="{Binding PegWorldItem, Converter={StaticResource EnumBoolConverter}, ConverterParameter={x:Static smz3:ItemPool.Progression}}" />
-                  <RadioButton GroupName="PegWorldItemPool"
-                               Content="Only junk items"
-                               ToolTip="Peg World is overrated anyway."
-                               IsChecked="{Binding PegWorldItem, Converter={StaticResource EnumBoolConverter}, ConverterParameter={x:Static smz3:ItemPool.Junk}}" />
-                </StackPanel>
-              </controls:LabeledControl>
+                        Margin="24,11,11,11">
+              <UniformGrid Columns="2" Name="EarlyItemsGrid" />
             </StackPanel>
           </Expander>
 

--- a/src/Randomizer.App/Windows/GenerateRomWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/GenerateRomWindow.xaml.cs
@@ -511,9 +511,12 @@ namespace Randomizer.App
         {
             var comboBox = sender as ComboBox;
             var selectedRegion = comboBox.SelectedItem as string;
-            foreach (FrameworkElement obj in LocationsGrid.Children) {
-                var location = obj.Tag as Location;
-                obj.Visibility = selectedRegion.Contains(location.Region.Name) ? Visibility.Visible : Visibility.Collapsed;
+            foreach (FrameworkElement obj in LocationsGrid.Children)
+            {
+                if (obj.Tag is Location location)
+                {
+                    obj.Visibility = selectedRegion.Contains(location.Region.Name) ? Visibility.Visible : Visibility.Collapsed;
+                }
             }
         }
 

--- a/src/Randomizer.App/Windows/GenerateRomWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/GenerateRomWindow.xaml.cs
@@ -320,7 +320,7 @@ namespace Randomizer.App
             var config = Options.ToConfig();
             var randomizer = _serviceProvider.GetRequiredService<Smz3Randomizer>();
 
-            const int numberOfSeeds = 50;
+            const int numberOfSeeds = 1000;
             var progressDialog = new ProgressDialog(this, $"Generating {numberOfSeeds} seeds...");
             var stats = InitStats();
             var itemCounts = new ConcurrentDictionary<(int itemId, int locationId), int>();

--- a/src/Randomizer.App/Windows/GenerateRomWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/GenerateRomWindow.xaml.cs
@@ -320,7 +320,7 @@ namespace Randomizer.App
             var config = Options.ToConfig();
             var randomizer = _serviceProvider.GetRequiredService<Smz3Randomizer>();
 
-            const int numberOfSeeds = 1000;
+            const int numberOfSeeds = 50;
             var progressDialog = new ProgressDialog(this, $"Generating {numberOfSeeds} seeds...");
             var stats = InitStats();
             var itemCounts = new ConcurrentDictionary<(int itemId, int locationId), int>();

--- a/src/Randomizer.App/Windows/GenerateRomWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/GenerateRomWindow.xaml.cs
@@ -80,7 +80,7 @@ namespace Randomizer.App
             foreach (ItemType itemType in Enum.GetValues(typeof(ItemType)))
             {
                 if (itemType.IsInAnyCategory(new[] { ItemCategory.Junk, ItemCategory.Scam, ItemCategory.Map, ItemCategory.Compass,
-                    ItemCategory.SmallKey, ItemCategory.BigKey, ItemCategory.Keycard, ItemCategory.NonRandomized }) || itemType == ItemType.Nothing)
+                    ItemCategory.SmallKey, ItemCategory.BigKey, ItemCategory.Keycard, ItemCategory.NonRandomized }) || itemType == ItemType.Nothing || itemType == ItemType.SilverArrows)
                 {
                     continue;
                 }
@@ -226,7 +226,7 @@ namespace Randomizer.App
             foreach (ItemType itemType in Enum.GetValues(typeof(ItemType)))
             {
                 if (itemType.IsInAnyCategory(new[] { ItemCategory.Junk, ItemCategory.Scam, ItemCategory.Map, ItemCategory.Compass,
-                    ItemCategory.SmallKey, ItemCategory.BigKey, ItemCategory.Keycard, ItemCategory.NonRandomized }) || itemType == ItemType.Nothing)
+                    ItemCategory.SmallKey, ItemCategory.BigKey, ItemCategory.Keycard, ItemCategory.NonRandomized }) || itemType == ItemType.Nothing || itemType == ItemType.SilverArrows)
                 {
                     continue;
                 }

--- a/src/Randomizer.App/Windows/RomListWindow.xaml
+++ b/src/Randomizer.App/Windows/RomListWindow.xaml
@@ -54,7 +54,7 @@
                   <MenuItem Header="View _Spoiler Log" Tag="{Binding Rom}" Click="ViewSpoilerMenuItem_Click"></MenuItem>
                   <MenuItem Header="_Edit Label" Tag="{Binding Rom}" Click="EditLabelMenuItem_Click"></MenuItem>
                   <MenuItem Header="_Copy Seed" Tag="{Binding Rom}" Click="CopySeedMenuItem_Click"></MenuItem>
-                  <MenuItem Header="Copy _Randomizer Config String" Tag="{Binding Rom}" Click="CopyConfigMenuItem_Click"></MenuItem>
+                  <MenuItem Header="Copy _Randomizer Settings String" Tag="{Binding Rom}" Click="CopyConfigMenuItem_Click"></MenuItem>
                   <MenuItem Header="_Delete Rom" Tag="{Binding Rom}" Click="DeleteRomMenuItem_Click"></MenuItem>
                 </ContextMenu>
               </Grid.ContextMenu>

--- a/src/Randomizer.App/Windows/RomListWindow.xaml
+++ b/src/Randomizer.App/Windows/RomListWindow.xaml
@@ -54,6 +54,7 @@
                   <MenuItem Header="View _Spoiler Log" Tag="{Binding Rom}" Click="ViewSpoilerMenuItem_Click"></MenuItem>
                   <MenuItem Header="_Edit Label" Tag="{Binding Rom}" Click="EditLabelMenuItem_Click"></MenuItem>
                   <MenuItem Header="_Copy Seed" Tag="{Binding Rom}" Click="CopySeedMenuItem_Click"></MenuItem>
+                  <MenuItem Header="Copy _Randomizer Config String" Tag="{Binding Rom}" Click="CopyConfigMenuItem_Click"></MenuItem>
                   <MenuItem Header="_Delete Rom" Tag="{Binding Rom}" Click="DeleteRomMenuItem_Click"></MenuItem>
                 </ContextMenu>
               </Grid.ContextMenu>

--- a/src/Randomizer.App/Windows/RomListWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/RomListWindow.xaml.cs
@@ -86,7 +86,11 @@ namespace Randomizer.App
         {
             var successful = _romGenerator.GenerateRom(Options, out var romPath, out var error, out var rom);
 
-            if (successful)
+            if (!successful && !string.IsNullOrEmpty(error))
+            {
+                MessageBox.Show(this, error, "SMZ3 Cas’ Randomizer", MessageBoxButton.OK, MessageBoxImage.Warning);
+            }
+            else
             {
                 UpdateRomList();
                 QuickLaunchRom(rom);

--- a/src/Randomizer.App/Windows/RomListWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/RomListWindow.xaml.cs
@@ -468,6 +468,22 @@ namespace Randomizer.App
         }
 
         /// <summary>
+        /// Menu item for copying the seed's config string for sending to someone else
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void CopyConfigMenuItem_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not MenuItem menuItem)
+                return;
+
+            if (menuItem.Tag is not GeneratedRom rom)
+                return;
+
+            Clipboard.SetText(rom.Settings);
+        }
+
+        /// <summary>
         /// Menu item for deleting a rom from the db and filesystem
         /// </summary>
         /// <param name="sender"></param>

--- a/src/Randomizer.SMZ3.Tracking/TrackerState.cs
+++ b/src/Randomizer.SMZ3.Tracking/TrackerState.cs
@@ -212,7 +212,7 @@ namespace Randomizer.SMZ3.Tracking
 
             var secondsElapsed = trackerState.SecondsElapsed;
 
-            var config = GeneratedRom.IsValid(generatedRom) ? JsonSerializer.Deserialize<Config>(generatedRom.Settings, s_options) : new Config();
+            var config = GeneratedRom.IsValid(generatedRom) ? Config.FromConfigString(generatedRom.Settings) : new Config();
 
             return new TrackerState(
                 itemStates,
@@ -232,7 +232,7 @@ namespace Randomizer.SMZ3.Tracking
         /// <returns>The deserialized config</returns>
         public static Config LoadConfig(GeneratedRom generatedRom)
         {
-            return GeneratedRom.IsValid(generatedRom) ? JsonSerializer.Deserialize<Config>(generatedRom.Settings, s_options) ?? new Config() : new Config(); ;
+            return GeneratedRom.IsValid(generatedRom) ? Config.FromConfigString(generatedRom.Settings) ?? new Config() : new Config(); ;
         }
 
         /// <summary>
@@ -395,7 +395,7 @@ namespace Randomizer.SMZ3.Tracking
 
                 if (rom != null)
                 {
-                    rom.Settings = JsonSerializer.Serialize(SeedConfig, s_options);
+                    rom.Settings = Config.ToConfigString(SeedConfig, true);
                 }
 
                 if (rom != null)

--- a/src/Randomizer.SMZ3/Config.cs
+++ b/src/Randomizer.SMZ3/Config.cs
@@ -203,6 +203,7 @@ namespace Randomizer.SMZ3
         public bool Keysanity => KeyShuffle != KeyShuffle.None;
 
         public IDictionary<int, int> LocationItems { get; set; } = new Dictionary<int, int>();
+        public ISet<ItemType> EarlyItems { get; set; } = new HashSet<ItemType>();
         public LogicConfig LogicConfig { get; set; } = new LogicConfig();
 
         public Config SeedOnly()

--- a/src/Randomizer.SMZ3/Generation/Smz3Randomizer.cs
+++ b/src/Randomizer.SMZ3/Generation/Smz3Randomizer.cs
@@ -5,7 +5,7 @@ using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
-
+using Microsoft.Extensions.Logging;
 using Randomizer.Shared;
 using Randomizer.SMZ3.FileData;
 
@@ -15,10 +15,12 @@ namespace Randomizer.SMZ3.Generation
     {
         private static readonly Regex s_illegalCharacters = new(@"[^A-Z0-9]", RegexOptions.IgnoreCase);
         private static readonly Regex s_continousSpace = new(@" +");
+        private readonly ILogger<Smz3Randomizer> _logger;
 
-        public Smz3Randomizer(IFiller filler)
+        public Smz3Randomizer(IFiller filler, ILogger<Smz3Randomizer> logger)
         {
             Filler = filler;
+            _logger = logger;
         }
 
         public static string Name => "Super Metroid & A Link to the Past Cas’ Randomizer";
@@ -59,6 +61,8 @@ namespace Randomizer.SMZ3.Generation
             var rng = new Random(seedNumber);
             if (config.Race)
                 rng = new Random(rng.Next());
+
+            _logger.LogDebug($"Seed: {seedNumber}");
 
             var worlds = new List<World>();
             if (config.SingleWorld)

--- a/src/Randomizer.SMZ3/Playthrough.cs
+++ b/src/Randomizer.SMZ3/Playthrough.cs
@@ -51,7 +51,7 @@ namespace Randomizer.SMZ3
                     /* With no new items added we might have a problem, so list inaccessable items */
                     var inaccessibleLocations = worlds.SelectMany(w => w.Locations).Where(l => !locations.Contains(l)).ToList();
                     if (inaccessibleLocations.Select(l => l.Item).Count() >= (15 * worlds.Count))
-                        throw new Exception("Too many inaccessible items, seed likely impossible.");
+                        throw new RandomizerGenerationException("Too many inaccessible items, seed likely impossible.");
 
                     sphere.InaccessibleLocations.AddRange(inaccessibleLocations);
                     break;
@@ -62,7 +62,7 @@ namespace Randomizer.SMZ3
                 spheres.Add(sphere);
 
                 if (spheres.Count > 100)
-                    throw new Exception("Too many spheres, seed likely impossible.");
+                    throw new RandomizerGenerationException("Too many spheres, seed likely impossible.");
             }
 
             return new Playthrough(config, spheres);

--- a/src/Randomizer.SMZ3/RandomizerGenerationException.cs
+++ b/src/Randomizer.SMZ3/RandomizerGenerationException.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace Randomizer.SMZ3
+{
+    /// <summary>
+    /// Class for housing potentially expected exceptions when generating seeds
+    /// </summary>
+    public class RandomizerGenerationException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RandomizerGenerationException"/>
+        /// class.
+        /// </summary>
+        public RandomizerGenerationException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RandomizerGenerationException"/>
+        /// class with the specified message.
+        /// </summary>
+        /// <param name="message">The error message.</param>
+        public RandomizerGenerationException(string? message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/src/Randomizer.SMZ3/StandardFiller.cs
+++ b/src/Randomizer.SMZ3/StandardFiller.cs
@@ -117,8 +117,19 @@ namespace Randomizer.SMZ3
 
                     if (itemPool == ItemPool.Progression && progressionItems.Any())
                     {
-                        var item = progressionItems.First();
-                        FillItemAtLocation(progressionItems, item.Type, location);
+                        // Some locations (AKA Shaktool) get pretty tough to tell if an item is needed there, so a workaround is to
+                        // grab an item from the opposite game to minimize chances of situations where an item required to access a
+                        // location is picked to go there
+                        var item = progressionItems.FirstOrDefault(x => (x.Type.IsInCategory(ItemCategory.Metroid) && location.Region is Z3Region) || (x.Type.IsInCategory(ItemCategory.Zelda) && location.Region is SMRegion));
+
+                        if (item != null)
+                        {
+                            FillItemAtLocation(progressionItems, item.Type, location);
+                        }
+                        else
+                        {
+                            _logger.LogDebug($"Could not find item to place at {location.Name}");
+                        }
                     }
                     else if(itemPool == ItemPool.Junk && junkItems.Any())
                     {

--- a/src/Randomizer.SMZ3/StandardFiller.cs
+++ b/src/Randomizer.SMZ3/StandardFiller.cs
@@ -199,27 +199,12 @@ namespace Randomizer.SMZ3
                 }
             }
 
-            foreach (var (itemType, itemPlacement) in config.ItemLocations)
+            // Add requested early items
+            foreach (var itemType in config.EarlyItems)
             {
                 if (progressionItems.Any(x => x.Type == itemType))
                 {
-                    switch (itemPlacement)
-                    {
-                        case ItemPlacement.Original:
-                            var vanilla = GetVanillaLocation(itemType, world);
-                            if (vanilla == null)
-                            {
-                                _logger.LogError("Unable to determine vanilla location for {item}", itemType);
-                                continue;
-                            }
-
-                            FillItemAtLocation(progressionItems, itemType, vanilla);
-                            break;
-
-                        case ItemPlacement.Early:
-                            FrontFillItemInOwnWorld(progressionItems, itemType, world);
-                            break;
-                    }
+                    FrontFillItemInOwnWorld(progressionItems, itemType, world);
                 }
             }
 

--- a/src/Randomizer.Shared/Enums/ItemCategory.cs
+++ b/src/Randomizer.Shared/Enums/ItemCategory.cs
@@ -61,6 +61,11 @@
         /// The item is especially numerious and can be found in a large number
         /// of locations.
         /// </summary>
-        Plentiful
+        Plentiful,
+
+        /// <summary>
+        /// This is an item that is not randomized, such as filled bottles
+        /// </summary>
+        NonRandomized
     }
 }

--- a/src/Randomizer.Shared/Enums/ItemType.cs
+++ b/src/Randomizer.Shared/Enums/ItemType.cs
@@ -549,43 +549,43 @@ namespace Randomizer.Shared
         SpeedBooster = 0xBA,
 
         [Description("Bottle with Red Potion")]
-        [ItemCategory(ItemCategory.Zelda)]
+        [ItemCategory(ItemCategory.Zelda, ItemCategory.NonRandomized)]
         BottleWithRedPotion = 0x2B,
 
         [Description("Bottle with Green Potion")]
-        [ItemCategory(ItemCategory.Zelda)]
+        [ItemCategory(ItemCategory.Zelda, ItemCategory.NonRandomized)]
         BottleWithGreenPotion = 0x2C,
 
         [Description("Bottle with Blue Potion")]
-        [ItemCategory(ItemCategory.Zelda)]
+        [ItemCategory(ItemCategory.Zelda, ItemCategory.NonRandomized)]
         BottleWithBluePotion = 0x2D,
 
         [Description("Bottle with Fairy")]
-        [ItemCategory(ItemCategory.Zelda)]
+        [ItemCategory(ItemCategory.Zelda, ItemCategory.NonRandomized)]
         BottleWithFairy = 0x3D,
 
         [Description("Bottle with Bee")]
-        [ItemCategory(ItemCategory.Zelda)]
+        [ItemCategory(ItemCategory.Zelda, ItemCategory.NonRandomized)]
         BottleWithBee = 0x3C,
 
         [Description("Bottle with Gold Bee")]
-        [ItemCategory(ItemCategory.Zelda)]
+        [ItemCategory(ItemCategory.Zelda, ItemCategory.NonRandomized)]
         BottleWithGoldBee = 0x48,
 
         [Description("Red Potion Refill")]
-        [ItemCategory(ItemCategory.Zelda)]
+        [ItemCategory(ItemCategory.Zelda, ItemCategory.NonRandomized)]
         RedContent = 0x2E,
 
         [Description("Green Potion Refill")]
-        [ItemCategory(ItemCategory.Zelda)]
+        [ItemCategory(ItemCategory.Zelda, ItemCategory.NonRandomized)]
         GreenContent = 0x2F,
 
         [Description("Blue Potion Refill")]
-        [ItemCategory(ItemCategory.Zelda)]
+        [ItemCategory(ItemCategory.Zelda, ItemCategory.NonRandomized)]
         BlueContent = 0x30,
 
         [Description("Bee Refill")]
-        [ItemCategory(ItemCategory.Zelda)]
+        [ItemCategory(ItemCategory.Zelda, ItemCategory.NonRandomized)]
         BeeContent = 0x0E,
     }
 }


### PR DESCRIPTION
Adding the ability to have more granular control over what gets generated where and adding the ability to share configs, opening the possibility for community created seeds for streamers to play.

- Every location can now have either progression items, junk items, or specific items be specified
- All progression items can be specified as early items
- Updated rom generation to handle potentially unwinnable seeds gracefully by displaying an error message upon generating the rom
  - Depending on settings, sometimes you can try regenerating the seed when this error displays, and it'll work successfully. If you requested a particular item at a location where the item isn't needed to get there, it may have randomly picked a logic chain that is impossible.
- Base 64 encoded settings strings can be generated and shared that house all of the config data
  - This can be retrieved by either right clicking in the rom list page or by viewing the spoiler log
  - All customization such as sprites, cas'troid, etc. should pull from the local player's settings. Only seed info is copied.