### PR TITLE
Catch Seeds that are Inconsistent With Requested Settings

### DIFF
--- a/src/Randomizer.App/RomGenerator.cs
+++ b/src/Randomizer.App/RomGenerator.cs
@@ -6,7 +6,8 @@ using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Threading;
-
+using System.Windows;
+using System.Windows.Forms;
 using Randomizer.App.Patches;
 using Randomizer.App.ViewModels;
 using Randomizer.Shared;
@@ -46,6 +47,20 @@ namespace Randomizer.App
             try
             {
                 var bytes = GenerateRomBytes(options, out var seed);
+
+                if (!_randomizer.ValidateSeedSettings(seed, options.ToConfig()))
+                {
+                    if (System.Windows.Forms.MessageBox.Show("The seed generated is playable but does not contain all requested settings.\n" +
+                        "Retrying to generate the seed may work, but the selected settings may be impossible to generate successfully and will need to be updated.\n" +
+                        "Continue with the current seed that does not meet all requested settings?", "SMZ3 Cas’ Randomizer", MessageBoxButtons.YesNo) == DialogResult.No)
+                    {
+                        path = null;
+                        error = "";
+                        rom = null;
+                        return false;
+                    }
+                }
+
                 var folderPath = Path.Combine(options.RomOutputPath, $"{DateTimeOffset.Now:yyyyMMdd-HHmmss}_{seed.Seed}");
                 Directory.CreateDirectory(folderPath);
 

--- a/src/Randomizer.App/Windows/GenerateRomWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/GenerateRomWindow.xaml.cs
@@ -79,8 +79,7 @@ namespace Randomizer.App
         {
             foreach (ItemType itemType in Enum.GetValues(typeof(ItemType)))
             {
-                if (itemType.IsInAnyCategory(new[] { ItemCategory.Junk, ItemCategory.Scam, ItemCategory.Map, ItemCategory.Compass,
-                    ItemCategory.SmallKey, ItemCategory.BigKey, ItemCategory.Keycard, ItemCategory.NonRandomized }) || itemType == ItemType.Nothing || itemType == ItemType.SilverArrows)
+                if (!itemType.IsProgression())
                 {
                     continue;
                 }
@@ -225,8 +224,7 @@ namespace Randomizer.App
             // Add specific progressive items
             foreach (ItemType itemType in Enum.GetValues(typeof(ItemType)))
             {
-                if (itemType.IsInAnyCategory(new[] { ItemCategory.Junk, ItemCategory.Scam, ItemCategory.Map, ItemCategory.Compass,
-                    ItemCategory.SmallKey, ItemCategory.BigKey, ItemCategory.Keycard, ItemCategory.NonRandomized }) || itemType == ItemType.Nothing || itemType == ItemType.SilverArrows)
+                if (!itemType.IsProgression())
                 {
                     continue;
                 }

--- a/src/Randomizer.App/Windows/GenerateRomWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/GenerateRomWindow.xaml.cs
@@ -286,10 +286,13 @@ namespace Randomizer.App
 
         private void GenerateRomButton_Click(object sender, RoutedEventArgs e)
         {
-            bool successful = _romGenerator.GenerateRom(Options, out var romPath, out var error, out var rom);
-            if (!successful && !string.IsNullOrEmpty(error))
+            var successful = _romGenerator.GenerateRom(Options, out var romPath, out var error, out var rom);
+            if (!successful)
             {
-                MessageBox.Show(this, error, "SMZ3 Cas’ Randomizer", MessageBoxButton.OK, MessageBoxImage.Warning);
+                if (!string.IsNullOrEmpty(error))
+                {
+                    MessageBox.Show(this, error, "SMZ3 Cas’ Randomizer", MessageBoxButton.OK, MessageBoxImage.Warning);
+                }
                 return;
             }
             DialogResult = true;

--- a/src/Randomizer.App/Windows/RomListWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/RomListWindow.xaml.cs
@@ -86,9 +86,12 @@ namespace Randomizer.App
         {
             var successful = _romGenerator.GenerateRom(Options, out var romPath, out var error, out var rom);
 
-            if (!successful && !string.IsNullOrEmpty(error))
+            if (!successful)
             {
-                MessageBox.Show(this, error, "SMZ3 Cas’ Randomizer", MessageBoxButton.OK, MessageBoxImage.Warning);
+                if (!string.IsNullOrEmpty(error))
+                {
+                    MessageBox.Show(this, error, "SMZ3 Cas’ Randomizer", MessageBoxButton.OK, MessageBoxImage.Warning);
+                }
             }
             else
             {

--- a/src/Randomizer.SMZ3/Generation/Smz3Randomizer.cs
+++ b/src/Randomizer.SMZ3/Generation/Smz3Randomizer.cs
@@ -140,7 +140,7 @@ namespace Randomizer.SMZ3.Generation
                     if (value < Enum.GetValues(typeof(ItemPool)).Length)
                     {
                         var itemPool = (ItemPool)value;
-                        if ((itemPool == ItemPool.Progression && !location.Item.Progression) || (itemPool == ItemPool.Junk && location.Item.Type.IsInCategory(ItemCategory.Junk)))
+                        if ((itemPool == ItemPool.Progression && !location.Item.Progression) || (itemPool == ItemPool.Junk && !location.Item.Type.IsInCategory(ItemCategory.Junk)))
                         {
                             throw new RandomizerGenerationException("Generated seed did not meet requested settings");
                         }

--- a/src/Randomizer.Shared/Enums/ItemCategory.cs
+++ b/src/Randomizer.Shared/Enums/ItemCategory.cs
@@ -66,6 +66,11 @@
         /// <summary>
         /// This is an item that is not randomized, such as filled bottles
         /// </summary>
-        NonRandomized
+        NonRandomized,
+
+        /// <summary>
+        ///This is an item that is useful, but not progression
+        /// </summary>
+        Nice
     }
 }

--- a/src/Randomizer.Shared/Enums/ItemType.cs
+++ b/src/Randomizer.Shared/Enums/ItemType.cs
@@ -209,7 +209,7 @@ namespace Randomizer.Shared
         Map = 0x33,
 
         [Description("Progressive Mail")]
-        [ItemCategory(ItemCategory.Zelda)]
+        [ItemCategory(ItemCategory.Zelda, ItemCategory.Nice)]
         ProgressiveTunic = 0x60,
 
         [Description("Progressive Shield")]
@@ -225,7 +225,7 @@ namespace Randomizer.Shared
         Bow = 0x0B,
 
         [Description("Silver Arrows")]
-        [ItemCategory(ItemCategory.Zelda)]
+        [ItemCategory(ItemCategory.Zelda, ItemCategory.Nice)]
         SilverArrows = 0x58,
 
         [Description("Blue Boomerang")]
@@ -505,7 +505,7 @@ namespace Randomizer.Shared
         Wave = 0xBD,
 
         [Description("Spazer")]
-        [ItemCategory(ItemCategory.Metroid)]
+        [ItemCategory(ItemCategory.Metroid, ItemCategory.Nice)]
         Spazer = 0xBE,
 
         [Description("Plasma Beam")]

--- a/src/Randomizer.Shared/Enums/ItemTypeExtensions.cs
+++ b/src/Randomizer.Shared/Enums/ItemTypeExtensions.cs
@@ -55,5 +55,16 @@ namespace Randomizer.Shared
 
             return attrib.Categories;
         }
+
+        /// <summary>
+        /// Returns true if this item type is a progression item type
+        /// </summary>
+        /// <param name="itemType">The item type to check</param>
+        /// <returns>True if it's a progression item type, false otherwise</returns>
+        public static bool IsProgression(this ItemType itemType)
+        {
+            return !(itemType.IsInAnyCategory(new[] { ItemCategory.Junk, ItemCategory.Scam, ItemCategory.Map, ItemCategory.Compass,
+                    ItemCategory.SmallKey, ItemCategory.BigKey, ItemCategory.Keycard, ItemCategory.NonRandomized, ItemCategory.Nice  }) || itemType == ItemType.Nothing);
+        }
     }
 }


### PR DESCRIPTION
Fixes to prevent issues with playing seeds that don't match the requested settings like in Pink's stream.

- After generating a seed, it will now throw an error popup if it doesn't match the user settings
- Spazer and tunics no longer show up as potential early items as they are not technically progression items