### PR TITLE
Clear dungeon fix

### DIFF
--- a/src/Randomizer.SMZ3.Tracking/Configuration/DungeonInfo.cs
+++ b/src/Randomizer.SMZ3.Tracking/Configuration/DungeonInfo.cs
@@ -222,7 +222,7 @@ namespace Randomizer.SMZ3.Tracking.Configuration
         public IReadOnlyCollection<Location> GetLocations(World world)
         {
             var region = GetRegion(world);
-            return region.Locations.ToImmutableList();
+            return region.Locations.Where(x => x.Type != LocationType.NotInDungeon).ToImmutableList();
         }
     }
 }

--- a/src/Randomizer.SMZ3.Tracking/Configuration/ResponseConfig.cs
+++ b/src/Randomizer.SMZ3.Tracking/Configuration/ResponseConfig.cs
@@ -14,7 +14,8 @@ namespace Randomizer.SMZ3.Tracking.Configuration
         public SchrodingersString? StartedTracking { get; init; }
 
         /// <summary>
-        /// Gets the phrases to respond with when tracker starts in "alternate" mode.
+        /// Gets the phrases to respond with when tracker starts in "alternate"
+        /// mode.
         /// </summary>
         public SchrodingersString? StartingTrackingAlternate { get; init; }
 
@@ -291,13 +292,46 @@ namespace Randomizer.SMZ3.Tracking.Configuration
             = new SchrodingersString("You already marked every dungeon.");
 
         /// <summary>
+        /// Gets the phrases to respond with when clearing all locations in a
+        /// dungeon.
+        /// </summary>
+        /// <remarks>
+        /// <c>{0}</c> is a placeholder for the name of the dungeon.
+        /// </remarks>
+        public SchrodingersString DungeonCleared { get; init; }
+             = new("Cleared everything in {0}.");
+
+        /// <summary>
+        /// Gets the phrases to respond with when clearing all location in a
+        /// dungeon, but all locations are already cleared.
+        /// </summary>
+        /// <remarks>
+        /// <c>{0}</c> is a placeholder for the name of the dungeon.
+        /// </remarks>
+        public SchrodingersString DungeonAlreadyCleared { get; init; }
+            = new("But you already got everything in {0}.");
+
+        /// <summary>
+        /// Gets the phrases to respond with when clearing all locations in a
+        /// dungeon, but some of the cleared locations were out of logic.
+        /// </summary>
+        /// <remarks>
+        /// <c>{0}</c> is a placeholder for the name of the dungeon. <c>{1}</c>
+        /// is a placeholder for the name of a location that was missed.
+        /// <c>{2}</c> is a placeholder for the items that are required for a
+        /// missed location.
+        /// </remarks>
+        public SchrodingersString DungeonClearedWithInaccessibleItems { get; init; }
+            = new("Including some out of logic checks that require {2}, such as {1}.");
+
+        /// <summary>
         /// Gets the phrases to respond with when clearing a dungeon.
         /// </summary>
         /// <remarks>
         /// <c>{0}</c> is a placeholder for the name of the dungeon that was
         /// cleared. <c>{1}</c> is a placeholder for the boss of the dungeon.
         /// </remarks>
-        public SchrodingersString DungeonCleared { get; init; }
+        public SchrodingersString DungeonBossCleared { get; init; }
             = new SchrodingersString("Cleared {0}.", "Marked {1} as defeated.");
 
         /// <summary>
@@ -308,7 +342,7 @@ namespace Randomizer.SMZ3.Tracking.Configuration
         /// <c>{0}</c> is a placeholder for the name of the dungeon that was
         /// cleared. <c>{1}</c> is a placeholder for the boss of the dungeon.
         /// </remarks>
-        public SchrodingersString DungeonAlreadyCleared { get; init; }
+        public SchrodingersString DungeonBossAlreadyCleared { get; init; }
             = new SchrodingersString("You already cleared {0}.", "You already defeated {1}.");
 
         /// <summary>
@@ -319,7 +353,7 @@ namespace Randomizer.SMZ3.Tracking.Configuration
         /// <c>{0}</c> is a placeholder for the name of the dungeon. <c>{1}</c>
         /// is a placeholder for the boss of the dungeon.
         /// </remarks>
-        public SchrodingersString DungeonUncleared { get; init; }
+        public SchrodingersString DungeonBossUncleared { get; init; }
             = new SchrodingersString("Reset {0}.", "Marked {1} as still alive.");
 
         /// <summary>
@@ -330,7 +364,7 @@ namespace Randomizer.SMZ3.Tracking.Configuration
         /// <c>{0}</c> is a placeholder for the name of the dungeon. <c>{1}</c>
         /// is a placeholder for the boss of the dungeon.
         /// </remarks>
-        public SchrodingersString DungeonNotYetCleared { get; init; }
+        public SchrodingersString DungeonBossNotYetCleared { get; init; }
             = new SchrodingersString("You haven't cleared {0} yet.", "You never defeated {1} in the first place.");
 
         /// <summary>

--- a/src/Randomizer.SMZ3.Tracking/Configuration/ResponseConfig.cs
+++ b/src/Randomizer.SMZ3.Tracking/Configuration/ResponseConfig.cs
@@ -325,6 +325,17 @@ namespace Randomizer.SMZ3.Tracking.Configuration
             = new("Including some out of logic checks that require {2}, such as {1}.");
 
         /// <summary>
+        /// Gets the phrases to respond with when clearing all locations in a
+        /// dungeon, but some of the cleared locations were out of logic with too many missing items.
+        /// </summary>
+        /// <remarks>
+        /// <c>{0}</c> is a placeholder for the name of the dungeon. <c>{1}</c>
+        /// is a placeholder for the name of a location that was missed.
+        /// </remarks>
+        public SchrodingersString DungeonClearedWithTooManyInaccessibleItems { get; init; }
+            = new("Are you sure you got everything?");
+
+        /// <summary>
         /// Gets the phrases to respond with when clearing a dungeon.
         /// </summary>
         /// <remarks>

--- a/src/Randomizer.SMZ3.Tracking/Tracker.cs
+++ b/src/Randomizer.SMZ3.Tracking/Tracker.cs
@@ -1537,13 +1537,19 @@ namespace Randomizer.SMZ3.Tracking
                 {
                     var anyMissedLocation = inaccessibleLocations.Random(s_random);
                     var locationInfo = WorldInfo.Location(anyMissedLocation);
-                    var missingItems = Logic.GetMissingRequiredItems(anyMissedLocation, progress)
-                        .Random(s_random)
-                        .Select(FindItemByType)
-                        .NonNull();
-                    var missingItemsText = NaturalLanguage.Join(missingItems, World.Config);
-
-                    Say(x => x.DungeonClearedWithInaccessibleItems, dungeon.Name, locationInfo.Name, missingItemsText);
+                    var missingItemCombinations = Logic.GetMissingRequiredItems(anyMissedLocation, progress);
+                    if (missingItemCombinations.Any())
+                    {
+                        var missingItems = missingItemCombinations.Random(s_random)
+                                .Select(FindItemByType)
+                                .NonNull();
+                        var missingItemsText = NaturalLanguage.Join(missingItems, World.Config);
+                        Say(x => x.DungeonClearedWithInaccessibleItems, dungeon.Name, locationInfo.Name, missingItemsText);
+                    }
+                    else
+                    {
+                        Say(x => x.DungeonClearedWithTooManyInaccessibleItems, dungeon.Name, locationInfo.Name);
+                    }
                 }
             }
             else

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/LocationTrackingModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/LocationTrackingModule.cs
@@ -40,6 +40,11 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
                         includeUnavailable: false,
                         confidence: result.Confidence);
                 }
+                else if (result.Semantics.ContainsKey(DungeonKey))
+                {
+                    var dungeon = GetDungeonFromResult(tracker, result);
+                    tracker.ClearDungeon(dungeon, result.Confidence);
+                }
                 else if (result.Semantics.ContainsKey(RegionKey))
                 {
                     var region = GetRegionFromResult(tracker, result);
@@ -106,8 +111,14 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
 
         private GrammarBuilder GetClearAreaRule()
         {
+            var dungeonNames = GetDungeonNames(includeDungeonsWithoutReward: true);
             var roomNames = GetRoomNames();
-            var regionNames = GetRegionNames();
+            var regionNames = GetRegionNames(excludeDungeons: true);
+
+            var clearDungeon = new GrammarBuilder()
+                .Append("Hey tracker,")
+                .OneOf("clear", "please clear")
+                .Append(DungeonKey, dungeonNames);
 
             var clearRoom = new GrammarBuilder()
                 .Append("Hey tracker,")
@@ -119,7 +130,7 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
                 .OneOf("clear", "please clear")
                 .Append(RegionKey, regionNames);
 
-            return GrammarBuilder.Combine(clearRoom, clearRegion);
+            return GrammarBuilder.Combine(clearDungeon, clearRoom, clearRegion);
         }
     }
 }

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/TrackerModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/TrackerModule.cs
@@ -452,12 +452,15 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
         /// A new <see cref="Choices"/> object representing all possible region
         /// names mapped to the primary region name.
         /// </returns>
-        protected virtual Choices GetRegionNames()
+        protected virtual Choices GetRegionNames(bool excludeDungeons = false)
         {
             var regionNames = new Choices();
 
             foreach (var region in Tracker.WorldInfo.Regions)
             {
+                if (excludeDungeons && Tracker.WorldInfo.Dungeon(region.TypeName) != null)
+                    continue;
+
                 foreach (var name in region.Name)
                     regionNames.Add(new SemanticResultValue(name.Text, region.TypeName));
             }

--- a/src/Randomizer.SMZ3.Tracking/tracker.json
+++ b/src/Randomizer.SMZ3.Tracking/tracker.json
@@ -1352,23 +1352,34 @@
       "You did that already."
     ],
     "DungeonCleared": [
+      "Cleared all items from {0}",
+      "Marked {0} as all clear"
+    ],
+    "DungeonAlreadyCleared": [
+      "But you already cleared {0}.",
+      "But there's nothing left in {0}."
+    ],
+    "DungeonClearedWithInaccessibleItems": [
+      "Including some out of logic checks that need {2}, like {1}.",
+      "Including some inaccessible areas that require {2}, such as {1}.",
+      "Also cleared some checks that require {2}. You might want to double-check {1}.",
+      "You might want to double-check {1} because it requires {2}."
+    ],
+    "DungeonBossCleared": [
       "Marked {1} as defeated.",
       "Congratulations on beating off {1}.",
       "RIP {1}",
       [ "f", 0.05 ]
     ],
-    "DungeonAlreadyCleared": [
-      "But you already cleared {0}.",
+    "DungeonBossAlreadyCleared": [
       "But you already defeated {1}.",
       "But {1} is already dead."
     ],
-    "DungeonUncleared": [
-      "Marked {0} as incomplete.",
+    "DungeonBossUncleared": [
       "Marked {1} as still alive.",
       "Revived {1}."
     ],
-    "DungeonNotYetCleared": [
-      "But you haven't cleared {0} yet.",
+    "DungeonBossNotYetCleared": [
       "But you never defeated {1} in the first place."
     ],
     "DungeonRequirementMarked": [

--- a/src/Randomizer.SMZ3.Tracking/tracker.json
+++ b/src/Randomizer.SMZ3.Tracking/tracker.json
@@ -1365,6 +1365,11 @@
       "Also cleared some checks that require {2}. You might want to double-check {1}.",
       "You might want to double-check {1} because it requires {2}."
     ],
+    "DungeonClearedWithTooManyInaccessibleItems": [
+      "Are you sure you cleared {0}? You're missing way too many items to get to {1}.",
+      "I doubt you got {1} though. Not with that many missing items.",
+      "I doubt you got {1} though. Not without so many items."
+    ],
     "DungeonBossCleared": [
       "Marked {1} as defeated.",
       "Congratulations on beating off {1}.",

--- a/src/Randomizer.Shared/EnumerableExtensions.cs
+++ b/src/Randomizer.Shared/EnumerableExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Randomizer.Shared
 {
@@ -35,6 +36,23 @@ namespace Randomizer.Shared
             }
 
             return -1;
+        }
+
+        /// <summary>
+        /// Filters a sequence of nullable values and returns only elements that
+        /// have a value.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type of element in <paramref name="source"/>.
+        /// </typeparam>
+        /// <param name="source">The collection to filter on.</param>
+        /// <returns>
+        /// A new collection that has no <see langword="null"/> values.
+        /// </returns>
+        public static IEnumerable<T> NonNull<T>(this IEnumerable<T?> source)
+        {
+            return source.Where(x => x != null)
+                .Select(x => x!);
         }
     }
 }

--- a/src/Randomizer.Shared/EnumerableExtensions.cs
+++ b/src/Randomizer.Shared/EnumerableExtensions.cs
@@ -38,6 +38,7 @@ namespace Randomizer.Shared
             return -1;
         }
 
+#nullable enable
         /// <summary>
         /// Filters a sequence of nullable values and returns only elements that
         /// have a value.
@@ -54,5 +55,6 @@ namespace Randomizer.Shared
             return source.Where(x => x != null)
                 .Select(x => x!);
         }
+#nullable restore
     }
 }

--- a/src/Randomizer.Shared/Randomizer.Shared.csproj
+++ b/src/Randomizer.Shared/Randomizer.Shared.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <Version>2.0.0</Version>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Reworked clear dungeon to always clear all locations and remaining treasure. Tracker will also mention if any locations might need to be double-checked because they were out of logic (but still clears them).

Resolves #89