### PR TITLE
Track all out of logic items

### DIFF
--- a/src/Randomizer.SMZ3.Tracking/Tracker.cs
+++ b/src/Randomizer.SMZ3.Tracking/Tracker.cs
@@ -1407,6 +1407,24 @@ namespace Randomizer.SMZ3.Tracking
                             ? NaturalLanguage.Join(itemsTracked, World.Config)
                             : $"{itemsCleared} items";
                         Say(x => x.TrackedMultipleItems, itemsCleared, area.GetName(), itemNames);
+
+                        var someOutOfLogicLocation = locations.Where(x => !x.IsAvailable(GetProgression())).Random(s_random);
+                        if (someOutOfLogicLocation != null)
+                        {
+                            var someOutOfLogicItem = FindItemByType(someOutOfLogicLocation.Item.Type);
+                            var missingItems = Logic.GetMissingRequiredItems(someOutOfLogicLocation, GetProgression())
+                                .OrderBy(x => x.Length)
+                                .FirstOrDefault();
+                            if (missingItems != null)
+                            {
+                                var missingItemNames = NaturalLanguage.Join(missingItems.Select(GetName));
+                                Say(x => x.TrackedOutOfLogicItem, someOutOfLogicItem?.Name, GetName(someOutOfLogicLocation), missingItemNames);
+                            }
+                            else
+                            {
+                                Say(x => x.TrackedOutOfLogicItemTooManyMissing, someOutOfLogicItem?.Name, GetName(someOutOfLogicLocation));
+                            }
+                        }
                     }
                     else
                     {

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/ItemTrackingModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/ItemTrackingModule.cs
@@ -75,6 +75,26 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
                 }
             });
 
+            AddCommand("Track all items in an area (including out-of-logic)", GetTrackEverythingIncludingOutOfLogicRule(), (tracker, result) =>
+            {
+                if (result.Semantics.ContainsKey(RoomKey))
+                {
+                    var room = GetRoomFromResult(tracker, result);
+                    tracker.ClearArea(room,
+                        trackItems: true,
+                        includeUnavailable: true,
+                        confidence: result.Confidence);
+                }
+                else if (result.Semantics.ContainsKey(RegionKey))
+                {
+                    var region = GetRegionFromResult(tracker, result);
+                    tracker.ClearArea(region,
+                        trackItems: true,
+                        includeUnavailable: true,
+                        confidence: result.Confidence);
+                }
+            });
+
             AddCommand("Untrack an item", GetUntrackItemRule(), (tracker, result) =>
             {
                 var item = GetItemFromResult(tracker, result, out _);
@@ -139,7 +159,7 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
                 .Append("Hey tracker,")
                 .Optional("please", "would you kindly")
                 .OneOf("track", "add")
-                .OneOf("everything", "all items", "available items")
+                .OneOf("everything", "available items")
                 .OneOf("in", "from", "in the", "from the")
                 .Append(RoomKey, roomNames);
 
@@ -147,11 +167,46 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
                 .Append("Hey tracker,")
                 .Optional("please", "would you kindly")
                 .OneOf("track", "add")
-                .OneOf("everything", "all items", "available items")
+                .OneOf("everything", "available items")
                 .OneOf("in", "from")
                 .Append(RegionKey, regionNames);
 
             return GrammarBuilder.Combine(trackAllInRoom, trackAllInRegion);
+        }
+
+        private GrammarBuilder GetTrackEverythingIncludingOutOfLogicRule()
+        {
+            var roomNames = GetRoomNames();
+            var regionNames = GetRegionNames();
+
+            var trackAllInRoom = new GrammarBuilder()
+                .Append("Hey tracker,")
+                .OneOf("force", "sudo")
+                .OneOf("track", "add")
+                .OneOf("everything", "all items")
+                .OneOf("in", "from", "in the", "from the")
+                .Append(RoomKey, roomNames);
+
+            var trackAllInRegion = new GrammarBuilder()
+                .Append("Hey tracker,")
+                .OneOf("force", "sudo")
+                .OneOf("track", "add")
+                .OneOf("everything", "all items")
+                .OneOf("in", "from")
+                .Append(RegionKey, regionNames);
+
+            var cheatedRoom = new GrammarBuilder()
+                .Append("Hey tracker,")
+                .OneOf("sequence break", "I sequence broke", "I cheated my way to")
+                .Append(RoomKey, roomNames);
+
+            var cheatedRegion = new GrammarBuilder()
+                .Append("Hey tracker,")
+                .OneOf("sequence break", "I sequence broke", "I cheated my way to")
+                .Append(RegionKey, regionNames);
+
+            return GrammarBuilder.Combine(trackAllInRoom, trackAllInRegion,
+                cheatedRoom, cheatedRegion);
         }
 
         private GrammarBuilder GetUntrackItemRule()


### PR DESCRIPTION
Added the ability to track everything in an area, including out of logic items, by saying e.g. "_Hey tracker, force track everything in Tower of Hera_" or "_Hey tracker, I cheated my way into Tower of Hera_".

I still haven't figured out how to make "clear dungeon" work more accurately. I might just need to rewrite it or something.