### PR TITLE
[Experimental] Handle interruptions

### DIFF
--- a/src/Randomizer.SMZ3.Tracking/Configuration/ResponseConfig.cs
+++ b/src/Randomizer.SMZ3.Tracking/Configuration/ResponseConfig.cs
@@ -603,6 +603,11 @@ namespace Randomizer.SMZ3.Tracking.Configuration
             = new SchrodingersString("But you haven't defeated {0} yet.");
 
         /// <summary>
+        /// Gets the phrases to respond with when Tracker is being interrupted.
+        /// </summary>
+        public SchrodingersString? Interrupted { get; init; }
+
+        /// <summary>
         /// Gets a dictionary that contains the phrases to respond with when no
         /// voice commands have been issued after a certain period of time, as
         /// expressed in the dictionary keys.

--- a/src/Randomizer.SMZ3.Tracking/Tracker.cs
+++ b/src/Randomizer.SMZ3.Tracking/Tracker.cs
@@ -51,6 +51,7 @@ namespace Randomizer.SMZ3.Tracking
         private string? _lastSpokenText;
         private Dictionary<string, Progression> _progression = new();
         private bool _alternateTracker;
+        private int _interruptions = 0;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Tracker"/> class.
@@ -1881,6 +1882,12 @@ namespace Randomizer.SMZ3.Tracking
 
         internal void HandleInterruption()
         {
+            if (Options.InterruptionTolerance < 0
+                || (++_interruptions % Options.InterruptionTolerance) != 0)
+            {
+                return;
+            }
+
             if (Responses.Interrupted != null)
             {
                 var remainingSpeech = _speechQueue.ToList();

--- a/src/Randomizer.SMZ3.Tracking/Tracker.cs
+++ b/src/Randomizer.SMZ3.Tracking/Tracker.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
@@ -41,6 +42,8 @@ namespace Randomizer.SMZ3.Tracking
         private readonly Dictionary<string, Timer> _idleTimers;
         private readonly Stack<Action> _undoHistory = new();
         private readonly RandomizerContext _dbContext;
+
+        private readonly ConcurrentQueue<string> _speechQueue = new();
 
         private DateTime _startTime = DateTime.MinValue;
         private bool _disposed;
@@ -100,6 +103,7 @@ namespace Randomizer.SMZ3.Tracking
 
             _tts = new SpeechSynthesizer();
             _tts.SelectVoiceByHints(_alternateTracker ? VoiceGender.Male : VoiceGender.Female);
+            _tts.SpeakCompleted += (sender, e) => _speechQueue.TryDequeue(out _);
 
             // Initialize the speech recognition engine
             _recognizer = new SpeechRecognitionEngine();
@@ -269,6 +273,11 @@ namespace Randomizer.SMZ3.Tracking
         public bool IsDirty { get; set; }
 
         /// <summary>
+        /// Gets the number of queued up speech synthesis actions.
+        /// </summary>
+        public int SpeechQueueCount => _speechQueue.Count;
+
+        /// <summary>
         /// Formats a string so that it will be pronounced correctly by the
         /// text-to-speech engine.
         /// </summary>
@@ -278,10 +287,13 @@ namespace Randomizer.SMZ3.Tracking
             => name.Replace("Samus", "Sammus");
 
         /// <summary>
-        /// Attempts to replace a user name with a pronunciation-corrected version of it.
+        /// Attempts to replace a user name with a pronunciation-corrected
+        /// version of it.
         /// </summary>
         /// <param name="userName">The user name to correct.</param>
-        /// <returns>The corrected user name, or <paramref name="userName"/>.</returns>
+        /// <returns>
+        /// The corrected user name, or <paramref name="userName"/>.
+        /// </returns>
         public string CorrectUserNamePronunciation(string userName)
         {
             if (Responses.Chat.UserNamePronunciation.TryGetValue(userName, out var correctedUserName))
@@ -771,6 +783,7 @@ namespace Randomizer.SMZ3.Tracking
         {
             DisableVoiceRecognition();
             _tts.SpeakAsyncCancelAll();
+            _speechQueue.Clear();
             _chatClient.Disconnect();
             Say(GoMode ? Responses.StoppedTrackingPostGoMode : Responses.StoppedTracking, wait: true);
 
@@ -883,6 +896,7 @@ namespace Randomizer.SMZ3.Tracking
 
             var formattedText = FormatPlaceholders(text);
             var prompt = ParseText(formattedText);
+            _speechQueue.Enqueue(text);
             if (wait)
                 _tts.Speak(prompt);
             else
@@ -950,6 +964,7 @@ namespace Randomizer.SMZ3.Tracking
         public virtual void ShutUp()
         {
             _tts.SpeakAsyncCancelAll();
+            _speechQueue.Clear();
         }
 
         /// <summary>
@@ -1862,6 +1877,20 @@ namespace Randomizer.SMZ3.Tracking
             Say(Responses.PegWorldModeDone);
             OnPegWorldModeToggled(new TrackerEventArgs(confidence));
             AddUndo(() => PegWorldMode = true);
+        }
+
+        internal void HandleInterruption()
+        {
+            if (Responses.Interrupted != null)
+            {
+                var remainingSpeech = _speechQueue.ToList();
+                _tts.SpeakAsyncCancelAll();
+
+                Say(x => x.Interrupted);
+
+                foreach (var queuedSpeech in remainingSpeech)
+                    Say(queuedSpeech);
+            }
         }
 
         /// <summary>

--- a/src/Randomizer.SMZ3.Tracking/TrackerOptions.cs
+++ b/src/Randomizer.SMZ3.Tracking/TrackerOptions.cs
@@ -60,5 +60,11 @@ namespace Randomizer.SMZ3.Tracking
         /// Gets or sets the name of the current user.
         /// </summary>
         public string? UserName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of times Tracker will tolerate being
+        /// interrupted before speaking up.
+        /// </summary>
+        public int InterruptionTolerance { get; set; } = 2;
     }
 }

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/TrackerModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/TrackerModule.cs
@@ -277,7 +277,7 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
                             Logger.LogInformation("Recognized \"{text}\" with {confidence:P2} confidence.",
                                 e.Result.Text, e.Result.Confidence);
 
-                            if (Tracker.SpeechQueueCount > 1)
+                            if (Tracker.SpeechQueueCount >= 1)
                                 Tracker.HandleInterruption();
 
                             executeCommand(Tracker, e.Result);

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/TrackerModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/TrackerModule.cs
@@ -276,6 +276,10 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
                         {
                             Logger.LogInformation("Recognized \"{text}\" with {confidence:P2} confidence.",
                                 e.Result.Text, e.Result.Confidence);
+
+                            if (Tracker.SpeechQueueCount > 1)
+                                Tracker.HandleInterruption();
+
                             executeCommand(Tracker, e.Result);
                         }
                         else

--- a/src/Randomizer.SMZ3.Tracking/tracker.json
+++ b/src/Randomizer.SMZ3.Tracking/tracker.json
@@ -1262,7 +1262,9 @@
     "Interrupted": [
       "Excuse me. <break strength='weak'/> As I was saying...",
       "Can you not? <break strength='weak'/> As I was saying...",
-      "I'm talking here. <break strength='weak'/> Anyway..."
+      "I'm talking here. <break strength='weak'/> Anyway...",
+      "Do you mind? <break strength='weak'/> Anyway...",
+      "It's not polite to talk over other people, you know. <break strength='weak'/> As I was saying..."
     ],
     "TrackedItem": [
       "Toggling {0} on.",

--- a/src/Randomizer.SMZ3.Tracking/tracker.json
+++ b/src/Randomizer.SMZ3.Tracking/tracker.json
@@ -1259,6 +1259,11 @@
       "What was that?",
       [ "English motherfucker, do you speak it?", 0.05 ]
     ],
+    "Interrupted": [
+      "Excuse me. <break strength='weak'/> As I was saying...",
+      "Can you not? <break strength='weak'/> As I was saying...",
+      "I'm talking here. <break strength='weak'/> Anyway..."
+    ],
     "TrackedItem": [
       "Toggling {0} on.",
       "Toggled {0} on.",


### PR DESCRIPTION
Pink inspired me by sometimes tracking multiple items in rapid succession — issues commands while Tracker is still responding to the previous command. I figured it'd be fun to add a little flair by having Tracker interrupt these kinds of situations with some sass.

Considerations:

- How many times should Tracker tolerate being interrupted before speaking up about it?
- Should we add a timeout before speaking up again, in addition to the threshold?
  - It's not likely to happen too often. And if it does happen often, we should increase the threshold instead. But still, it's worth considering.
- I've added #97 so for similar ideas in the future, we can experiment more easily and give users the ability to toggle something off.