### PR TITLE
Implementing Twitch Polls

### DIFF
--- a/src/Randomizer.App/App.xaml.cs
+++ b/src/Randomizer.App/App.xaml.cs
@@ -79,9 +79,10 @@ namespace Randomizer.App
             services.AddScoped<TrackerLocationSyncer>();
 
             // Chat
+            services.AddSingleton<IChatApi, TwitchChatAPI>();
             services.AddScoped<IChatClient, TwitchChatClient>();
             services.AddSingleton<IChatAuthenticationService, TwitchAuthenticationService>();
-
+            
             // WPF
             services.AddSingleton<OptionsFactory>();
             services.AddSingleton<RomListWindow>();

--- a/src/Randomizer.App/ViewModels/GeneralOptions.cs
+++ b/src/Randomizer.App/ViewModels/GeneralOptions.cs
@@ -22,6 +22,7 @@ namespace Randomizer.App.ViewModels
         private string _twitchUserName;
         private string _twitchOAuthToken;
         private string _twitchChannel;
+        private string _twitchId;
 
         /// <summary>
         /// Converts the enum descriptions into a string array for displaying in a dropdown
@@ -103,7 +104,22 @@ namespace Randomizer.App.ViewModels
             }
         }
 
+        public string TwitchId
+        {
+            get => _twitchId;
+            set
+            {
+                if (_twitchId != value)
+                {
+                    _twitchId = value;
+                    OnPropertyChanged();
+                }
+            }
+
+        }
+
         public bool EnableChatGreeting { get; set; } = true;
+        public bool EnablePollCreation { get; set; } = true;
 
         public int ChatGreetingTimeLimit { get; set; } = 0;
 
@@ -125,7 +141,8 @@ namespace Randomizer.App.ViewModels
             SpoilersEnabled = TrackerSpoilersEnabled,
             UserName = TwitchChannel,
             ChatGreetingEnabled = EnableChatGreeting,
-            ChatGreetingTimeLimit = ChatGreetingTimeLimit
+            ChatGreetingTimeLimit = ChatGreetingTimeLimit,
+            PollCreationEnabled = EnablePollCreation
         };
 
         protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)

--- a/src/Randomizer.App/Windows/OptionsWindow.xaml
+++ b/src/Randomizer.App/Windows/OptionsWindow.xaml
@@ -203,6 +203,12 @@
                          IsEnabled="{Binding IsLoggingIn, ElementName=Self}" />
               </controls:LabeledControl>
 
+              <controls:LabeledControl Text="Twitch id:"
+                                       ToolTip="User id from Twitch that is used for advanced Twitch integration. Requires you to be logged into your own account rather than a bot.">
+                <TextBox Text="{Binding TwitchId, Mode=TwoWay}"
+                         IsEnabled="{Binding IsLoggingIn, ElementName=Self}" />
+              </controls:LabeledControl>
+
               <controls:LabeledControl Text="">
                 <Button x:Name="TwitchLoginButton"
                         Click="TwitchLoginButton_Click"
@@ -227,6 +233,11 @@
                              Margin="3,0,0,0">minutes</TextBlock>
                 </StackPanel>
               </controls:LabeledControl>
+
+              <CheckBox x:Name="EnableChatPolls"
+                        Content="Enable poll creation"
+                        ToolTip="When this is checked, Tracker can create polls on your behalf. Note: You cannot use a bot account for this."
+                        IsChecked="{Binding EnablePollCreation}" />
 
             </StackPanel>
           </Expander>

--- a/src/Randomizer.App/Windows/OptionsWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/OptionsWindow.xaml.cs
@@ -73,11 +73,13 @@ namespace Randomizer.App
                     try
                     {
                         var token = await _chatAuthenticationService.GetTokenInteractivelyAsync(default);
-                        var userName = await _chatAuthenticationService.GetUserNameAsync(token, default);
+                        var userData = await _chatAuthenticationService.GetUserData(token, default);
 
-                        Options.TwitchUserName = userName;
+                        Options.TwitchUserName = userData.Name;
                         Options.TwitchOAuthToken = token;
-                        Options.TwitchChannel = string.IsNullOrEmpty(Options.TwitchChannel) ? userName : Options.TwitchChannel;
+                        Options.TwitchChannel = string.IsNullOrEmpty(Options.TwitchChannel) ? userData.Name : Options.TwitchChannel;
+                        Options.TwitchId = userData.Id;
+
                     }
                     catch (Exception ex)
                     {

--- a/src/Randomizer.App/Windows/TrackerWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/TrackerWindow.xaml.cs
@@ -634,7 +634,7 @@ namespace Randomizer.App
 
             Tracker.StartTracking();
             Tracker.ConnectToChat(Options.GeneralOptions.TwitchUserName, Options.GeneralOptions.TwitchOAuthToken,
-                Options.GeneralOptions.TwitchChannel);
+                Options.GeneralOptions.TwitchChannel, Options.GeneralOptions.TwitchId);
             _startTime = DateTime.Now;
             _dispatcherTimer.Start();
 

--- a/src/Randomizer.SMZ3.ChatIntegration/IChatApi.cs
+++ b/src/Randomizer.SMZ3.ChatIntegration/IChatApi.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Randomizer.SMZ3.ChatIntegration
+{
+    public interface IChatApi
+    {
+        Task<T?> MakeApiCallAsync<T>(string api, HttpMethod method, CancellationToken cancellationToken);
+        Task<TResponse?> MakeApiCallAsync<TRequest, TResponse>(string api, TRequest requestData, HttpMethod method, CancellationToken cancellationToken);
+        void SetAccessToken(string? authToken);
+        string GetClientId();
+    }
+}

--- a/src/Randomizer.SMZ3.ChatIntegration/IChatAuthenticationService.cs
+++ b/src/Randomizer.SMZ3.ChatIntegration/IChatAuthenticationService.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
+using Randomizer.SMZ3.ChatIntegration.Models;
 
 namespace Randomizer.SMZ3.ChatIntegration
 {
@@ -7,6 +8,6 @@ namespace Randomizer.SMZ3.ChatIntegration
     {
         Task<string?> GetTokenInteractivelyAsync(CancellationToken cancellationToken);
 
-        Task<string?> GetUserNameAsync(string accessToken, CancellationToken cancellationToken);
+        Task<ChatUserData?> GetUserData(string accessToken, CancellationToken cancellationToken);
     }
 }

--- a/src/Randomizer.SMZ3.ChatIntegration/IChatAuthenticationService.cs
+++ b/src/Randomizer.SMZ3.ChatIntegration/IChatAuthenticationService.cs
@@ -8,6 +8,6 @@ namespace Randomizer.SMZ3.ChatIntegration
     {
         Task<string?> GetTokenInteractivelyAsync(CancellationToken cancellationToken);
 
-        Task<ChatUserData?> GetUserData(string accessToken, CancellationToken cancellationToken);
+        Task<AuthenticatedUserData?> GetUserData(string accessToken, CancellationToken cancellationToken);
     }
 }

--- a/src/Randomizer.SMZ3.ChatIntegration/IChatClient.cs
+++ b/src/Randomizer.SMZ3.ChatIntegration/IChatClient.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
+using Randomizer.SMZ3.ChatIntegration.Models;
 
 namespace Randomizer.SMZ3.ChatIntegration
 {
@@ -13,10 +16,14 @@ namespace Randomizer.SMZ3.ChatIntegration
         string? ConnectedAs { get; }
         string? Channel { get; }
 
-        void Connect(string userName, string oauthToken, string channel);
+        void Connect(string userName, string oauthToken, string channel, string id);
 
         void Disconnect();
 
         Task SendMessageAsync(string message, bool announce = false);
+
+        Task<string?> CreatePollAsync(string title, ICollection<string> options, int duration);
+
+        Task<ChatPoll> CheckPollAsync(string id);
     }
 }

--- a/src/Randomizer.SMZ3.ChatIntegration/MessageReceivedEventArgs.cs
+++ b/src/Randomizer.SMZ3.ChatIntegration/MessageReceivedEventArgs.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Randomizer.SMZ3.ChatIntegration.Models;
 
 namespace Randomizer.SMZ3.ChatIntegration
 {

--- a/src/Randomizer.SMZ3.ChatIntegration/Models/AuthenticatedUserData.cs
+++ b/src/Randomizer.SMZ3.ChatIntegration/Models/AuthenticatedUserData.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Randomizer.SMZ3.ChatIntegration.Models
 {
-    public class ChatUserData
+    public class AuthenticatedUserData
     {
         public string? Id { get; set; }
         public string? Name { get; set; }

--- a/src/Randomizer.SMZ3.ChatIntegration/Models/ChatMessage.cs
+++ b/src/Randomizer.SMZ3.ChatIntegration/Models/ChatMessage.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Randomizer.SMZ3.ChatIntegration
+namespace Randomizer.SMZ3.ChatIntegration.Models
 {
     public abstract class ChatMessage
     {

--- a/src/Randomizer.SMZ3.ChatIntegration/Models/ChatPoll.cs
+++ b/src/Randomizer.SMZ3.ChatIntegration/Models/ChatPoll.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Randomizer.SMZ3.ChatIntegration.Models
+{
+    public class ChatPoll
+    {
+        public bool IsComplete { get; set; }
+        public bool IsSuccessful { get; set; }
+        public string? WinningChoice { get; set; }
+    }
+}

--- a/src/Randomizer.SMZ3.ChatIntegration/Models/ChatUserData.cs
+++ b/src/Randomizer.SMZ3.ChatIntegration/Models/ChatUserData.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Randomizer.SMZ3.ChatIntegration.Models
+{
+    public class ChatUserData
+    {
+        public string? Id { get; set; }
+        public string? Name { get; set; }
+        public string? DisplayName { get; set; }
+    }
+}

--- a/src/Randomizer.SMZ3.ChatIntegration/OAuthChatAuthenticationService.cs
+++ b/src/Randomizer.SMZ3.ChatIntegration/OAuthChatAuthenticationService.cs
@@ -70,6 +70,6 @@ namespace Randomizer.SMZ3.ChatIntegration
             return accessToken;
         }
 
-        public abstract Task<ChatUserData?> GetUserData(string accessToken, CancellationToken cancellationToken);
+        public abstract Task<AuthenticatedUserData?> GetUserData(string accessToken, CancellationToken cancellationToken);
     }
 }

--- a/src/Randomizer.SMZ3.ChatIntegration/OAuthChatAuthenticationService.cs
+++ b/src/Randomizer.SMZ3.ChatIntegration/OAuthChatAuthenticationService.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using Randomizer.SMZ3.ChatIntegration.Models;
 
 namespace Randomizer.SMZ3.ChatIntegration
 {
@@ -69,6 +70,6 @@ namespace Randomizer.SMZ3.ChatIntegration
             return accessToken;
         }
 
-        public abstract Task<string?> GetUserNameAsync(string accessToken, CancellationToken cancellationToken);
+        public abstract Task<ChatUserData?> GetUserData(string accessToken, CancellationToken cancellationToken);
     }
 }

--- a/src/Randomizer.SMZ3.Tracking/Configuration/ChatConfig.cs
+++ b/src/Randomizer.SMZ3.Tracking/Configuration/ChatConfig.cs
@@ -102,5 +102,42 @@ namespace Randomizer.SMZ3.Tracking.Configuration
         /// </summary>
         public IReadOnlyDictionary<string, string> UserNamePronunciation { get; init; }
             = new Dictionary<string, string>();
+
+        /// <summary>
+        /// Gets the phrases for when asking the chat if content should be
+        /// increased or not
+        /// </summary>
+        public SchrodingersString AskChatAboutContent { get; init; }
+            = new("Hmm. I'm not so sure about that. Let's ask the professionals in chat if that was some hashtag content.");
+
+        /// <summary>
+        /// Gets the phrases for when chat decided to increase content
+        /// </summary>
+        public SchrodingersString AskChatAboutContentYes { get; init; }
+            = new("It's your lucky day. Chat has confirmed that was some hashtag content.");
+
+        /// <summary>
+        /// Gets the phrases for when chat decided not to increase content
+        /// </summary>
+        public SchrodingersString AskChatAboutContentNo { get; init; }
+            = new("I'm glad I asked. The chat has denied your request to increase your content levels.");
+
+        /// <summary>
+        /// Gets the phrases for when the poll is complete
+        /// </summary>
+        public SchrodingersString PollComplete { get; init; }
+            = new("And the results are now in.");
+
+        /// <summary>
+        /// Gets the phrases for when the poll is opened
+        /// </summary>
+        public SchrodingersString PollOpened { get; init; }
+            = new("I have opened a poll for {0} seconds.");
+
+        /// <summary>
+        /// Gets the phrases for when the poll outcome could not be determined
+        /// </summary>
+        public SchrodingersString PollError { get; init; }
+            = new("Sorry, I was unable to get the poll results.");
     }
 }

--- a/src/Randomizer.SMZ3.Tracking/Tracker.cs
+++ b/src/Randomizer.SMZ3.Tracking/Tracker.cs
@@ -749,11 +749,14 @@ namespace Randomizer.SMZ3.Tracking
         /// <param name="channel">
         /// The channel to monitor for incoming messages.
         /// </param>
-        public void ConnectToChat(string? userName, string? oauthToken, string? channel)
+        /// <param name="id">
+        /// The is for <paramref name="userName"/>.
+        /// </param>
+        public void ConnectToChat(string? userName, string? oauthToken, string? channel, string? id)
         {
             if (userName != null && oauthToken != null)
             {
-                _chatClient.Connect(userName, oauthToken, channel ?? userName);
+                _chatClient.Connect(userName, oauthToken, channel ?? userName, id);
             }
         }
 

--- a/src/Randomizer.SMZ3.Tracking/TrackerOptions.cs
+++ b/src/Randomizer.SMZ3.Tracking/TrackerOptions.cs
@@ -72,5 +72,10 @@ namespace Randomizer.SMZ3.Tracking
         /// interrupted before quitting.
         /// </summary>
         public int InterruptionLimit { get; set; } = 5;
+
+        /// <summary>
+        /// If tracker can create chat polls
+        /// </summary>
+        public bool PollCreationEnabled { get; set; }
     }
 }

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/ChatIntegrationModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/ChatIntegrationModule.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
 using Randomizer.SMZ3.ChatIntegration;
+using Randomizer.SMZ3.ChatIntegration.Models;
 
 namespace Randomizer.SMZ3.Tracking.VoiceCommands
 {
@@ -19,8 +20,13 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
     /// </summary>
     public class ChatIntegrationModule : TrackerModule, IDisposable
     {
+        private static readonly Random s_random = new();
         private const string WinningGuessKey = "WinningGuess";
         private readonly Dictionary<string, int> _usersGreetedTimes = new();
+        private bool AskChatAboutContentCheckPollResults = true;
+        private string? AskChatAboutContentPollId;
+        private int AskChatAboutContentPollTime = 60;
+        private bool HasAskedChatAboutContent = false;
 
         /// <summary>
         /// Initializes a new instance of the <see
@@ -51,6 +57,11 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
             {
                 var winningNumber = (int)result.Semantics[WinningGuessKey].Value;
                 await DeclareGanonsTowerGuessingGameWinner(winningNumber);
+            });
+
+            AddCommand("Track Content", GetTrackContent(), (tracker, result) =>
+            {
+                var task = AskChatAboutContent();
             });
         }
 
@@ -168,6 +179,75 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
         }
 
         /// <summary>
+        /// Asks the chat if tracker should increase content by one step
+        /// </summary>
+        /// <returns></returns>
+        public async Task AskChatAboutContent()
+        {
+            // Always ask the first time, otherwise it's a random change. Can probably change to always be random later.
+            var shouldAskChat = !HasAskedChatAboutContent || s_random.Next(0, 4) == 0;
+            if (!ShouldCreatePolls || !shouldAskChat)
+            {
+                Tracker.TrackItem(Tracker.Items.Where(x => x.Name.First() == "Content").First());
+                return;
+            }
+
+            AskChatAboutContentPollId = await ChatClient.CreatePollAsync("Do you think that was some high quality #content?", new List<string>() { "Yes", "No" }, AskChatAboutContentPollTime);
+
+            if (AskChatAboutContentPollId == null)
+            {
+                Tracker.TrackItem(Tracker.Items.Where(x => x.Name.First() == "Content").First());
+                return;
+            }
+
+            Tracker.Say(x => x.Chat.AskChatAboutContent);
+            Tracker.Say(x => x.Chat.PollOpened, AskChatAboutContentPollTime);
+            AskChatAboutContentCheckPollResults = true;
+            HasAskedChatAboutContent = true;
+            var task = Task.Run(async () =>
+            {
+                await Task.Delay(AskChatAboutContentPollTime * 1000 + 5000);
+
+                do
+                {
+                    var result = await ChatClient.CheckPollAsync(AskChatAboutContentPollId);
+                    if (result.IsComplete && AskChatAboutContentCheckPollResults)
+                    {
+                        AskChatAboutContentCheckPollResults = false;
+
+                        if (result.IsSuccessful)
+                        {
+                            Tracker.Say(x => x.Chat.PollComplete);
+
+                            if ("Yes" == result.WinningChoice)
+                            {
+                                Tracker.Say(x => x.Chat.AskChatAboutContentYes);
+                                Tracker.TrackItem(Tracker.Items.Where(x => x.Name.First() == "Content").First());
+                            }
+                            else
+                            {
+                                Tracker.Say(x => x.Chat.AskChatAboutContentNo);
+                            }
+                        }
+                        else
+                        {
+                            Tracker.Say(x => x.Chat.PollError);
+                        }
+                    }
+                    else if (AskChatAboutContentCheckPollResults)
+                    {
+                        await Task.Delay(5 * 1000);
+                    }
+                } while (AskChatAboutContentCheckPollResults);
+            });
+
+            Tracker.AddUndo(() =>
+            {
+                AskChatAboutContentCheckPollResults = false;
+            });
+        }
+
+        /// <summary>
         /// Frees up resources used by the <see cref="ChatIntegrationModule"/>.
         /// </summary>
         /// <param name="disposing">
@@ -214,6 +294,8 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
         private bool ShouldRespondToGreetings => Tracker.Options.ChatGreetingEnabled
             && (Tracker.Options.ChatGreetingTimeLimit == 0
                 || Tracker.TotalElapsedTime.TotalMinutes <= Tracker.Options.ChatGreetingTimeLimit);
+
+        private bool ShouldCreatePolls => Tracker.Options.PollCreationEnabled;
 
         private void TryRecordGanonsTowerGuess(ChatMessage message)
         {
@@ -329,6 +411,15 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
                     "the winning number is",
                     "the correct number is")
                 .Append(WinningGuessKey, validGuesses);
+        }
+
+        private GrammarBuilder GetTrackContent()
+        {
+            return new GrammarBuilder()
+                .Append("Hey tracker,")
+                .Optional("please", "would you kindly")
+                .OneOf("track", "add")
+                .Append("content");
         }
     }
 }

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/ItemTrackingModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/ItemTrackingModule.cs
@@ -131,7 +131,7 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
         private GrammarBuilder GetTrackItemRule()
         {
             var dungeonNames = GetDungeonNames(includeDungeonsWithoutReward: true);
-            var itemNames = GetItemNames();
+            var itemNames = GetItemNames(x => x.Name[0] != "Content");
             var locationNames = GetLocationNames();
             var roomNames = GetRoomNames();
 

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/TrackerModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/TrackerModule.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Speech.Recognition;
 
 using Microsoft.Extensions.Logging;
-
+using Randomizer.Shared;
 using Randomizer.SMZ3.Tracking.Configuration;
 
 namespace Randomizer.SMZ3.Tracking.VoiceCommands
@@ -362,10 +362,15 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
         /// A new <see cref="Choices"/> object representing all possible item
         /// names.
         /// </returns>
-        protected virtual Choices GetItemNames()
+        protected virtual Choices GetItemNames(Func<ItemData, bool>? where = null)
         {
+            if (where == null)
+            {
+                where = a => 1 == 1;
+            }
+
             var itemNames = new Choices();
-            foreach (var itemData in Tracker.Items)
+            foreach (var itemData in Tracker.Items.Where(where))
             {
                 foreach (var name in itemData.Name)
                     itemNames.Add(new SemanticResultValue(name.ToString(), name.ToString()));

--- a/src/Randomizer.SMZ3.Tracking/tracker.json
+++ b/src/Randomizer.SMZ3.Tracking/tracker.json
@@ -1610,7 +1610,36 @@
         "skennedysa": "s kennedy",
         "the_betus": "the underscore beetus",
         "Axnollouse": "Fragger"
-      }
+      },
+      "AskChatAboutContent": [
+        "Hmm. I'm not so sure about that. Let's ask the professionals in chat if that was some hashtag content.",
+        "Do you really think that was high quality hashtag content? Let's get some unbiased opinions from chat to confirm.",
+        "Error. My metrics calculation algorithm could not determine the quality of that hashtag content. Falling back to chat confirmation of content quality."
+      ],
+      "AskChatAboutContentYes": [
+        "It's your lucky day. Chat has confirmed that was some hashtag content.",
+        "I can't say that I agree with the results, but the chat indeed believes that was some hashtag content.",
+        "Congratulations! You're the lucky winner of our grand prize."
+      ],
+      "AskChatAboutContentNo": [
+        "I'm glad I asked. The chat has denied your request to increase your content levels.",
+        "The racing council regrets to inform you that your application for additional content has been denied.",
+        "Ouch. The chat did not think that was some hashtag content. I can see the metrics dropping."
+      ],
+      "PollOpened": [
+        "I have opened a poll for {0} seconds.",
+        "Chat, you have {0} seconds to respond to the poll.",
+        "The polls are now opened, but only for {0} seconds."
+      ],
+      "PollComplete": [
+        "And the results are now in.",
+        "Let's see. I am crunching the numbers.",
+        "The poll is now closed."
+      ],
+      "PollError": [
+        "Sorry, I was unable to get the poll results.",
+        "Whoops. I couldn't get the poll results."
+      ]
     },
     "Hints": {
       "EnabledHints": [

--- a/src/Randomizer.SMZ3.Twitch/Models/TwitchPoll.cs
+++ b/src/Randomizer.SMZ3.Twitch/Models/TwitchPoll.cs
@@ -27,8 +27,10 @@ namespace Randomizer.SMZ3.Twitch.Models
         [JsonPropertyName("status")]
         public string? Status { get; set; }
 
-        public bool IsComplete => "ACTIVE" != Status;
+        public bool IsComplete => !"ACTIVE".Equals(Status, StringComparison.OrdinalIgnoreCase);
 
-        public bool Successful => "COMPLETED" == Status;
+        public bool Successful => WinningChoice != null && "COMPLETED".Equals(Status, StringComparison.OrdinalIgnoreCase);
+
+        public TwitchPollChoice? WinningChoice => Choices?.OrderByDescending(x => x.Votes).FirstOrDefault();
     }
 }

--- a/src/Randomizer.SMZ3.Twitch/Models/TwitchPoll.cs
+++ b/src/Randomizer.SMZ3.Twitch/Models/TwitchPoll.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace Randomizer.SMZ3.Twitch.Models
+{
+    public class TwitchPoll
+    {
+        [JsonPropertyName("broadcaster_id")]
+        public string? BroadcasterId { get; set; }
+
+        [JsonPropertyName("id")]
+        public string? Id { get; set; }
+
+        [JsonPropertyName("title")]
+        public string? Title { get; set; }
+
+        [JsonPropertyName("choices")]
+        public ICollection<TwitchPollChoice>? Choices { get; set; }
+
+        [JsonPropertyName("duration")]
+        public int? Duration { get; set; }
+
+        [JsonPropertyName("status")]
+        public string? Status { get; set; }
+
+        public bool IsComplete => "ACTIVE" != Status;
+
+        public bool Successful => "COMPLETED" == Status;
+    }
+}

--- a/src/Randomizer.SMZ3.Twitch/Models/TwitchPollChoice.cs
+++ b/src/Randomizer.SMZ3.Twitch/Models/TwitchPollChoice.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace Randomizer.SMZ3.Twitch.Models
+{
+    public class TwitchPollChoice
+    {
+        [JsonPropertyName("id")]
+        public string? Id { get; set; }
+
+        [JsonPropertyName("title")]
+        public string? Title { get; set; }
+
+        [JsonPropertyName("votes")]
+        public int? Votes { get; set; }
+
+    }
+}

--- a/src/Randomizer.SMZ3.Twitch/Models/TwitchUser.cs
+++ b/src/Randomizer.SMZ3.Twitch/Models/TwitchUser.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace Randomizer.SMZ3.Twitch.Models
+{
+    public class TwitchUser
+    {
+        [JsonPropertyName("id")]
+        public string? Id { get; set; }
+
+        [JsonPropertyName("login")]
+        public string? Login { get; set; }
+
+        [JsonPropertyName("display_name")]
+        public string? DisplayName { get; set; }
+    }
+}

--- a/src/Randomizer.SMZ3.Twitch/TwitchAuthenticationService.cs
+++ b/src/Randomizer.SMZ3.Twitch/TwitchAuthenticationService.cs
@@ -1,58 +1,41 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Text;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-
-using Microsoft.Extensions.Logging;
-
 using Randomizer.SMZ3.ChatIntegration;
+using Randomizer.SMZ3.ChatIntegration.Models;
+using Randomizer.SMZ3.Twitch.Models;
 
 namespace Randomizer.SMZ3.Twitch
 {
     public class TwitchAuthenticationService : OAuthChatAuthenticationService
     {
-        private const string ClientId = "i8sfdyflu72jddzpaho80fdt6vc3ax";
+        private readonly IChatApi _twitchChatAPI;
 
-        private static readonly HttpClient s_httpClient = new();
-        private readonly ILogger<TwitchAuthenticationService> _logger;
-
-        public TwitchAuthenticationService(ILogger<TwitchAuthenticationService> logger)
+        public TwitchAuthenticationService(IChatApi twitchChatAPI)
         {
-            _logger = logger;
+            _twitchChatAPI = twitchChatAPI;
         }
 
         public override Uri GetOAuthUrl(Uri redirectUri)
         {
             return new Uri("https://id.twitch.tv/oauth2/authorize" +
-                $"?client_id={ClientId}" +
+                $"?client_id={_twitchChatAPI.GetClientId()}" +
                 $"&redirect_uri={Uri.EscapeDataString(redirectUri.ToString())}" +
                 "&response_type=token" +
-                $"&scope={Uri.EscapeDataString("chat:read chat:edit channel:moderate")}");
+                $"&scope={Uri.EscapeDataString("chat:read chat:edit channel:moderate channel:read:polls channel:manage:polls channel:read:predictions channel:manage:predictions")}");
         }
 
-        public override async Task<string?> GetUserNameAsync(string accessToken, CancellationToken cancellationToken)
+        public override async Task<ChatUserData?> GetUserData(string accessToken, CancellationToken cancellationToken)
         {
-            var request = new HttpRequestMessage(HttpMethod.Get, "https://api.twitch.tv/helix/users");
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
-            request.Headers.TryAddWithoutValidation("Client-Id", ClientId);
-
-            var response = await s_httpClient.SendAsync(request, cancellationToken);
-            var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
-            if (!response.IsSuccessStatusCode)
+            _twitchChatAPI.SetAccessToken(accessToken);
+            var user = await _twitchChatAPI.MakeApiCallAsync<TwitchUser>("users", HttpMethod.Get, cancellationToken);
+            return user == null ? null : new()
             {
-                _logger.LogError("{RequestMethod} {RequestUri} returned unexpected {StatusCode} response: {Body}",
-                    request.Method.Method, request.RequestUri, (int)response.StatusCode, responseContent);
-                return null;
-            }
-
-            var responseObject = JsonDocument.Parse(responseContent);
-            var user = responseObject.RootElement.GetProperty("data")[0];
-            return user.GetProperty("login").GetString();
+                Name = user.Login,
+                DisplayName = user.DisplayName,
+                Id = user.Id
+            };
         }
     }
 }

--- a/src/Randomizer.SMZ3.Twitch/TwitchAuthenticationService.cs
+++ b/src/Randomizer.SMZ3.Twitch/TwitchAuthenticationService.cs
@@ -26,7 +26,7 @@ namespace Randomizer.SMZ3.Twitch
                 $"&scope={Uri.EscapeDataString("chat:read chat:edit channel:moderate channel:read:polls channel:manage:polls channel:read:predictions channel:manage:predictions")}");
         }
 
-        public override async Task<ChatUserData?> GetUserData(string accessToken, CancellationToken cancellationToken)
+        public override async Task<AuthenticatedUserData?> GetUserData(string accessToken, CancellationToken cancellationToken)
         {
             _twitchChatAPI.SetAccessToken(accessToken);
             var user = await _twitchChatAPI.MakeApiCallAsync<TwitchUser>("users", HttpMethod.Get, cancellationToken);

--- a/src/Randomizer.SMZ3.Twitch/TwitchChatAPI.cs
+++ b/src/Randomizer.SMZ3.Twitch/TwitchChatAPI.cs
@@ -1,0 +1,108 @@
+﻿using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Randomizer.SMZ3.ChatIntegration;
+
+namespace Randomizer.SMZ3.Twitch
+{
+
+    public class TwitchChatAPI : IChatApi
+    {
+        private static readonly JsonSerializerOptions s_serializerOptions = new()
+        {
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+        };
+
+        private static readonly HttpClient s_httpClient = new();
+
+#if DEBUG
+        private const string ClientId = "26d7dd70e5035307b0c8612d6f9d83";
+        private const string ApiEndpoint = "http://localhost:8080/mock/";
+#else
+        private const string ClientId = "i8sfdyflu72jddzpaho80fdt6vc3ax";
+        private const string ApiEndpoint = "https://api.twitch.tv/helix/";
+#endif
+
+        private string? OAuthToken { get; set; }
+
+        protected ILogger<TwitchChatAPI> _logger { get; }
+
+        public TwitchChatAPI(ILogger<TwitchChatAPI> logger)
+        {
+            _logger = logger;
+        }
+
+        public async Task<TResponse?> MakeApiCallAsync<TRequest, TResponse>(string api, TRequest requestData, HttpMethod method, CancellationToken cancellationToken)
+        {
+            var request = GetHttpRequestMessage(api, method);
+            request.Content = new StringContent(JsonSerializer.Serialize(requestData, s_serializerOptions), Encoding.UTF8, "application/json");
+            return await GetHttpResponseAsync<TResponse>(request, cancellationToken);
+        }
+
+        public async Task<T?> MakeApiCallAsync<T>(string api, HttpMethod method, CancellationToken cancellationToken)
+        {
+            var request = GetHttpRequestMessage(api, method);
+            return await GetHttpResponseAsync<T>(request, cancellationToken);
+        }
+
+        public void SetAccessToken(string? token)
+        {
+            OAuthToken = token;
+        }
+
+        private HttpRequestMessage GetHttpRequestMessage(string api, HttpMethod method)
+        {
+            var request = new HttpRequestMessage(method, ApiEndpoint + api);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", OAuthToken);
+            request.Headers.TryAddWithoutValidation("Client-Id", ClientId);
+            return request;
+        }
+
+        private async Task<T?> GetHttpResponseAsync<T>(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = await s_httpClient.SendAsync(request, cancellationToken);
+            var responseContent = await response.Content.ReadAsStringAsync(cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogError("{RequestMethod} {RequestUri} returned unexpected {StatusCode} response: {Body}",
+                    request.Method.Method, request.RequestUri, (int)response.StatusCode, responseContent);
+                return default;
+            }
+
+            if (string.IsNullOrEmpty(responseContent))
+            {
+                _logger.LogError("{RequestMethod} {RequestUri} returned unexpected empty response",
+                    request.Method.Method, request.RequestUri);
+                return default;
+            }
+
+            try
+            {
+                var responseObject = JsonDocument.Parse(responseContent).RootElement.GetProperty("data");
+
+                if (!typeof(T).IsGenericType)
+                {
+                    return JsonSerializer.Deserialize<T>(responseObject[0].GetRawText());
+                }
+                else
+                {
+                    return JsonSerializer.Deserialize<T>(responseObject.GetRawText());
+                }
+            }
+            catch (JsonException)
+            {
+                _logger.LogError("Unable to deserialize from {RequestMethod} {RequestUri}. Response: {Body}",
+                    request.Method.Method, request.RequestUri, responseContent);
+                return default;
+            }
+        }
+
+        public string GetClientId() => ClientId;
+    }
+}

--- a/src/Randomizer.SMZ3.Twitch/TwitchChatAPI.cs
+++ b/src/Randomizer.SMZ3.Twitch/TwitchChatAPI.cs
@@ -21,7 +21,7 @@ namespace Randomizer.SMZ3.Twitch
         private static readonly HttpClient s_httpClient = new();
 
 #if DEBUG
-        private const string ClientId = "26d7dd70e5035307b0c8612d6f9d83";
+        private const string ClientId = "";
         private const string ApiEndpoint = "http://localhost:8080/mock/";
 #else
         private const string ClientId = "i8sfdyflu72jddzpaho80fdt6vc3ax";

--- a/src/Randomizer.SMZ3.Twitch/TwitchChatClient.cs
+++ b/src/Randomizer.SMZ3.Twitch/TwitchChatClient.cs
@@ -55,7 +55,7 @@ namespace Randomizer.SMZ3.Twitch
             _twitchClient.Connect();
             ConnectedAs = userName;
             Channel = channel;
-            Id = userName.Equals(channel, StringComparison.CurrentCultureIgnoreCase) ? id : null;
+            Id = userName.Equals(channel, StringComparison.OrdinalIgnoreCase) ? id : null;
             _chatApi.SetAccessToken(oauthToken);
         }
 
@@ -149,11 +149,13 @@ namespace Randomizer.SMZ3.Twitch
                 };
             }
 
+            Logger.LogInformation("Poll complete with status {0} and winning choice of {1}", poll.Status, poll.WinningChoice?.Title);
+
             return new()
             {
                 IsComplete = poll.IsComplete,
                 IsSuccessful = poll.Successful,
-                WinningChoice = poll.Choices.OrderByDescending(x => x.Votes).FirstOrDefault()?.Title
+                WinningChoice = poll.WinningChoice?.Title
             };
         }
 

--- a/src/Randomizer.SMZ3.Twitch/TwitchChatClient.cs
+++ b/src/Randomizer.SMZ3.Twitch/TwitchChatClient.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
-
 using Microsoft.Extensions.Logging;
-
 using Randomizer.SMZ3.ChatIntegration;
-
+using Randomizer.SMZ3.ChatIntegration.Models;
+using Randomizer.SMZ3.Twitch.Models;
 using TwitchLib.Client;
 using TwitchLib.Client.Models;
 
@@ -13,8 +15,9 @@ namespace Randomizer.SMZ3.Twitch
     public class TwitchChatClient : IChatClient
     {
         private readonly TwitchClient _twitchClient;
+        private readonly IChatApi _chatApi;
 
-        public TwitchChatClient(ILogger<TwitchChatClient> logger, ILoggerFactory loggerFactory)
+        public TwitchChatClient(ILogger<TwitchChatClient> logger, ILoggerFactory loggerFactory, IChatApi chatApi)
         {
             Logger = logger;
 
@@ -22,6 +25,7 @@ namespace Randomizer.SMZ3.Twitch
             _twitchClient.OnConnected += _twitchClient_OnConnected;
             _twitchClient.OnDisconnected += _twitchClient_OnDisconnected;
             _twitchClient.OnMessageReceived += _twitchClient_OnMessageReceived;
+            _chatApi = chatApi;
         }
 
         public event EventHandler? Connected;
@@ -32,11 +36,15 @@ namespace Randomizer.SMZ3.Twitch
 
         public string? Channel { get; protected set; }
 
+        public string? OAuthToken { get; protected set; }
+
+        public string? Id { get; protected set; }
+
         public bool IsConnected { get; protected set; }
 
         protected ILogger<TwitchChatClient> Logger { get; }
 
-        public void Connect(string userName, string oauthToken, string channel)
+        public void Connect(string userName, string oauthToken, string channel, string id)
         {
             if (!_twitchClient.IsInitialized)
             {
@@ -47,6 +55,8 @@ namespace Randomizer.SMZ3.Twitch
             _twitchClient.Connect();
             ConnectedAs = userName;
             Channel = channel;
+            Id = userName.Equals(channel, StringComparison.CurrentCultureIgnoreCase) ? id : null;
+            _chatApi.SetAccessToken(oauthToken);
         }
 
         public void Disconnect()
@@ -106,5 +116,46 @@ namespace Randomizer.SMZ3.Twitch
         {
             OnMessageReceived(new MessageReceivedEventArgs(new TwitchChatMessage(e.ChatMessage)));
         }
+
+        public async Task<string?> CreatePollAsync(string title, ICollection<string> options, int duration)
+        {
+            // Create the poll object
+            var poll = new TwitchPoll()
+            {
+                BroadcasterId = Id,
+                Title = title,
+                Choices = options.Select(x => new TwitchPollChoice()
+                {
+                    Title = x
+                }).ToList(),
+                Duration = duration
+            };
+
+            poll = await _chatApi.MakeApiCallAsync<TwitchPoll, TwitchPoll>("polls", poll, HttpMethod.Post, default);
+
+            return poll?.Id;
+        }
+
+        public async Task<ChatPoll> CheckPollAsync(string id)
+        {
+            var poll = await _chatApi.MakeApiCallAsync<TwitchPoll>($"polls?broadcaster_id={Id}&id={id}", HttpMethod.Get, default);
+
+            if (poll == null)
+            {
+                return new ChatPoll
+                {
+                    IsComplete = true,
+                    IsSuccessful = false
+                };
+            }
+
+            return new()
+            {
+                IsComplete = poll.IsComplete,
+                IsSuccessful = poll.Successful,
+                WinningChoice = poll.Choices.OrderByDescending(x => x.Votes).FirstOrDefault()?.Title
+            };
+        }
+
     }
 }

--- a/src/Randomizer.SMZ3.Twitch/TwitchChatMessage.cs
+++ b/src/Randomizer.SMZ3.Twitch/TwitchChatMessage.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-
-using Randomizer.SMZ3.ChatIntegration;
+using Randomizer.SMZ3.ChatIntegration.Models;
 
 namespace Randomizer.SMZ3.Twitch
 {


### PR DESCRIPTION
In this I have created a Twitch API class which can be used to making calls out to the Twitch API for integration that the current Twitch client does not currently provide. Currently this is used by our internal TwitchChatClient for poll creation. I opted to include all of this in the TwitchChatClient just in the case that the client we're currently using adds poll functionality. I figured one sort of front facing client to use in the application would be easier than multiple.

To test this functionality, I made use of the Twitch CLI's mock api functionality. However, there are a few unfortunate holes in its implementation:

- The authentication endpoint fails to work if you provide the scopes chat:read chat:edit. However, it does work with just channel:read:polls channel:manage:polls
- Polls do not automatically end after hitting their duration. Because of this I had to force values by debugging in Visual Studio, so the testing I did of this was not perfect, though I definitely tried to be as thorough as I could.

The first usage of this functionality is that if enabled, Tracker will sometimes question if the user is worthy of upping their content, and will then open a poll for 60 seconds to see if it should up the content level or not. Currently the first time it will always ask, then after that it will switch to being random. I think after the first weekend it could probably be set to be fully random.