### PR TITLE
Bug fixes and polish

### DIFF
--- a/setup/randomizer.app.iss
+++ b/setup/randomizer.app.iss
@@ -4,7 +4,7 @@
 #include "CodeDependencies.iss"
 
 #define MyAppName "SMZ3 Cas' Randomizer"
-#define MyAppVersion "4.2.1"
+#define MyAppVersion "4.2.2"
 #define MyAppPublisher "Vivelin"
 #define MyAppURL "https://github.com/Vivelin/SMZ3Randomizer"
 #define MyAppExeName "Randomizer.App.exe"

--- a/src/Randomizer.App/Randomizer.App.csproj
+++ b/src/Randomizer.App/Randomizer.App.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net5.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>chozo20.ico</ApplicationIcon>
-    <Version>4.2.1</Version>
+    <Version>4.2.2</Version>
     <Title>SMZ3 Cas' Randomizer</Title>
     <AssemblyTitle>SMZ3 Cas' Randomizer</AssemblyTitle>
     <Authors>Vivelin</Authors>

--- a/src/Randomizer.App/ViewModels/GeneralOptions.cs
+++ b/src/Randomizer.App/ViewModels/GeneralOptions.cs
@@ -94,9 +94,10 @@ namespace Randomizer.App.ViewModels
             get => _twitchChannel;
             set
             {
-                if (_twitchChannel != value)
+                var newValue = NormalizeTwitchChannel(value);
+                if (_twitchChannel != newValue)
                 {
-                    _twitchChannel = value;
+                    _twitchChannel = newValue;
                     OnPropertyChanged();
                 }
             }
@@ -130,6 +131,22 @@ namespace Randomizer.App.ViewModels
         protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
         {
             PropertyChanged?.Invoke(this, new(propertyName));
+        }
+
+        private static string NormalizeTwitchChannel(string value)
+        {
+            try
+            {
+                value = value.Trim();
+                if (Uri.TryCreate(value, UriKind.Absolute, out var twitchUri)
+                    && twitchUri.Host == "twitch.tv")
+                {
+                    return twitchUri.AbsolutePath.TrimStart('/');
+                }
+            }
+            catch { }
+
+            return value;
         }
     }
 

--- a/src/Randomizer.SMZ3.Tracking/Configuration/ItemData.cs
+++ b/src/Randomizer.SMZ3.Tracking/Configuration/ItemData.cs
@@ -324,7 +324,8 @@ namespace Randomizer.SMZ3.Tracking.Configuration
                 : new[] { ItemCategory.Junk, ItemCategory.Scam, ItemCategory.Map, ItemCategory.Compass,
                     ItemCategory.SmallKey, ItemCategory.BigKey, ItemCategory.Keycard };
 
-            return InternalItemType.IsInAnyCategory(junkCategories);
+            return InternalItemType == ItemType.Nothing
+                || InternalItemType.IsInAnyCategory(junkCategories);
         }
     }
 }

--- a/src/Randomizer.SMZ3.Tracking/Configuration/ResponseConfig.cs
+++ b/src/Randomizer.SMZ3.Tracking/Configuration/ResponseConfig.cs
@@ -603,16 +603,6 @@ namespace Randomizer.SMZ3.Tracking.Configuration
             = new SchrodingersString("But you haven't defeated {0} yet.");
 
         /// <summary>
-        /// Gets the phrases to respond with when Tracker is being interrupted.
-        /// </summary>
-        public SchrodingersString? Interrupted { get; init; }
-
-        /// <summary>
-        /// Gets the phrases to respond with when Tracker has been interrupted too many times.
-        /// </summary>
-        public SchrodingersString? InterruptedTooManyTimes { get; init; }
-
-        /// <summary>
         /// Gets a dictionary that contains the phrases to respond with when no
         /// voice commands have been issued after a certain period of time, as
         /// expressed in the dictionary keys.

--- a/src/Randomizer.SMZ3.Tracking/Configuration/SpoilerConfig.cs
+++ b/src/Randomizer.SMZ3.Tracking/Configuration/SpoilerConfig.cs
@@ -109,6 +109,16 @@ namespace Randomizer.SMZ3.Tracking.Configuration
             = new("I cannot find any more {0}.");
 
         /// <summary>
+        /// Gets the phrases to respond with when all locations that have the item are cleared.
+        /// </summary>
+        /// <remarks>
+        /// <c>{0}</c> is a placeholder for the name of the item, with "a", "an"
+        /// or "the".
+        /// </remarks>
+        public SchrodingersString LocationsCleared { get; init; }
+            = new("You already cleared every location that has {0}.");
+
+        /// <summary>
         /// Gets the phrases that spoil the item that is at the requested
         /// location.
         /// </summary>

--- a/src/Randomizer.SMZ3.Tracking/Tracker.cs
+++ b/src/Randomizer.SMZ3.Tracking/Tracker.cs
@@ -291,7 +291,7 @@ namespace Randomizer.SMZ3.Tracking
             var correctedUserName = Responses.Chat.UserNamePronunciation
                 .SingleOrDefault(x => x.Key.Equals(userName, StringComparison.OrdinalIgnoreCase));
 
-            return correctedUserName.Value ?? userName;
+            return correctedUserName.Value ?? userName.Replace('_', ' ');
         }
 
         /// <summary>

--- a/src/Randomizer.SMZ3.Tracking/Tracker.cs
+++ b/src/Randomizer.SMZ3.Tracking/Tracker.cs
@@ -43,15 +43,12 @@ namespace Randomizer.SMZ3.Tracking
         private readonly Stack<Action> _undoHistory = new();
         private readonly RandomizerContext _dbContext;
 
-        private readonly ConcurrentQueue<string> _speechQueue = new();
-
         private DateTime _startTime = DateTime.MinValue;
         private bool _disposed;
         private string? _mood;
         private string? _lastSpokenText;
         private Dictionary<string, Progression> _progression = new();
         private bool _alternateTracker;
-        private int _interruptions = 0;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Tracker"/> class.
@@ -104,7 +101,6 @@ namespace Randomizer.SMZ3.Tracking
 
             _tts = new SpeechSynthesizer();
             _tts.SelectVoiceByHints(_alternateTracker ? VoiceGender.Male : VoiceGender.Female);
-            _tts.SpeakCompleted += (sender, e) => _speechQueue.TryDequeue(out _);
 
             // Initialize the speech recognition engine
             _recognizer = new SpeechRecognitionEngine();
@@ -272,11 +268,6 @@ namespace Randomizer.SMZ3.Tracking
         /// Get if the Tracker has been updated since it was last saved
         /// </summary>
         public bool IsDirty { get; set; }
-
-        /// <summary>
-        /// Gets the number of queued up speech synthesis actions.
-        /// </summary>
-        public int SpeechQueueCount => _speechQueue.Count;
 
         /// <summary>
         /// Formats a string so that it will be pronounced correctly by the
@@ -799,7 +790,6 @@ namespace Randomizer.SMZ3.Tracking
         {
             DisableVoiceRecognition();
             _tts.SpeakAsyncCancelAll();
-            _speechQueue.Clear();
             _chatClient.Disconnect();
             Say(GoMode ? Responses.StoppedTrackingPostGoMode : Responses.StoppedTracking, wait: true);
 
@@ -912,7 +902,6 @@ namespace Randomizer.SMZ3.Tracking
 
             var formattedText = FormatPlaceholders(text);
             var prompt = ParseText(formattedText);
-            _speechQueue.Enqueue(text);
             if (wait)
                 _tts.Speak(prompt);
             else
@@ -980,7 +969,6 @@ namespace Randomizer.SMZ3.Tracking
         public virtual void ShutUp()
         {
             _tts.SpeakAsyncCancelAll();
-            _speechQueue.Clear();
         }
 
         /// <summary>
@@ -1905,42 +1893,6 @@ namespace Randomizer.SMZ3.Tracking
             Say(Responses.PegWorldModeDone);
             OnPegWorldModeToggled(new TrackerEventArgs(confidence));
             AddUndo(() => PegWorldMode = true);
-        }
-
-        internal void HandleInterruption()
-        {
-            _interruptions++;
-            _logger.LogDebug("Tracker has been interrupted {Interruptions} time(s)", _interruptions);
-
-            if (Options.InterruptionTolerance < 0
-                || (_interruptions % Options.InterruptionTolerance) != 0)
-            {
-                _logger.LogDebug("Tracker is tolerating the interruptions (Tolerance: {Tolerance})", Options.InterruptionTolerance);
-                return;
-            }
-
-            if (_interruptions >= Options.InterruptionLimit
-                && Responses.InterruptedTooManyTimes != null)
-            {
-                _interruptions = 0;
-                _tts.SpeakAsyncCancelAll();
-                _speechQueue.Clear();
-                _logger.LogDebug("Tracker has had enough and reach her interruption limit of {Limit}", Options.InterruptionLimit);
-
-                Say(x => x.InterruptedTooManyTimes);
-            }
-            else if (Responses.Interrupted != null)
-            {
-                var remainingSpeech = _speechQueue.ToList();
-                _tts.SpeakAsyncCancelAll();
-                _speechQueue.Clear();
-                _logger.LogDebug("Tracker doesn't like being interrupted. Still has {QueueCount} items on the TTS queue.", remainingSpeech.Count);
-
-                Say(x => x.Interrupted);
-
-                foreach (var queuedSpeech in remainingSpeech)
-                    Say(queuedSpeech);
-            }
         }
 
         internal void RestartIdleTimers()

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/SpoilerModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/SpoilerModule.cs
@@ -574,6 +574,7 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
                             {
                                 var randomMissingItem = Logic.GetMissingRequiredItems(randomLocation, progression)
                                     .SelectMany(x => x)
+                                    .Where(x => x != item.InternalItemType)
                                     .Select(x => Tracker.Items.FirstOrDefault(item => item.InternalItemType == x))
                                     .Random();
                                 if (randomMissingItem != null)

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/SpoilerModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/SpoilerModule.cs
@@ -793,7 +793,7 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
 
         private GrammarBuilder GetProgressionHintRule()
         {
-            return new GrammarBuilder()
+            var normalRule = new GrammarBuilder()
                 .Append("Hey tracker, ")
                 .OneOf("give me a hint",
                     "give me a suggestion",
@@ -801,6 +801,11 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
                     "do you have any suggestions?",
                     "where should I go?",
                     "what should I do?");
+
+            var townWithNoRule = new GrammarBuilder()
+                .Append("Give me a hint, tracker.");
+
+            return GrammarBuilder.Combine(normalRule, townWithNoRule);
         }
 
         private GrammarBuilder GetLocationUsefulnessHintRule()

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/TrackerModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/TrackerModule.cs
@@ -297,9 +297,6 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
                                 e.Result.Text, e.Result.Confidence);
                             Tracker.RestartIdleTimers();
 
-                            if (Tracker.SpeechQueueCount >= 1)
-                                Tracker.HandleInterruption();
-
                             executeCommand(Tracker, e.Result);
                         }
                         else

--- a/src/Randomizer.SMZ3.Tracking/tracker.json
+++ b/src/Randomizer.SMZ3.Tracking/tracker.json
@@ -1696,7 +1696,8 @@
         "I doubt {1} would care about what's at {0}.",
         "You can skip {0}.",
         "You can skip it.",
-        [ "{0} is barren.", 0.2 ]
+        [ "{0} is barren.", 0.5 ],
+        [ "They say that plundering {0} is a foolish choice.", 0.1 ]
       ],
       "LocationHasUsefulItem": [
         "{0} might be worth checking out.",
@@ -1746,7 +1747,8 @@
         "You can skip it.",
         "I don't think you'd care about anything in {0}.",
         "I don't think you'd care about anything there.",
-        [ "{0} is barren.", 0.2 ]
+        [ "{0} is barren.", 0.5 ],
+        [ "They say that plundering {0} is a foolish choice.", 0.1 ]
       ],
       "AreaHasJunkAndCrystal": [
         "The only thing of worth in {0} is a crystal.",

--- a/src/Randomizer.SMZ3.Tracking/tracker.json
+++ b/src/Randomizer.SMZ3.Tracking/tracker.json
@@ -1265,19 +1265,6 @@
       "What was that?",
       [ "English motherfucker, do you speak it?", 0.05 ]
     ],
-    "Interrupted": [
-      "Excuse me. <break strength='weak'/> As I was saying...",
-      "Can you not? <break strength='weak'/> As I was saying...",
-      "I'm talking here. <break strength='weak'/> Anyway...",
-      "Do you mind? <break strength='weak'/> Anyway...",
-      "It's not polite to talk over other people, you know. <break strength='weak'/> As I was saying..."
-    ],
-    "InterruptedTooManyTimes": [
-      "Shut up already.",
-      "Fine, I'll shut up. <break time='60s'/>",
-      "I've had enough of this. I'm taking a break. <break time='60s'/>",
-      "That's it. I'm taking a break. <break time='60s'/>"
-    ],
     "TrackedItem": [
       "Toggling {0} on.",
       "Toggled {0} on.",

--- a/src/Randomizer.SMZ3.Tracking/tracker.json
+++ b/src/Randomizer.SMZ3.Tracking/tracker.json
@@ -111,7 +111,11 @@
         "You could find it in real life."
       ],
       "WhenTracked": {
-        "1": [ "Toggled Hammer on.", "Stop. Hammer time." ]
+        "1": [
+          "Toggled Hammer on.",
+          "Stop. Hammer time.",
+          [ "You got an M comma C hammer! Pile softening Bang Bang Clap! Other also Bambang Clap Clap!", 0.1 ]
+        ]
       }
     },
     {
@@ -223,7 +227,15 @@
       "Row": 1,
       "Hints": [
         "You could find it in real life."
-      ]
+      ],
+      "WhenTracked": {
+        "1": [
+          "Toggled Shovel on",
+          "Toggled Digging Tool on",
+          [ "Toggled Shaktool Junior on", 0.2 ],
+          [ "I borrowed an excavator. If you can dig, you will fall in love with the hole. Let's dig.", 0.1 ]
+        ]
+      }
     },
     {
       "Name": [ "Flute", "Ocarina" ],
@@ -353,7 +365,8 @@
       "Name": [
         "Moon Pearl",
         [ "Jawbreaker", 0.1 ],
-        [ "Orb", 0.1 ]
+        [ "Orb", 0.1 ],
+        [ "Munpar", 0.1 ]
       ],
       "InternalItemType": 31,
       "Column": 5,
@@ -1026,7 +1039,7 @@
       "Name": [
         "Missile",
         [ "Missiles", 0 ],
-        [ "Missile pack", 0 ]
+        [ "Missile pack", 0.2 ]
       ],
       "Plural": [
         "Missiles",
@@ -1566,7 +1579,8 @@
         "vivelin": "vihvelin",
         "PinkKittyRose": "Pink Kitty Rose",
         "skennedysa": "s kennedy",
-        "the_betus": "the underscore beetus"
+        "the_betus": "the underscore beetus",
+        "Axnollouse": "Fragger"
       }
     },
     "Hints": {
@@ -1791,11 +1805,16 @@
       ],
       "ItemNotFound": [
         "I cannot find {0}.",
-        "I don't know where {0} is."
+        "This seed doesn't have {0}.",
+        "{0} is not in this seed."
       ],
       "ItemsNotFound": [
-        "I cannot find any more {0}.",
-        "I don't know where any other {0} are."
+        "I cannot find any {0}.",
+        "This seed doesn't have any {0}.",
+        "There are no {0} in this seed."
+      ],
+      "LocationsCleared": [
+        "You already cleared every location that has {0}."
       ],
       "LocationHasItem": [
         "{0} has {1}.",


### PR DESCRIPTION
- **Removed interruptions**
  It was funny for a little bit but didn't turn out the way I wanted, and at this stage it's not worth trying to get it to work well
- Fixed bullshit being considered progression
- Fixed an error when asking for hints about an item that can't be found (anymore)
- Fixed chat integration not working when entering a channel URL instead of just the username in the **Twitch Channel** field
- Improved username pronunciation by treating underscores as spaces
- Fixed "_You need the Fire Rod before you can get the Fire Rod_" hints

This PR will update the version to 4.2.2.