### PR TITLE
Added "Hey tracker, what's in <area>?"

### DIFF
--- a/src/Randomizer.SMZ3.Tracking/Configuration/HintsConfig.cs
+++ b/src/Randomizer.SMZ3.Tracking/Configuration/HintsConfig.cs
@@ -280,9 +280,49 @@ namespace Randomizer.SMZ3.Tracking.Configuration
         /// <remarks>
         /// <c>{0}</c> is a placeholder for the name of the location. <c>{1}</c>
         /// is a placeholder for the text that would be displayed when using the
-        /// Book of Mudora. <c>{2}</c> is the name of the Book of Mudora, including "the".
+        /// Book of Mudora. <c>{2}</c> is the name of the Book of Mudora,
+        /// including "the".
         /// </remarks>
         public SchrodingersString BookHint { get; init; }
             = new("If the item there was on the Master Sword Pedestal, it would say '{1}'.");
+
+        /// <summary>
+        /// Gets the phrases to respond with when asking for hints about an area
+        /// that was already cleared.
+        /// </summary>
+        /// <remarks>
+        /// <c>{0}</c> is a placeholder for the name of the area.
+        /// </remarks>
+        public SchrodingersString AreaAlreadyCleared { get; init; }
+            = new("You already got everything in {0}.");
+
+        /// <summary>
+        /// Gets the hint to give for an area that might have one or more useful
+        /// items.
+        /// </summary>
+        /// <remarks>
+        /// <c>{0}</c> is a placeholder for the name of the area.
+        /// </remarks>
+        public SchrodingersString AreaHasSomethingGood { get; init; }
+            = new("{0} might have something good.");
+
+        /// <summary>
+        /// Gets the hint to give for an area that only has junk items left.
+        /// </summary>
+        /// <remarks>
+        /// <c>{0}</c> is a placeholder for the name of the area.
+        /// </remarks>
+        public SchrodingersString AreaHasJunk { get; init; }
+            = new("{0} isn't worth your time.");
+
+        /// <summary>
+        /// Gets the hint to give for an area that only has junk items left, but
+        /// also has a crystal as reward for beating the boss.
+        /// </summary>
+        /// <remarks>
+        /// <c>{0}</c> is a placeholder for the name of the area.
+        /// </remarks>
+        public SchrodingersString AreaHasJunkAndCrystal { get; init; }
+            = new("{0} only has a crystal.");
     }
 }

--- a/src/Randomizer.SMZ3.Tracking/Configuration/HintsConfig.cs
+++ b/src/Randomizer.SMZ3.Tracking/Configuration/HintsConfig.cs
@@ -324,5 +324,16 @@ namespace Randomizer.SMZ3.Tracking.Configuration
         /// </remarks>
         public SchrodingersString AreaHasJunkAndCrystal { get; init; }
             = new("{0} only has a crystal.");
+
+        /// <summary>
+        /// Gets the hint to give for an area whose worth is complicated, e.g.
+        /// when a dungeon has only junk and is not a crystal dungeon, but the
+        /// pendant might result in something good.
+        /// </summary>
+        /// <remarks>
+        /// <c>{0}</c> is a placeholder for the name of the area.
+        /// </remarks>
+        public SchrodingersString AreaWorthComplicated { get; init; }
+            = new("It's complicated.");
     }
 }

--- a/src/Randomizer.SMZ3.Tracking/Configuration/ItemData.cs
+++ b/src/Randomizer.SMZ3.Tracking/Configuration/ItemData.cs
@@ -290,6 +290,21 @@ namespace Randomizer.SMZ3.Tracking.Configuration
         }
 
         /// <summary>
+        /// Determines whether the item is worth getting given the specified
+        /// configuration.
+        /// </summary>
+        /// <param name="config">The randomizer configuration.</param>
+        /// <returns>
+        /// <c>true</c> if the item is considered good; otherwise, <c>false</c>.
+        /// </returns>
+        /// <remarks>
+        /// This method only considers the item's value on its own. Call <see
+        /// cref="Tracker.IsWorth(ItemData)"/> to include items that this item
+        /// might logically lead to.
+        /// </remarks>
+        public bool IsGood(Config config) => !IsJunk(config);
+
+        /// <summary>
         /// Determines whether the item is junk given the specified
         /// configuration.
         /// </summary>
@@ -297,6 +312,11 @@ namespace Randomizer.SMZ3.Tracking.Configuration
         /// <returns>
         /// <c>true</c> if the item is considered junk; otherwise, <c>false</c>.
         /// </returns>
+        /// <remarks>
+        /// This method only considers the item's value on its own. Call <see
+        /// cref="Tracker.IsWorth(ItemData)"/> to include items that this item
+        /// might logically lead to.
+        /// </remarks>
         public bool IsJunk(Config config)
         {
             var junkCategories = config.Keysanity

--- a/src/Randomizer.SMZ3.Tracking/Configuration/SpoilerConfig.cs
+++ b/src/Randomizer.SMZ3.Tracking/Configuration/SpoilerConfig.cs
@@ -177,5 +177,15 @@ namespace Randomizer.SMZ3.Tracking.Configuration
         /// </remarks>
         public SchrodingersString ItemsAreAtOutOfLogicLocation { get; init; }
             = new("There is {0} at {1} <break strength='weak'/> in {2}, but you cannot get it yet.");
+
+        /// <summary>
+        /// Gets the phrases that mention all the items in an area.
+        /// </summary>
+        /// <remarks>
+        /// <c>{0}</c> is a placeholder for the name of the room or region.
+        /// <c>{1}</c> is a placeholder for the names of the items left.
+        /// </remarks>
+        public SchrodingersString ItemsInArea { get; init; }
+            = new("{0} has {1}");
     }
 }

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/SpoilerModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/SpoilerModule.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Security.Cryptography.X509Certificates;
 
 using Microsoft.Extensions.Logging;
 
@@ -160,11 +161,21 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
                 {
                     Tracker.Say(x => x.Hints.AreaHasSomethingGood, area.GetName());
                 }
-                else if (area is IHasReward region
-                    && (region.Reward == Reward.CrystalBlue
-                        || region.Reward == Reward.CrystalRed))
+                else if (area is IHasReward region)
                 {
-                    Tracker.Say(x => x.Hints.AreaHasJunkAndCrystal, area.GetName());
+                    if (region.Reward == Reward.CrystalBlue
+                        || region.Reward == Reward.CrystalRed)
+                    {
+                        Tracker.Say(x => x.Hints.AreaHasJunkAndCrystal, area.GetName());
+                    }
+                    else if (Tracker.IsWorth(region.Reward))
+                    {
+                        Tracker.Say(x => x.Hints.AreaWorthComplicated, area.GetName());
+                    }
+                    else
+                    {
+                        Tracker.Say(x => x.Hints.AreaHasJunk, area.GetName());
+                    }
                 }
                 else
                 {

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/TrackerModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/TrackerModule.cs
@@ -215,6 +215,25 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
         }
 
         /// <summary>
+        /// Returns the region or room that was detected in a voice
+        /// command.
+        /// </summary>
+        /// <param name="tracker">The tracker instance.</param>
+        /// <param name="result">The speech recognition result.</param>
+        /// <returns>
+        /// The recognized area from the recognition result.
+        /// </returns>
+        protected static IHasLocations GetAreaFromResult(Tracker tracker, RecognitionResult result)
+        {
+            if (result.Semantics.ContainsKey(RegionKey))
+                return GetRegionFromResult(tracker, result);
+            else if (result.Semantics.ContainsKey(RoomKey))
+                return GetRoomFromResult(tracker, result);
+            else
+                throw new InvalidOperationException("Could not find a region or room in the recognized voice command.");
+        }
+
+        /// <summary>
         /// Adds a new voice command that matches the specified phrase.
         /// </summary>
         /// <param name="ruleName">The name of the command.</param>

--- a/src/Randomizer.SMZ3.Tracking/tracker.json
+++ b/src/Randomizer.SMZ3.Tracking/tracker.json
@@ -1750,6 +1750,9 @@
         "You could skip it if it didn't have a crystal.",
         "I don't think you'd care about anything in {0} but the crystal.",
         "I don't think you'd care about anything in there but the crystal."
+      ],
+      "AreaWorthComplicated": [
+        "It's complicated."
       ]
     },
     "Spoilers": {

--- a/src/Randomizer.SMZ3.Tracking/tracker.json
+++ b/src/Randomizer.SMZ3.Tracking/tracker.json
@@ -1700,7 +1700,7 @@
         "I bet {1} would appreciate it if you checked out {0}.",
         "I wouldn't skip that if I were you.",
         "{1} would not want you to skip it.",
-        [ "{0} is on the way of the hero.", 0.2 ]
+        [ "{0} is on the way of the hero.", 0.5 ]
       ],
       "AreaSuggestion": [
         "What about {0}?",
@@ -1716,6 +1716,40 @@
         "If the item there was on the Master Sword Pedestal, it would say <break strength='weak'/> '{1}'.",
         "'{1}' is what {2} would tell you.",
         "Let me consult {2}. <break strength='1s'/> {1}."
+      ],
+      "AreaAlreadyCleared": [
+        "You already got everything in {0}.",
+        "If there was anything good in {0} you already got it."
+      ],
+      "AreaHasSomethingGood": [
+        "{0} might have something good.",
+        "It might have something good.",
+        "{0} might be worth checking out.",
+        "It might be worth checking out.",
+        "I wouldn't skip it if I were you.",
+        "I wouldn't skip {0} if I were you.",
+        [ "{0} is on the way of the hero.", 0.5 ]
+      ],
+      "AreaHasJunk": [
+        "{0} isn't worth your time.",
+        "It isn't worth your time.",
+        "There's nothing important in {0}.",
+        "There's nothing important there.",
+        "You can skip {0}.",
+        "You can skip it.",
+        "I don't think you'd care about anything in {0}.",
+        "I don't think you'd care about anything there.",
+        [ "{0} is barren.", 0.2 ]
+      ],
+      "AreaHasJunkAndCrystal": [
+        "The only thing of worth in {0} is a crystal.",
+        "The only thing of worth there is a crystal.",
+        "There's nothing important in {0} except for the crystal.",
+        "There's nothing important there except for the crystal.",
+        "You could skip {0} if it didn't have a crystal.",
+        "You could skip it if it didn't have a crystal.",
+        "I don't think you'd care about anything in {0} but the crystal.",
+        "I don't think you'd care about anything in there but the crystal."
       ]
     },
     "Spoilers": {
@@ -1790,6 +1824,10 @@
       "ItemsAreAtOutOfLogicLocation": [
         "There is {0} at {1} <break strength='weak'/> in {2}, but you cannot get it yet.",
         "{0} is at {1} <break strength='weak'/> in {2}, but it's out of logic."
+      ],
+      "ItemsInArea": [
+        "{0} has {1}",
+        "It's got {1}"
       ]
     },
     "Idle": {


### PR DESCRIPTION
Works for both regions, dungeons, and rooms.

If spoilers are enabled, Tracker will straight up list all the items there.
If hints are enabled, she'll tell you whether there's anything useful or not. 

I kinda went all in and considered whether pendants are useful, for which I had to create some code to consider some item chains. It would be a lot of work to apply this to everything we've already done, but might be worth adding once it's noticed.