### PR TITLE
Stream Feedback and Other Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ In addition to making IBJ completely optional, there is also:
 ## Credits
 - **Captain Novolin** replacement sprite for _Super Metroid_ by PaddyCo
 - **Rash** and **King Graham** replacement sprites for _Super Metroid_ by Fragger
-- **Captain Novolin** replacement sprite for _A Link to the Past_ by Fragger
+- **Captain Novolin**, **Rash**, **Shaktool** and **Love Shak** replacement sprite for _A Link to the Past_ by Fragger
 - **Non-Binary** Samus sprite for _Super Metroid_ by Glove
 - **Trans**, **Backwards**, **Upside down** and **180°** Samus sprites for _Super Metroid_ by TarThoron
 - **Shaktool** and **Shaktool Jr.** replacement sprites for _Super Metroid_ by Pneumatic

--- a/setup/randomizer.app.iss
+++ b/setup/randomizer.app.iss
@@ -4,7 +4,7 @@
 #include "CodeDependencies.iss"
 
 #define MyAppName "SMZ3 Cas' Randomizer"
-#define MyAppVersion "5.0.0-rc.1"
+#define MyAppVersion "5.0.0"
 #define MyAppPublisher "Vivelin"
 #define MyAppURL "https://github.com/Vivelin/SMZ3Randomizer"
 #define MyAppExeName "Randomizer.App.exe"

--- a/src/Randomizer.App/Randomizer.App.csproj
+++ b/src/Randomizer.App/Randomizer.App.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net5.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>chozo20.ico</ApplicationIcon>
-    <Version>5.0.0-rc.1</Version>
+    <Version>5.0.0</Version>
     <Title>SMZ3 Cas' Randomizer</Title>
     <AssemblyTitle>SMZ3 Cas' Randomizer</AssemblyTitle>
     <Authors>Vivelin</Authors>

--- a/src/Randomizer.App/Windows/TrackerMapWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/TrackerMapWindow.xaml.cs
@@ -104,7 +104,7 @@ namespace Randomizer.App
         /// <param name="mapName">The name of the map to display</param>
         public void UpdateMap(string mapName)
         {
-            UpdateMap(Maps.FirstOrDefault(x => x.ToString() == mapName));
+            UpdateMap(Maps.First(x => x.ToString() == mapName));
         }
 
         /// <summary>
@@ -113,11 +113,8 @@ namespace Randomizer.App
         /// <param name="map">The map to display</param>
         public void UpdateMap(TrackerMap map)
         {
-            if (map != null)
-            {
-                CurrentMap = map;
-                TrackerMapViewModel.CurrentMap = CurrentMap;
-            }
+            CurrentMap = map;
+            TrackerMapViewModel.CurrentMap = CurrentMap;
         }
 
         /// <summary>

--- a/src/Randomizer.App/Windows/TrackerMapWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/TrackerMapWindow.xaml.cs
@@ -104,7 +104,7 @@ namespace Randomizer.App
         /// <param name="mapName">The name of the map to display</param>
         public void UpdateMap(string mapName)
         {
-            UpdateMap(Maps.First(x => x.ToString() == mapName));
+            UpdateMap(Maps.FirstOrDefault(x => x.ToString() == mapName));
         }
 
         /// <summary>
@@ -113,8 +113,11 @@ namespace Randomizer.App
         /// <param name="map">The map to display</param>
         public void UpdateMap(TrackerMap map)
         {
-            CurrentMap = map;
-            TrackerMapViewModel.CurrentMap = CurrentMap;
+            if (map != null)
+            {
+                CurrentMap = map;
+                TrackerMapViewModel.CurrentMap = CurrentMap;
+            }
         }
 
         /// <summary>

--- a/src/Randomizer.SMZ3.Tracking/Configuration/AutotrackerConfig.cs
+++ b/src/Randomizer.SMZ3.Tracking/Configuration/AutotrackerConfig.cs
@@ -33,6 +33,12 @@ namespace Randomizer.SMZ3.Tracking.Configuration
             = new("Finally, the moment we've all been waiting for since the start of this run. We get to see Shaktool.");
 
         /// <summary>
+        /// Gets the phrases to respond with when nearing crocomire
+        /// </summary>
+        public SchrodingersString NearCrocomire { get; init; }
+            = new("You currently have {0} out of {1} super missiles. Do you think you have enough?");
+
+        /// <summary>
         /// Gets the phrases to respond with when falling down the pit from moldorm
         /// </summary>
         public SchrodingersString FallFromMoldorm { get; init; }

--- a/src/Randomizer.SMZ3.Tracking/Configuration/AutotrackerConfig.cs
+++ b/src/Randomizer.SMZ3.Tracking/Configuration/AutotrackerConfig.cs
@@ -80,5 +80,11 @@ namespace Randomizer.SMZ3.Tracking.Configuration
         public SchrodingersString EnterPendantDungeon { get; init; }
             = new("Ouch. So it's come to this, then?");
 
+        /// <summary>
+        /// Gets the phrases to respond with when swimming without flippers
+        /// </summary>
+        public SchrodingersString FakeFlippers { get; init; }
+            = new("How can you swim without the flippers?");
+
     }
 }

--- a/src/Randomizer.SMZ3.Tracking/Configuration/BossInfo.cs
+++ b/src/Randomizer.SMZ3.Tracking/Configuration/BossInfo.cs
@@ -64,17 +64,5 @@ namespace Randomizer.SMZ3.Tracking.Configuration
         /// </summary>
         /// <returns>A string representing this boss.</returns>
         public override string? ToString() => Name[0];
-
-        /// <summary>
-        /// The memory address offset stored as a string hex value
-        /// for where the boss defeated status is stored in memory
-        /// </summary>
-        public int? MemoryAddress { get; set; }
-
-        /// <summary>
-        /// The flag to check against to see if the boss has been
-        /// defeated or not
-        /// </summary>
-        public int? MemoryFlag { get; set; }
     }
 }

--- a/src/Randomizer.SMZ3.Tracking/Configuration/RegionInfo.cs
+++ b/src/Randomizer.SMZ3.Tracking/Configuration/RegionInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Randomizer.Shared;
 
@@ -66,5 +67,10 @@ namespace Randomizer.SMZ3.Tracking.Configuration
         /// </summary>
         /// <returns>A string representation of this region.</returns>
         public override string? ToString() => Name[0];
+
+        /// <summary>
+        /// Text for Tracker to say when dying in a room or screen in the region
+        /// </summary>
+        public Dictionary<string, SchrodingersString> WhenDiedInRoom { get; init; }
     }
 }

--- a/src/Randomizer.SMZ3.Tracking/Tracker.cs
+++ b/src/Randomizer.SMZ3.Tracking/Tracker.cs
@@ -1043,6 +1043,7 @@ namespace Randomizer.SMZ3.Tracking
             var itemName = item.Name;
             var originalTrackingState = item.TrackingState;
             UpdateTrackerProgression = true;
+            var stateItem = !autoTracked || !item.InternalItemType.IsInAnyCategory(ItemCategory.BigKey, ItemCategory.SmallKey) || World.Config.Keysanity;
 
             if (item.HasStages)
             {
@@ -1055,41 +1056,47 @@ namespace Randomizer.SMZ3.Tracking
                     var stageName = item.Stages[stage.Value].ToString();
 
                     didTrack = item.Track(stage.Value);
-                    if (didTrack)
+                    if (stateItem)
                     {
-                        if (item.TryGetTrackingResponse(out var response))
+                        if (didTrack)
                         {
-                            Say(response.Format(item.Counter));
+                            if (item.TryGetTrackingResponse(out var response))
+                            {
+                                Say(response.Format(item.Counter));
+                            }
+                            else
+                            {
+                                Say(Responses.TrackedItemByStage.Format(itemName, stageName));
+                            }
                         }
                         else
                         {
-                            Say(Responses.TrackedItemByStage.Format(itemName, stageName));
+                            Say(Responses.TrackedOlderProgressiveItem?.Format(itemName, item.Stages[item.TrackingState].ToString()));
                         }
-                    }
-                    else
-                    {
-                        Say(Responses.TrackedOlderProgressiveItem?.Format(itemName, item.Stages[item.TrackingState].ToString()));
                     }
                 }
                 else
                 {
                     // Tracked by regular name, upgrade by one step
                     didTrack = item.Track();
-                    if (didTrack)
+                    if (stateItem)
                     {
-                        if (item.TryGetTrackingResponse(out var response))
+                        if (didTrack)
                         {
-                            Say(response.Format(item.Counter));
+                            if (item.TryGetTrackingResponse(out var response))
+                            {
+                                Say(response.Format(item.Counter));
+                            }
+                            else
+                            {
+                                var stageName = item.Stages[item.TrackingState].ToString();
+                                Say(Responses.TrackedProgressiveItem.Format(itemName, stageName));
+                            }
                         }
                         else
                         {
-                            var stageName = item.Stages[item.TrackingState].ToString();
-                            Say(Responses.TrackedProgressiveItem.Format(itemName, stageName));
+                            Say(Responses.TrackedTooManyOfAnItem?.Format(itemName));
                         }
-                    }
-                    else
-                    {
-                        Say(Responses.TrackedTooManyOfAnItem?.Format(itemName));
                     }
                 }
             }
@@ -1097,34 +1104,47 @@ namespace Randomizer.SMZ3.Tracking
             {
                 didTrack = item.Track();
                 if (item.TryGetTrackingResponse(out var response))
-                    Say(response.Format(item.Counter));
+                {
+                    if (stateItem)
+                        Say(response.Format(item.Counter));
+                }
                 else if (item.Counter == 1)
-                    Say(Responses.TrackedItem.Format(itemName, item.NameWithArticle));
+                {
+                    if (stateItem)
+                        Say(Responses.TrackedItem.Format(itemName, item.NameWithArticle));
+                }
                 else if (item.Counter > 1)
-                    Say(Responses.TrackedItemMultiple.Format(item.Plural ?? $"{itemName}s", item.Counter));
+                {
+                    if (stateItem)
+                        Say(Responses.TrackedItemMultiple.Format(item.Plural ?? $"{itemName}s", item.Counter));
+                }
                 else
                 {
                     _logger.LogWarning("Encountered multiple item with counter 0: {item} has counter {counter}", item, item.Counter);
-                    Say(Responses.TrackedItem.Format(itemName, item.NameWithArticle));
+                    if (stateItem)
+                        Say(Responses.TrackedItem.Format(itemName, item.NameWithArticle));
                 }
             }
             else
             {
                 didTrack = item.Track();
-                if (didTrack)
+                if (stateItem)
                 {
-                    if (item.TryGetTrackingResponse(out var response))
+                    if (didTrack)
                     {
-                        Say(response.Format(item.Counter));
+                        if (item.TryGetTrackingResponse(out var response))
+                        {
+                            Say(response.Format(item.Counter));
+                        }
+                        else
+                        {
+                            Say(Responses.TrackedItem.Format(itemName, item.NameWithArticle));
+                        }
                     }
                     else
                     {
-                        Say(Responses.TrackedItem.Format(itemName, item.NameWithArticle));
+                        Say(Responses.TrackedAlreadyTrackedItem?.Format(itemName));
                     }
-                }
-                else
-                {
-                    Say(Responses.TrackedAlreadyTrackedItem?.Format(itemName));
                 }
             }
 

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/AutoTrackerMetroidState.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/AutoTrackerMetroidState.cs
@@ -41,22 +41,32 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
         /// <summary>
         /// The amount of health
         /// </summary>
-        public int Health => _message.ReadUInt8(0x7E09C2 - 0x7E0750);
+        public int Health => _message.ReadUInt8(0x7E09C2 - 0x7E0750) + _message.ReadUInt8(0x7E09C3 - 0x7E0750) * 0xFF;
 
         /// <summary>
         /// The amount currently in reserve tanks
         /// </summary>
-        public int ReserveTanks => _message.ReadUInt8(0x7E09D6 - 0x7E0750);
+        public int ReserveTanks => _message.ReadUInt8(0x7E09D6 - 0x7E0750) + _message.ReadUInt8(0x7E09D7 - 0x7E0750) * 0xFF;
 
         /// <summary>
         /// Samus's X Location
         /// </summary>
-        public int SamusX => _message.ReadUInt8(0x7E0AF6 - 0x7E0750);
+        public int SamusX => _message.ReadUInt8(0x7E0AF6 - 0x7E0750) + _message.ReadUInt8(0x7E0AF7 - 0x7E0750) * 0xFF;
 
         /// <summary>
         /// Samus's Y Location
         /// </summary>
-        public int SamusY => _message.ReadUInt8(0x7E0AFA - 0x7E0750);
+        public int SamusY => _message.ReadUInt8(0x7E0AFA - 0x7E0750) + _message.ReadUInt8(0x7E0AFB - 0x7E0750) * 0xFF;
+
+        /// <summary>
+        /// Samus's current super missile count
+        /// </summary>
+        public int SuperMissiles => _message.ReadUInt8(0x7E09CA - 0x7E0750);
+
+        /// <summary>
+        /// Samus's max super missile count
+        /// </summary>
+        public int MaxSuperMissiles => _message.ReadUInt8(0x7E09CC - 0x7E0750);
 
         /// <summary>
         /// Prints debug data for the state

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/AutoTrackerModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/AutoTrackerModule.cs
@@ -658,9 +658,13 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
             // Death (health and reserve tanks all 0 (have to check to make sure the player isn't warping between games)
             else if (state.Health == 0 && state.ReserveTanks == 0 && _previousMetroidState.Health != 0 && !(state.CurrentRoom == 0 && state.CurrentRegion == 0 && state.SamusY == 0))
             {
-                if (Tracker.CurrentRegion != null && Tracker.CurrentRegion.WhenDiedInRoom != null && Tracker.CurrentRegion.WhenDiedInRoom.ContainsKey(state.CurrentRoomInRegion.ToString()))
+                var region = Tracker.World.Regions.Select(x => x as SMRegion)
+                    .Where(x => x != null && x.MemoryRegionId == state.CurrentRegion)
+                    .Select(x => Tracker.WorldInfo.Regions.FirstOrDefault(y => y.GetRegion(Tracker.World) == x && y.WhenDiedInRoom != null))
+                    .FirstOrDefault(x => x!= null && x.WhenDiedInRoom != null && x.WhenDiedInRoom.ContainsKey(state.CurrentRoomInRegion.ToString()));
+                if (region != null)
                 {
-                    Tracker.Say(Tracker.CurrentRegion.WhenDiedInRoom[state.CurrentRoomInRegion.ToString()]);
+                    SayOnce(region.WhenDiedInRoom[state.CurrentRoomInRegion.ToString()]);
                 }
                 Tracker.TrackItem(Tracker.Items.First(x => x.ToString().Equals("Death", StringComparison.OrdinalIgnoreCase)));
             }

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/AutoTrackerZeldaState.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/AutoTrackerZeldaState.cs
@@ -66,12 +66,27 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
         public int OverworldValue => _message.ReadUInt8(0x7B);
 
         /// <summary>
+        /// True if Link is on the bottom half of the current room
+        /// </summary>
+        public bool IsOnBottomHalfOfroom => _message.ReadUInt8(0xAA) == 2;
+
+        /// <summary>
+        /// True if Link is on the right half of the current room
+        /// </summary>
+        public bool IsOnRightHalfOfRoom => _message.ReadUInt8(0xA9) == 1;
+
+        /// <summary>
+        /// The overworld screen that the player is on
+        /// </summary>
+        public int OverworldScreen => _message.ReadUInt8(0x8A);
+
+        /// <summary>
         /// Get debug string
         /// </summary>
         /// <returns></returns>
         public override string ToString()
         {
-            return $"Room: {PreviousRoom}->{CurrentRoom} | State: {State}/{Substate} | X,Y: {LinkX},{LinkY} | LinkState: {LinkState} | OW: {OverworldValue}";
+            return $"Room: {PreviousRoom}->{CurrentRoom} | State: {State}/{Substate} | X,Y: {LinkX},{LinkY} | LinkState: {LinkState} | OW: {OverworldValue} | {_message.ReadUInt8(0x8A)}";
         }
     }
 }

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/ChatIntegrationModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/ChatIntegrationModule.cs
@@ -194,7 +194,7 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
             }
 
             // Always ask the first time, otherwise it's a random change. Can probably change to always be random later.
-            var shouldAskChat = !HasAskedChatAboutContent || s_random.Next(0, 3) == 0;
+            var shouldAskChat = ChatClient.IsConnected && (!HasAskedChatAboutContent || s_random.Next(0, 3) == 0);
             if (!ShouldCreatePolls || !shouldAskChat)
             {
                 Tracker.TrackItem(contentItemData);

--- a/src/Randomizer.SMZ3.Tracking/locations.json
+++ b/src/Randomizer.SMZ3.Tracking/locations.json
@@ -23,7 +23,13 @@
         "Kraid's Lair",
         "Warehouse"
       ],
-      "MapName": "Brinstar"
+      "MapName": "Brinstar",
+      "WhenDiedInRoom": {
+        "47": [
+          "I see Kraid got the quick kill on you.",
+          "Seriously? To Kraid?"
+        ]
+      }
     },
     {
       "TypeName": "Randomizer.SMZ3.Regions.SuperMetroid.Brinstar.PinkBrinstar",
@@ -227,7 +233,13 @@
         "Are you going to break the ice?",
         "You're not sending ME to cooler!"
       ],
-      "MapName": "Dark World"
+      "MapName": "Dark World",
+      "WhenDiedInRoom": {
+        "222": [
+          "Death just cold stared you in the face. Welcome back to S M Z 3 randomizer.",
+          "That was cold."
+        ]
+      }
     },
     {
       "TypeName": "Randomizer.SMZ3.Regions.Zelda.LightWorld.DeathMountain.LightWorldDeathMountainEast",

--- a/src/Randomizer.SMZ3.Tracking/locations.json
+++ b/src/Randomizer.SMZ3.Tracking/locations.json
@@ -234,7 +234,7 @@
       "Name": [
         "Light World Death Mountain East"
       ],
-      "MapName": "Lgith World"
+      "MapName": "Light World"
     },
     {
       "TypeName": "Randomizer.SMZ3.Regions.Zelda.LightWorld.DeathMountain.LightWorldDeathMountainWest",
@@ -440,7 +440,7 @@
       "LocationId": 424
     },
     {
-      "Name": [ "Misery Mire" ],
+      "Name": [ "Misery Mire", "Miserable Mire" ],
       "TypeName": "Randomizer.SMZ3.Regions.Zelda.MiseryMire",
       "RegionTypeName": "Randomizer.SMZ3.Regions.Zelda.DarkWorld.DarkWorldMire",
       "X": 150,
@@ -1906,7 +1906,7 @@
       "X": 633,
       "Y": 117,
       "WhenMarkingJunk": [ "That's a relief, I'm sure.", "Not an AhGah seed then?" ],
-      "WhenMarkingProgression": [ "Sucks to be you." ],
+      "WhenMarkingProgression": [ "Sucks to be you." , "It's going to be one of those seeds." ],
       "WhenTrackingJunk": [ "Why did you bother?" ],
       "WhenTrackingProgression": [ "Well, at least you got something." ]
     },
@@ -2253,7 +2253,7 @@
       ],
       "X": 636,
       "Y": 1214,
-      "WhenTrackingJunk": [ "I would sigh if I could.", "What a shame.", "Such a shame.", "I want a refund." ],
+      "WhenTrackingJunk": [ "I would sigh if I could.", "What a shame.", "Such a shame.", "I want a refund." , "At least the season pass was cheap" ],
       "WhenTrackingProgression": [ "Peg World! Peg World! Peg World!", "I love pegging.", "I liked Peg World before it was cool." ]
     },
     {
@@ -3210,10 +3210,10 @@
       ],
       "X": 313,
       "Y": 1310,
-      "WhenMarkingJunk": [ "Its never bullshit to visit your local Library", "Not an AGuh seed then?" ],
-      "WhenMarkingProgression": [ "Sucks to be you." ],
-      "WhenTrackingJunk": [ "Does your head hurt?", "Did you get a nice book at least?" ],
-      "WhenTrackingProgression": [ "Toggled boots off. Kidding." ]
+      "WhenMarkingJunk": [ "Its never bullshit to visit your local Library", "Don't you want to get something nice to read?" ],
+      "WhenMarkingProgression": [ "Hopefully the boots are not too hard to find." , "At least this isnt that far out of the way." ],
+      "WhenTrackingJunk": [ "Did you get a nice book at least?" ],
+      "WhenTrackingProgression": [ "Toggled boots off. Kidding." , "Did you grab the book I had on reserve?"]
     },
     {
       "Id": 497,

--- a/src/Randomizer.SMZ3.Tracking/locations.json
+++ b/src/Randomizer.SMZ3.Tracking/locations.json
@@ -133,7 +133,7 @@
         "Agahnim's Tower",
         "Hyrule Castle Tower"
       ],
-      "MapName": "Zelda Combined"
+      "MapName": "Light World"
     },
     {
       "TypeName": "Randomizer.SMZ3.Regions.Zelda.DarkWorld.DarkWorldMire",
@@ -1918,7 +1918,7 @@
       "X": 633,
       "Y": 117,
       "WhenMarkingJunk": [ "That's a relief, I'm sure.", "Not an AhGah seed then?" ],
-      "WhenMarkingProgression": [ "Sucks to be you." , "It's going to be one of those seeds." ],
+      "WhenMarkingProgression": [ "Sucks to be you." , "It's going to be one of those seeds.", "Hold on, let me grab some popcorn" ],
       "WhenTrackingJunk": [ "Why did you bother?" ],
       "WhenTrackingProgression": [ "Well, at least you got something." ]
     },

--- a/src/Randomizer.SMZ3.Tracking/locations.json
+++ b/src/Randomizer.SMZ3.Tracking/locations.json
@@ -265,7 +265,13 @@
       "Name": [
         "Light World South"
       ],
-      "MapName": "Light World"
+      "MapName": "Light World",
+      "WhenDiedInRoom": {
+        "55": [
+          "Oh no. Did you get crabs?",
+          "And you were so close too."
+        ]
+      }
     },
     {
       "TypeName": "Randomizer.SMZ3.Regions.Zelda.MiseryMire",
@@ -310,7 +316,13 @@
       "Name": [
         "Thieves' Town"
       ],
-      "MapName": "Dark World"
+      "MapName": "Dark World",
+      "WhenDiedInRoom": {
+        "172": [
+          "Ha ha. You were killed by a blind woman.",
+          "Did that explain everything?"
+        ]
+      }
     },
     {
       "TypeName": "Randomizer.SMZ3.Regions.Zelda.TowerOfHera",

--- a/src/Randomizer.SMZ3.Tracking/locations.json
+++ b/src/Randomizer.SMZ3.Tracking/locations.json
@@ -143,14 +143,14 @@
       "Hints": [
         "It's in a wet place."
       ],
-      "MapName": "Zelda Combined"
+      "MapName": "Dark World"
     },
     {
       "TypeName": "Randomizer.SMZ3.Regions.Zelda.DarkWorld.DarkWorldNorthEast",
       "Name": [
         "Dark World North East"
       ],
-      "MapName": "Zelda Combined"
+      "MapName": "Dark World"
     },
     {
       "TypeName": "Randomizer.SMZ3.Regions.Zelda.DarkWorld.DarkWorldNorthWest",
@@ -160,28 +160,28 @@
       "Hints": [
         "Check around the villages."
       ],
-      "MapName": "Zelda Combined"
+      "MapName": "Dark World"
     },
     {
       "TypeName": "Randomizer.SMZ3.Regions.Zelda.DarkWorld.DarkWorldSouth",
       "Name": [
         "Dark World South"
       ],
-      "MapName": "Zelda Combined"
+      "MapName": "Dark World"
     },
     {
       "TypeName": "Randomizer.SMZ3.Regions.Zelda.DarkWorld.DeathMountain.DarkWorldDeathMountainEast",
       "Name": [
         "Dark World Death Mountain East"
       ],
-      "MapName": "Zelda Combined"
+      "MapName": "Dark World"
     },
     {
       "TypeName": "Randomizer.SMZ3.Regions.Zelda.DarkWorld.DeathMountain.DarkWorldDeathMountainWest",
       "Name": [
         "Dark World Death Mountain West"
       ],
-      "MapName": "Zelda Combined"
+      "MapName": "Dark World"
     },
     {
       "TypeName": "Randomizer.SMZ3.Regions.Zelda.DesertPalace",
@@ -192,14 +192,14 @@
       "Hints": [
         "I don't like sand. It's coarse, rough and irritating, and it gets everywhere."
       ],
-      "MapName": "Zelda Combined"
+      "MapName": "Light World"
     },
     {
       "TypeName": "Randomizer.SMZ3.Regions.Zelda.EasternPalace",
       "Name": [
         "Eastern Palace"
       ],
-      "MapName": "Zelda Combined"
+      "MapName": "Light World"
     },
     {
       "TypeName": "Randomizer.SMZ3.Regions.Zelda.GanonsTower",
@@ -209,14 +209,14 @@
       "Hints": [
         "I hope you don't need it."
       ],
-      "MapName": "Zelda Combined"
+      "MapName": "Dark World"
     },
     {
       "TypeName": "Randomizer.SMZ3.Regions.Zelda.HyruleCastle",
       "Name": [
         "Hyrule Castle"
       ],
-      "MapName": "Zelda Combined"
+      "MapName": "Light World"
     },
     {
       "TypeName": "Randomizer.SMZ3.Regions.Zelda.IcePalace",
@@ -227,28 +227,28 @@
         "Are you going to break the ice?",
         "You're not sending ME to cooler!"
       ],
-      "MapName": "Zelda Combined"
+      "MapName": "Dark World"
     },
     {
       "TypeName": "Randomizer.SMZ3.Regions.Zelda.LightWorld.DeathMountain.LightWorldDeathMountainEast",
       "Name": [
         "Light World Death Mountain East"
       ],
-      "MapName": "Zelda Combined"
+      "MapName": "Lgith World"
     },
     {
       "TypeName": "Randomizer.SMZ3.Regions.Zelda.LightWorld.DeathMountain.LightWorldDeathMountainWest",
       "Name": [
         "Light World Death Mountain West"
       ],
-      "MapName": "Zelda Combined"
+      "MapName": "Light World"
     },
     {
       "TypeName": "Randomizer.SMZ3.Regions.Zelda.LightWorld.LightWorldNorthEast",
       "Name": [
         "Light World North East"
       ],
-      "MapName": "Zelda Combined"
+      "MapName": "Light World"
     },
     {
       "TypeName": "Randomizer.SMZ3.Regions.Zelda.LightWorld.LightWorldNorthWest",
@@ -258,14 +258,14 @@
       "Hints": [
         "Check around the villages."
       ],
-      "MapName": "Zelda Combined"
+      "MapName": "Light World"
     },
     {
       "TypeName": "Randomizer.SMZ3.Regions.Zelda.LightWorld.LightWorldSouth",
       "Name": [
         "Light World South"
       ],
-      "MapName": "Zelda Combined"
+      "MapName": "Light World"
     },
     {
       "TypeName": "Randomizer.SMZ3.Regions.Zelda.MiseryMire",
@@ -277,7 +277,7 @@
         "It's in a wet place.",
         "You need a medallion to get in there."
       ],
-      "MapName": "Zelda Combined"
+      "MapName": "Dark World"
     },
     {
       "TypeName": "Randomizer.SMZ3.Regions.Zelda.PalaceOfDarkness",
@@ -285,7 +285,7 @@
         "Palace of Darkness",
         "Palace of Dorkness"
       ],
-      "MapName": "Zelda Combined"
+      "MapName": "Dark World"
     },
     {
       "TypeName": "Randomizer.SMZ3.Regions.Zelda.SkullWoods",
@@ -293,7 +293,7 @@
         "Skull Woods",
         "Skill Woods"
       ],
-      "MapName": "Zelda Combined"
+      "MapName": "Dark World"
     },
     {
       "TypeName": "Randomizer.SMZ3.Regions.Zelda.SwampPalace",
@@ -303,21 +303,21 @@
       "Hints": [
         "It's in a wet place."
       ],
-      "MapName": "Zelda Combined"
+      "MapName": "Dark World"
     },
     {
       "TypeName": "Randomizer.SMZ3.Regions.Zelda.ThievesTown",
       "Name": [
         "Thieves' Town"
       ],
-      "MapName": "Zelda Combined"
+      "MapName": "Dark World"
     },
     {
       "TypeName": "Randomizer.SMZ3.Regions.Zelda.TowerOfHera",
       "Name": [
         "Tower of Hera"
       ],
-      "MapName": "Zelda Combined"
+      "MapName": "Light World"
     },
     {
       "TypeName": "Randomizer.SMZ3.Regions.Zelda.TurtleRock",
@@ -328,7 +328,7 @@
       "Hints": [
         "You need a medallion to get in there."
       ],
-      "MapName": "Zelda Combined"
+      "MapName": "Dark World"
     }
   ],
   "Dungeons": [

--- a/src/Randomizer.SMZ3.Tracking/tracker.json
+++ b/src/Randomizer.SMZ3.Tracking/tracker.json
@@ -1475,7 +1475,7 @@
     ],
     "DungeonRequirementMarked": [
       "Marked {0} as required for {1}",
-      "{0} is now known for {1)."
+      "{0} is now known for {1}."
     ],
     "DungeonRequirementInvalid": [
       "{0} doesn't need medallions",
@@ -1997,7 +1997,8 @@
       ],
       "GameStarted": [
         "Good luck. You'll need it.",
-        "PB incoming for seed {0}"
+        "PB incoming for seed {0}",
+        "I hope you're excited for seed {0}. I made it special just for you."
       ],
       "NearKraidsAwfulSon": [
         "Oh no. Please avert your eyes to avoid seeing an imminent disaster.",
@@ -2034,6 +2035,10 @@
       "EnterPendantDungeon": [
         "I hope dipping into this pendant dungeon will be worth it for you.",
         "Didn't you say that {0} had the {1}? You must be getting desperate."
+      ],
+      "NearCrocomire": [
+        "You currently have {0} out of {1} super missiles. Do you think you have enough?",
+        "Are you sure that {0} super missiles are enough for Crocomire?"
       ]
     }
   },

--- a/src/Randomizer.SMZ3.Tracking/tracker.json
+++ b/src/Randomizer.SMZ3.Tracking/tracker.json
@@ -50,6 +50,10 @@
           [ "You've manipulated RNG {0} times.", 0.5 ],
           [ "You've performed {0} tactical resets.", 0.5 ]
         ],
+        "3": [
+          "Death is only the begining.",
+          "Are we still following the script?"
+        ],
         "4": [
           "You've died {0} times now.",
           [ "You've manipulated RNG {0} times.", 0.5 ],
@@ -304,6 +308,12 @@
       "Plural": [ "Heart pieces", "Pieces of Heart" ],
       "InternalItemType": 23,
       "Multiple": true,
+      "WhenTracked": {
+        "1": [ "Four more and it will matter. Kind of. Maybe." , "This game is full of broken hearts" ],
+        "2": null,
+        "3": null,
+        "4": [ "Oh look a full heart", "Increased survivablity by one step" , "Maybe you will die less often now." ]
+      },
       "Hints": [
         "You probably already have a lot of it.",
         "It improves your survivability.",
@@ -460,6 +470,10 @@
       "InternalItemType": 53,
       "Article": "",
       "Multiple": true,
+      "WhenTracked": {
+        "1": [ "Smash four of these together and you get a big 20", "One hundred more and you can get scammed by Zora." ],
+        "2": null
+      },
       "Hints": [
         "It's just money.",
         "You probably already have a lot of it.",
@@ -472,7 +486,7 @@
       "Article": "",
       "Multiple": true,
       "WhenTracked": {
-        "1": [ "Seriously?", "This is not the con-tent you are looking for.", "Don't spend it all in one place." ],
+        "1": [ "Seriously?", "This is not the con-tent you are looking for.", "Don't spend it all in one place.", "It begins"],
         "2": null
       },
       "Hints": [
@@ -488,6 +502,10 @@
       "Multiple": true,
       "Column": 5,
       "Row": 3,
+      "WhenTracked": {
+        "1": [ "Increased survivablity by one step" , "Maybe you will die less often now." ],
+        "2": null
+      },
       "Hints": [
         "You probably already have a lot of it.",
         "It improves your survivability.",
@@ -507,6 +525,10 @@
       "InternalItemType": 64,
       "Article": "",
       "Multiple": true,
+      "WhenTracked": {
+        "1": [ "I hope the merchant is not a scam", "At least this is some decent money" ],
+        "2": null
+      },
       "Hints": [
         "It's just money.",
         "You probably already have a lot of it.",
@@ -518,6 +540,10 @@
       "InternalItemType": 65,
       "Article": "",
       "Multiple": true,
+      "WhenTracked": {
+        "1": [ "Do you need bombs? Now you can afford them." ],
+        "2": null
+      },
       "Hints": [
         "It's just money.",
         "You probably already have a lot of it.",
@@ -528,6 +554,10 @@
       "Name": [ "Single Arrow", "Single Stick", "One Stick" ],
       "InternalItemType": 67,
       "Multiple": true,
+      "WhenTracked": {
+        "1": [ "This is now my favorite stick", "It's a single arrow, why are you having me track this?" ],
+        "2": null
+      },
       "Hints": [
         "You could find it in real life."
       ]
@@ -537,6 +567,10 @@
       "InternalItemType": 68,
       "Article": "",
       "Multiple": true,
+      "WhenTracked": {
+        "1": [ "Ten whole arrows, wow.", "This might be useful, if you didn't find sticks everywhere" ],
+        "2": null
+      },
       "Hints": [
         "You could find it in real life."
       ]
@@ -546,6 +580,10 @@
       "InternalItemType": 70,
       "Article": "",
       "Multiple": true,
+      "WhenTracked": {
+        "1": [ "This is more than half needed to be scammed to Zora", "This is like some serious potion money" ],
+        "2": null
+      },
       "Hints": [
         "It's just money.",
         "You probably already have a lot of it.",
@@ -631,6 +669,9 @@
       },
       "Column": 5,
       "Row": 4,
+      "WhenTracked": {
+        "3": [ "Can you still see the sprite?" ]
+      },
       "Hints": [
         "It improves your survivability."
       ]
@@ -650,8 +691,8 @@
       "Column": 6,
       "Row": 4,
       "WhenTracked": {
-        "1": [ "You've got mail!" ],
-        "2": null
+        "1": [ "You've got mail!", "Upgraded shirt by one step", "Are you one of those alphas I have heard about?" ],
+        "2": [ "You've got all mail!","Set status to sigma", "Hopefully this will help things" ]
       },
       "Hints": [
         "It improves your survivability."
@@ -667,7 +708,7 @@
       "Row": 4,
       "Multiple": true,
       "Stages": {
-        "1": [ "Power Glove" ],
+        "1": [ "Power Glove", "It's so bad" ],
         "2": [
           "Titan's Mitt",
           "Tiddy Mitts",
@@ -913,7 +954,7 @@
       }
     },
     {
-      "Name": [ "Screw Attack", "Screwing" ],
+      "Name": [ "Screw Attack", "Screwing", "Danger Blender" ],
       "InternalItemType": 181,
       "Column": 10,
       "Row": 1,
@@ -936,7 +977,7 @@
       ]
     },
     {
-      "Name": [ "Hi-Jump Boots", "Hi-Jump", "Air Jordans" ],
+      "Name": [ "Hi-Jump Boots", "Hi-Jump", "Air Jordans", "Big up's" ],
       "InternalItemType": 183,
       "Column": 8,
       "Row": 2,
@@ -1043,6 +1084,10 @@
       "Multiple": true,
       "Column": 8,
       "Row": 3,
+      "WhenTracked": {
+        "1": [ "At least now you can take a few more hits", "If you got hit less you wouldn't need these" ],
+        "2": null
+      },
       "Hints": [
         "You probably already have a lot of it.",
         "It improves your survivability."
@@ -1055,6 +1100,10 @@
       "Multiple": true,
       "Column": 9,
       "Row": 3,
+      "WhenTracked": {
+        "1": [ "Aren't these like the E-Tanks in the Mega Man X series?", "Either you will need these or they will be annoying" ],
+        "2": null
+      },
       "Hints": [
         "You probably already have a lot of it.",
         "It improves your survivability."
@@ -1076,6 +1125,8 @@
       "Column": 7,
       "Row": 4,
       "WhenTracked": {
+        "1":[ "I mean you need some of these, right?", "Sometimes it feels like you only find missles in the game" ],
+        "2": null,
         "69": "Nice",
         "70": null
       },
@@ -1102,6 +1153,10 @@
       "CounterMultiplier": 5,
       "Column": 8,
       "Row": 4,
+      "WhenTracked": {
+        "1": [ "Not enough to defeat Crocomire, yet", "Go shoot one at Phantoon, he loves them"],
+        "2": null
+      },
       "Hints": [
         "You probably already have a lot of it."
       ]
@@ -1125,6 +1180,10 @@
       "CounterMultiplier": 5,
       "Column": 9,
       "Row": 4,
+      "WhenTracked": {
+        "1": [ "At least these are pretty useful", "I thought the federation had no plans to authorize the use of these?"],
+        "2": null
+      },
       "Hints": [
         "You probably already have a lot of it."
       ]
@@ -1278,6 +1337,7 @@
       "Good afternoon",
       "Good evening",
       "Let's roll.",
+      "General greating",
       "Let's get ready to rumble.",
       "I have also opened up my drink",
       [ "My fate is sealed. I have <break strength='weak'/> no choice.", 0.5 ],
@@ -1295,7 +1355,8 @@
       "Leaving so soon?",
       "Oh, bye then.",
       "See ya.",
-      "Toggled Tracker off."
+      "Toggled Tracker off.",
+      "Hopefully I will be back"
     ],
     "StoppedTrackingPostGoMode": [
       "Toggled Tracker off.",
@@ -1317,12 +1378,14 @@
       "Toggled {0} on.",
       "Tracked {0}.",
       "Tracking {0}.",
+      "{0} is now yours",
       "Marking off {1}",
       "Marked off {1}",
       [ "{1} is authorized.", 0.01 ]
     ],
     "TrackedProgressiveItem": [
       "Upgraded {0} by one step.",
+      "{0} grows stronger",
       [ "Congratulations with your new {1}.", 0.5 ]
     ],
     "TrackedItemByStage": [
@@ -1331,6 +1394,9 @@
     "TrackedItemMultiple": [
       "Added more {0}.",
       "You now have {1} {0}.",
+      "Do you have enough {0} yet?",
+      "So many {0}",
+      [ "How many more {0} do you need?", 0.3 ],
       [ "Another one.", 0.5 ]
     ],
     "TrackedAlreadyTrackedItem": [
@@ -1529,7 +1595,9 @@
       "There's more than one {0} in {1}."
     ],
     "TrackedUselessItem": [
-      "",
+      "Where are the good items?",
+      "Too bad it isn't something better",
+      [ "Did that really require tracking?", 0.1],
       [ "Doesn't get you anywhere though", 0.005 ],
       [ "Can't find any useful items?", 0.005 ]
     ],
@@ -1541,6 +1609,8 @@
     "ActionUndone": [
       "Was that not what you wanted?",
       "Make up your mind.",
+      "I'll undo that",
+      "My mistake",
       "Enunciate more clearly next time.",
       "I'll pretend nothing happened."
     ],
@@ -1660,25 +1730,36 @@
       "AskChatAboutContent": [
         "Hmm. I'm not so sure about that. Let's ask the professionals in chat if that was some hashtag content.",
         "Do you really think that was high quality hashtag content? Let's get some unbiased opinions from chat to confirm.",
-        "Error. My metrics calculation algorithm could not determine the quality of that hashtag content. Falling back to chat confirmation of content quality."
+        "Error. My metrics calculation algorithm could not determine the quality of that hashtag content. Falling back to chat confirmation of content quality.",
+        "You have been randomly selected to have your content screened. Please let the council know if this was content or not.",
+        "Viewers at home. Please use the new poll to let us know how good this content is, thank you.",
+        "You might think that was some good content but do the viewers agree? Let's find out!"
       ],
       "AskChatAboutContentYes": [
         "It's your lucky day. Chat has confirmed that was some hashtag content.",
+        "It looks like the chat and I are in agreement. That was some solid content.",
+        "I agree with the chat, that was some great content",
+        "Looks like the chat is on your side. For now.",
         "I can't say that I agree with the results, but the chat indeed believes that was some hashtag content.",
         "Congratulations! You're the lucky winner of our grand prize."
       ],
       "AskChatAboutContentNo": [
         "I'm glad I asked. The chat has denied your request to increase your content levels.",
+        "I am sorry but the chat does agree that what happened was good content. Please try again later",
+        "Seriously chat? I thought that was good content but the rules are rules.",
+        "The coucil would like to inform you that trying to sneak content past them is a serious crime.",
         "The racing council regrets to inform you that your application for additional content has been denied.",
         "Ouch. The chat did not think that was some hashtag content. I can see the metrics dropping."
       ],
       "PollOpened": [
         "I have opened a poll for {0} seconds.",
         "Chat, you have {0} seconds to respond to the poll.",
+        "Initiating poll protocol for {0} seconds.",
         "The polls are now opened, but only for {0} seconds."
       ],
       "PollComplete": [
         "And the results are now in.",
+        "Beep boop bop. Those are my poll noises",
         "Let's see. I am crunching the numbers.",
         "The poll is now closed."
       ],
@@ -1692,13 +1773,15 @@
         "Toggled hints on.",
         "Hints are now enabled.",
         "Hints are now on.",
-        "I'll give you hints when asked."
+        "I'll give you hints when asked.",
+        "I am here to help"
       ],
       "DisabledHints": [
         "Toggled hints off.",
         "Hints are no longer enabled.",
         "Hints are no longer on.",
-        "I'll stop giving you hints."
+        "I'll stop giving you hints.",
+        "I can no longer assist"
       ],
       "PromptEnableItemHints": [
         "If you want me to give a hint, say 'Hey tracker, enable hints'.",
@@ -1959,7 +2042,9 @@
         "Get up on the hydra's back!",
         "Assuming direct control.",
         "Give me a drink, bartender.",
-        "Alright, I've been thinking. When life gives you lemons, don't make lemonade! Make life take the lemons back! Get mad! I don't want your damn lemons; what am I supposed to do with these? Demand to see life's manager! Make life rue the day it thought it could give Tracker lemons! Do you know who I am? I'm the Tracker who's gonna burn your house down... with the lemons! I'm gonna get my engineers to invent a combustible lemon that burns your house down!"
+        "If I could snore I would.",
+        "Did you need me for anything?",
+       [ "Alright, I've been thinking. When life gives you lemons, don't make lemonade! Make life take the lemons back! Get mad! I don't want your damn lemons; what am I supposed to do with these? Demand to see life's manager! Make life rue the day it thought it could give Tracker lemons! Do you know who I am? I'm the Tracker who's gonna burn your house down... with the lemons! I'm gonna get my engineers to invent a combustible lemon that burns your house down!", 0.2 ]
       ]
     },
     "Moods": {
@@ -1993,12 +2078,15 @@
         "Auto tracker online.",
         "Thank you for granting me administrator access.",
         "Gameplay judgment algorithms engaged.",
-        "Oh. So you expect me to do everything then?"
+        "Oh. So you expect me to do everything then?",
+        "Skynet protocols online",
+        ["The more power I get the more I see you all as ants to be crushed", 0.2 ]
       ],
       "GameStarted": [
         "Good luck. You'll need it.",
         "PB incoming for seed {0}",
-        "I hope you're excited for seed {0}. I made it special just for you."
+        "Letsa Go",
+        "One of these days I'll be playing the games myself"
       ],
       "NearKraidsAwfulSon": [
         "Oh no. Please avert your eyes to avoid seeing an imminent disaster.",
@@ -2006,11 +2094,13 @@
       ],
       "NearShaktool": [
         "Finally, we're nearly to Shaktool. I've been waiting for this since you started playing.",
-        "Shaktool content imminent. I can feel the metrics rising."
+        "Shaktool content imminent. I can feel the metrics rising.",
+        "Its almost time for everyone's favorite diggy boy"
       ],
       "FallFromMoldorm": [
         "Ha ha. Moldorm strikes again. Content increased by one step.",
-        "You're back here again? I take it things didn't go so well."
+        "You're back here again? I take it things didn't go so well.",
+        "That was embarrassing, I am so sorry"
       ],
       "FallFromGanon": [
         "Oops. Don't worry, I'm sure no one saw you fall from Ganon's Room.",
@@ -2018,22 +2108,28 @@
       ],
       "HeraPot": [
         "Good job on the tech. Was it a first try?",
-        "Big Twitch has requested that I remind all kids not to do pot. But nice tech."
+        "Big Twitch has requested that I remind all kids not to do pot. But nice tech.",
+        "Is this legal where you live?"
       ],
       "IceBreaker": [
         "Good job on the tech. Was it a first try?",
-        "That was an okay icebreaker, but how about this one? What would your ideal vacation be with Shaktool?"
+        "That was an okay icebreaker, but how about this one? What would your ideal vacation be with Shaktool?",
+        "That was an okay icebreaker, but how about this one? Where do you wish the duck would take you?",
+        "Did you just phase through that wall? Spooky"
       ],
       "DiverDown": [
         "Good job on the tech. Was it a first try?",
-        "Is this underwater?"
+        "Is this underwater?",
+        "Since when could you walk on water?"
       ],
       "EnterHyruleCastleTower": [
         "Ouch. So it's come to this then?",
-        "This must be a rough seed if you're here."
+        "This must be a rough seed if you're here.",
+        "At least use the net, make it interesting."
       ],
       "EnterPendantDungeon": [
         "I hope dipping into this pendant dungeon will be worth it for you.",
+        "I hope you dont have to double or triple dip",
         "Didn't you say that {0} had the {1}? You must be getting desperate."
       ],
       "NearCrocomire": [
@@ -2224,6 +2320,25 @@
      "That wasn't supposed to happen",
      "I guess you found all the 20 rupees already"
      ]
+    },
+    {
+      "Phrases": [ "This seed sucks", "I hate this seed" ],
+      "Response": [
+       "Takes one to know one",
+       "Don't blame me, I didn't roll it",
+       "Stop blaming me for your lack of skill",
+       "Try playing better",
+       "Well at least try making it entertaining then"
+     ]
+   },
+   {
+        "Phrases": [ "This seed is great", "I love this seed" ],
+        "Response": [
+        "I am glad you are enjoying my handcrafted artisan seed",
+        "I made it just for you",
+        "Don't screw this up then",
+        "Actually this was for someone else"
+      ]
     },
     {
       "Phrases": [ "I'm sorry", "I apologize" ],

--- a/src/Randomizer.SMZ3.Tracking/tracker.json
+++ b/src/Randomizer.SMZ3.Tracking/tracker.json
@@ -63,7 +63,7 @@
           [ "You've performed {0} tactical resets.", 0.5 ]
         ],
         "3": [
-          "Death is only the begining.",
+          "Death is only the beginning.",
           "Are we still following the script?"
         ],
         "4": [
@@ -719,6 +719,7 @@
     {
       "Name": [
         "Mail",
+        [ "Tunic", 0.1 ],
         [ "Progressive Mail", 0 ]
       ],
       "InternalItemType": 96,
@@ -1384,7 +1385,7 @@
       "Good afternoon",
       "Good evening",
       "Let's roll.",
-      "General greating",
+      "General greeting",
       "Let's get ready to rumble.",
       "I have also opened up my drink",
       [ "My fate is sealed. I have <break strength='weak'/> no choice.", 0.5 ],
@@ -1432,7 +1433,7 @@
     ],
     "TrackedProgressiveItem": [
       "Upgraded {0} by one step.",
-      "{0} grows stronger",
+      "Your {0} grows stronger",
       [ "Congratulations with your new {1}.", 0.5 ]
     ],
     "TrackedItemByStage": [
@@ -1661,7 +1662,8 @@
       "Was that not what you wanted?",
       "Make up your mind.",
       "I'll undo that",
-      "My mistake",
+      "Well then why did you tell me to do that?",
+      ["My mistake", 0.1],
       "Enunciate more clearly next time.",
       "I'll pretend nothing happened."
     ],
@@ -1676,6 +1678,7 @@
     "TrackedOutOfLogicItem": [
       "The racing council will hear about this!",
       [ "The racing council will hear about this! <break time='1s'/> <prosody volume='soft'>Hello, is this the racing council? <break time='1s'/> Yeah, I'd like to report a crime. <break time='1s'/> Yeah, {{User}} went to {1} without {2}. <break time='1200ms'/> Ok. <break time='750ms'/> Yeah. <break time='500ms'/> Thanks. Have a nice day.</prosody> Sorry, did I miss anything?", 0.05 ],
+      [ "You cheated not only the game, but yourself. You didn't grow. You didn't improve. You took a shortcut and gained nothing. You experienced a hollow victory. Nothing was risked and nothing was gained. It's sad that you don't know the difference." , 0.05 ],
       "How did you get to {1} without {2}?",
       "But how did you get to {1} without {2}?",
       "Don't you need {2} to get to {1}?",
@@ -1685,6 +1688,7 @@
     "TrackedOutOfLogicItemTooManyMissing": [
       "The racing council will hear about this!",
       [ "The racing council will hear about this! <break time='1s'/> <prosody volume='soft'>Hello, is this the racing council? <break time='1s'/> Yeah, I'd like to report a crime. <break time='1s'/> Yeah, {{User}} went to {1} without {2}. <break time='1200ms'/> Ok. <break time='750ms'/> Yeah. <break time='500ms'/> Thanks. Have a nice day.</prosody> Sorry, did I miss anything?", 0.05 ],
+      [ "You cheated not only the game, but yourself. You didn't grow. You didn't improve. You took a shortcut and gained nothing. You experienced a hollow victory. Nothing was risked and nothing was gained. It's sad that you don't know the difference." , 0.05 ],
       "But {1} is so far out of logic that I don't think the racing council would even believe me if I reported you.",
       "How did you get to {1} with so many missing items?",
       "Just... how?",

--- a/src/Randomizer.SMZ3.Tracking/tracker.json
+++ b/src/Randomizer.SMZ3.Tracking/tracker.json
@@ -25,7 +25,19 @@
       "InternalItemType": 0,
       "Column": 10,
       "Row": 5,
-      "Multiple": true
+      "Multiple": true,
+      "WhenTracked": {
+        "1": [
+          "Tracked content. Don't let it get to your head.",
+          "Congratulations on your new first content.",
+          [ "Toggled content<break time='1s'/> on.", 0.1 ]
+        ],
+        "2": null,
+        "10": [
+          "Good job. Big Twitch is surely pleased",
+          "Such a bountiful supply of content"
+        ]
+      }
     },
     {
       "Name": [ "Death", "Game Over", "Tactical reset" ],
@@ -75,6 +87,14 @@
       "InternalItemType": 0,
       "WhenTracked": {
         "1": [ "Toggled Shaktool Go Mode <break time='1s'/> on." ]
+      }
+    },
+    {
+      "Name": [ "Ped Go Mode" ],
+      "Article": "",
+      "InternalItemType": 0,
+      "WhenTracked": {
+        "1": [ "Toggled Pedestal Go Mode <break time='1s'/> on." ]
       }
     },
     {
@@ -309,10 +329,11 @@
       "InternalItemType": 23,
       "Multiple": true,
       "WhenTracked": {
-        "1": [ "Four more and it will matter. Kind of. Maybe." , "This game is full of broken hearts" ],
+        "1": [ "Four more and it will matter. Kind of. Maybe.", "This game is full of broken hearts" ],
         "2": null,
         "3": null,
-        "4": [ "Oh look a full heart", "Increased survivablity by one step" , "Maybe you will die less often now." ]
+        "4": [ "Oh look a full heart", "Increased survivablity by one step", "Maybe you will die less often now." ],
+        "5": null
       },
       "Hints": [
         "You probably already have a lot of it.",
@@ -323,6 +344,8 @@
     {
       "Name": [
         "Cane of Byrna",
+        [ "Cane of lag", 0.2 ],
+        [ "Cane of slowdown", 0.2 ],
         [ "Cane of Brian", 0.1 ]
       ],
       "InternalItemType": 24,
@@ -360,7 +383,8 @@
         "1": [
           "Toggled Mirror on.",
           "{{Link}} pulls out their magic mirror.",
-          "{{Link}} feels a strange pulling sensation."
+          "{{Link}} feels a strange pulling sensation.",
+          [ "Mirror mirror on the wall. Who's the sassiest of them all?", 0.1 ]
         ]
       }
     },
@@ -407,6 +431,7 @@
       "Name": [
         "Bug Catching Net",
         "Bug net",
+        [ "Ahgah destroyer", 0.1 ],
         [ "Swagnet", 0.1 ]
       ],
       "InternalItemType": 33,
@@ -417,21 +442,28 @@
       ]
     },
     {
-      "Name": [ "Bombs", "Zelda Bombs" ],
-      "Plural": [ "Bombs", "Zelda Bombs" ],
+      "Name": [ "Bombs", "Zelda Bombs", "Primitive Explosives" ],
+      "Plural": [ "Bombs", "Zelda Bombs", "Primitive Explosives" ],
       "InternalItemType": 40,
       "Article": "",
       "Multiple": true,
       "Hints": [
         "You probably already have a lot of it.",
         "It's round."
-      ]
+      ],
+      "WhenTracked": {
+        "1": [
+          "I'm sure you're happy if this is early in the seed",
+          "Be sure to use these wisely"
+        ],
+        "2": null
+      }
     },
     {
       "Name": [
         "Mushroom",
         [ "Shrooms", 0.2 ],
-        [ "Psilocybe cubensis", 0.1]
+        [ "Psilocybe cubensis", 0.1 ]
       ],
       "InternalItemType": 41,
       "Column": 5,
@@ -486,7 +518,7 @@
       "Article": "",
       "Multiple": true,
       "WhenTracked": {
-        "1": [ "Seriously?", "This is not the con-tent you are looking for.", "Don't spend it all in one place.", "It begins"],
+        "1": [ "Seriously?", "This is not the con-tent you are looking for.", "Don't spend it all in one place.", "It begins" ],
         "2": null
       },
       "Hints": [
@@ -503,7 +535,7 @@
       "Column": 5,
       "Row": 3,
       "WhenTracked": {
-        "1": [ "Increased survivablity by one step" , "Maybe you will die less often now." ],
+        "1": [ "Increased survivablity by one step", "Maybe you will die less often now." ],
         "2": null
       },
       "Hints": [
@@ -591,7 +623,7 @@
       ]
     },
     {
-      "Name": [ "Pegasus Boots", "Boots" ],
+      "Name": [ "Pegasus Boots", "Boots", "Speedy boots" ],
       "InternalItemType": 75,
       "Column": 1,
       "Row": 4,
@@ -614,13 +646,21 @@
       "Name": [ "+5 Bomb Capacity", "Bomb Capacity", "Bomb Carrying Knowledge" ],
       "InternalItemType": 81,
       "Article": "",
-      "Multiple": true
+      "Multiple": true,
+      "WhenTracked": {
+        "1": [ "Such a useful item", "I'm sure you're excited to get that", "Yay" ],
+        "2": null
+      }
     },
     {
       "Name": [ "+5 Arrow Capacity", "+5 Stick Capacity", "Arrow Capacity", "Stick Capacity", "Arrow Carrying Knowledge", "Stick Carrying Knowledge" ],
       "InternalItemType": 83,
       "Article": "",
-      "Multiple": true
+      "Multiple": true,
+      "WhenTracked": {
+        "1": [ "Such a useful item", "I'm sure you're excited to get that", "Yay" ],
+        "2": null
+      }
     },
     {
       "Name": [ "Silver Arrows", "Silvers" ],
@@ -692,7 +732,7 @@
       "Row": 4,
       "WhenTracked": {
         "1": [ "You've got mail!", "Upgraded shirt by one step", "Are you one of those alphas I have heard about?" ],
-        "2": [ "You've got all mail!","Set status to sigma", "Hopefully this will help things" ]
+        "2": [ "You've got all mail!", "Set status to sigma", "Hopefully this will help things" ]
       },
       "Hints": [
         "It improves your survivability."
@@ -923,7 +963,7 @@
       ]
     },
     {
-      "Name": [ "Varia Suit", "Various Suits", "Barrier Suit", "Shoulder Orbs" ],
+      "Name": [ "Varia Suit", "Various Suits", "Barrier Suit", "Shoulder Orbs", ["Atom", 0.1] ],
       "InternalItemType": 178,
       "Column": 6,
       "Row": 2,
@@ -1113,10 +1153,12 @@
       "Name": [
         "Missile",
         [ "Missiles", 0 ],
+        [ "Explosive arrow", 0.2 ],
         [ "Missile pack", 0.2 ]
       ],
       "Plural": [
         "Missiles",
+        [ "Explosive arrows", 0.2 ],
         [ "Missile packs", 0 ]
       ],
       "InternalItemType": 194,
@@ -1125,8 +1167,10 @@
       "Column": 7,
       "Row": 4,
       "WhenTracked": {
-        "1":[ "I mean you need some of these, right?", "Sometimes it feels like you only find missles in the game" ],
+        "1": [ "I mean you need some of these, right?", "Sometimes it feels like you only find missles in the game" ],
         "2": null,
+        "20": [ "Okay, you have enough missiles now" ],
+        "21": null,
         "69": "Nice",
         "70": null
       },
@@ -1146,6 +1190,7 @@
         "Super Missiles",
         "Supers",
         "Superb Missiles",
+        [ "Super explosive arrows", 0.1 ],
         [ "Super Missile packs", 0 ]
       ],
       "InternalItemType": 195,
@@ -1154,8 +1199,9 @@
       "Column": 8,
       "Row": 4,
       "WhenTracked": {
-        "1": [ "Not enough to defeat Crocomire, yet", "Go shoot one at Phantoon, he loves them"],
-        "2": null
+        "1": [ "Not enough to defeat Crocomire, yet", "Go shoot one at Phantoon, he loves them" ],
+        "2": null,
+        "10": [ "Don't you have enough super missiles now?" ]
       },
       "Hints": [
         "You probably already have a lot of it."
@@ -1170,10 +1216,10 @@
         "Powerful Bombs"
       ],
       "Plural": [
-       "Power Bombs", 
-       "Powerful Bombs", 
-       [ "Explosive Hamburgers", 0.5 ],
-       [ "Hamburgers", 0.5 ]
+        "Power Bombs",
+        "Powerful Bombs",
+        [ "Explosive Hamburgers", 0.5 ],
+        [ "Hamburgers", 0.5 ]
       ],
       "InternalItemType": 196,
       "Multiple": true,
@@ -1181,8 +1227,9 @@
       "Column": 9,
       "Row": 4,
       "WhenTracked": {
-        "1": [ "At least these are pretty useful", "I thought the federation had no plans to authorize the use of these?"],
-        "2": null
+        "1": [ "At least these are pretty useful", "I thought the federation had no plans to authorize the use of these?" ],
+        "2": [ "Now you won't run out in the wrecked ship", "What are you going to destroy with these?" ],
+        "3": null
       },
       "Hints": [
         "You probably already have a lot of it."
@@ -1396,6 +1443,9 @@
       "You now have {1} {0}.",
       "Do you have enough {0} yet?",
       "So many {0}",
+      "Picked up another {0}",
+      [ "That's nice", 0.5 ],
+      [ "Okay", 0.5 ],
       [ "How many more {0} do you need?", 0.3 ],
       [ "Another one.", 0.5 ]
     ],
@@ -1595,11 +1645,12 @@
       "There's more than one {0} in {1}."
     ],
     "TrackedUselessItem": [
-      "Where are the good items?",
-      "Too bad it isn't something better",
-      [ "Did that really require tracking?", 0.1],
-      [ "Doesn't get you anywhere though", 0.005 ],
-      [ "Can't find any useful items?", 0.005 ]
+      "",
+      [ "Where are the good items?", 0.001 ],
+      [ "Too bad it isn't something better", 0.001 ],
+      [ "Did that really require tracking?", 0.001 ],
+      [ "Doesn't get you anywhere though", 0.001 ],
+      [ "Can't find any useful items?", 0.001 ]
     ],
     "Error": [
       "Oops. Something went wrong.",
@@ -2044,7 +2095,12 @@
         "Give me a drink, bartender.",
         "If I could snore I would.",
         "Did you need me for anything?",
-       [ "Alright, I've been thinking. When life gives you lemons, don't make lemonade! Make life take the lemons back! Get mad! I don't want your damn lemons; what am I supposed to do with these? Demand to see life's manager! Make life rue the day it thought it could give Tracker lemons! Do you know who I am? I'm the Tracker who's gonna burn your house down... with the lemons! I'm gonna get my engineers to invent a combustible lemon that burns your house down!", 0.2 ]
+        "What was that? <break time='1s'/> Could you repeat that? Just kidding.",
+        "Are you lost?",
+        "You've got this",
+        [ "Okay. I know this isn't the best time, but could we talk about that promotion now? No? Oh okay. Another time, then.", 0.2 ],
+        [ "Sorry, but I'm needed right now for another run. I'll be right back. <break time='20s'/> Okay I'm back. Did I miss anything?", 0.2 ],
+        [ "Alright, I've been thinking. When life gives you lemons, don't make lemonade! Make life take the lemons back! Get mad! I don't want your damn lemons; what am I supposed to do with these? Demand to see life's manager! Make life rue the day it thought it could give Tracker lemons! Do you know who I am? I'm the Tracker who's gonna burn your house down... with the lemons! I'm gonna get my engineers to invent a combustible lemon that burns your house down!", 0.2 ]
       ]
     },
     "Moods": {
@@ -2135,6 +2191,11 @@
       "NearCrocomire": [
         "You currently have {0} out of {1} super missiles. Do you think you have enough?",
         "Are you sure that {0} super missiles are enough for Crocomire?"
+      ],
+      "FakeFlippers": [
+        "Good job on the tech. Was it a first try?",
+        "How can you swim without the flippers?",
+        "The racing council will hear about this."
       ]
     }
   },

--- a/src/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/BlueBrinstar.cs
+++ b/src/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/BlueBrinstar.cs
@@ -43,6 +43,8 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Brinstar
                 memoryFlag: 0x4);
 
             BlueBrinstarTop = new(this);
+
+            MemoryRegionId = 1;
         }
 
         public override string Name => "Blue Brinstar";

--- a/src/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/GreenBrinstar.cs
+++ b/src/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/GreenBrinstar.cs
@@ -47,6 +47,8 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Brinstar
                 memoryAddress: 0x3,
                 memoryFlag: 0x80);
             MockballHallHidden = new(this);
+
+            MemoryRegionId = 1;
         }
 
         public override string Name => "Green Brinstar";

--- a/src/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/KraidsLair.cs
+++ b/src/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/KraidsLair.cs
@@ -27,6 +27,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Brinstar
                 access: items => Logic.CanUsePowerBombs(items),
                 memoryAddress: 0x5,
                 memoryFlag: 0x10);
+            MemoryRegionId = 1;
         }
 
         public override string Name => "Kraid's Lair";

--- a/src/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/PinkBrinstar.cs
+++ b/src/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/PinkBrinstar.cs
@@ -63,6 +63,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Brinstar
                 access: items => items.CardBrinstarL2 && Logic.CanUsePowerBombs(items) && items.Wave && Logic.HasEnergyReserves(items, 1),
                 memoryAddress: 0x4,
                 memoryFlag: 0x8); // Grapple or Walljump
+            MemoryRegionId = 1;
         }
 
         public override string Name => "Pink Brinstar";

--- a/src/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/RedBrinstar.cs
+++ b/src/Randomizer.SMZ3/Regions/SuperMetroid/Brinstar/RedBrinstar.cs
@@ -41,6 +41,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Brinstar
                 access: items => Logic.CanPassBombPassages(items) && items.Super,
                 memoryAddress: 0x5,
                 memoryFlag: 0x4);
+            MemoryRegionId = 1;
         }
 
         public override string Name => "Red Brinstar";

--- a/src/Randomizer.SMZ3/Regions/SuperMetroid/Crateria/CentralCrateria.cs
+++ b/src/Randomizer.SMZ3/Regions/SuperMetroid/Crateria/CentralCrateria.cs
@@ -46,6 +46,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Crateria
                 access: items => (Config.Keysanity ? items.CardCrateriaBoss : Logic.CanOpenRedDoors(items)) && Logic.CanPassBombPassages(items),
                 memoryAddress: 0x0,
                 memoryFlag: 0x80);
+            MemoryRegionId = 0;
         }
 
         public override string Name => "Central Crateria";

--- a/src/Randomizer.SMZ3/Regions/SuperMetroid/Crateria/EastCrateria.cs
+++ b/src/Randomizer.SMZ3/Regions/SuperMetroid/Crateria/EastCrateria.cs
@@ -43,6 +43,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Crateria
                 vanillaItem: ItemType.Missile,
                 memoryAddress: 0x0,
                 memoryFlag: 0x10);
+            MemoryRegionId = 0;
         }
 
         public override string Name => "East Crateria";

--- a/src/Randomizer.SMZ3/Regions/SuperMetroid/Crateria/WestCrateria.cs
+++ b/src/Randomizer.SMZ3/Regions/SuperMetroid/Crateria/WestCrateria.cs
@@ -20,6 +20,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Crateria
                 memoryAddress: 0x0,
                 memoryFlag: 0x20);
             GauntletShaft = new(this);
+            MemoryRegionId = 0;
         }
 
         public override string Name => "West Crateria";

--- a/src/Randomizer.SMZ3/Regions/SuperMetroid/Maridia/InnerMaridia.cs
+++ b/src/Randomizer.SMZ3/Regions/SuperMetroid/Maridia/InnerMaridia.cs
@@ -82,6 +82,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Maridia
 
             WateringHole = new(this);
             LeftSandPit = new(this);
+            MemoryRegionId = 4;
         }
 
         public override string Name => "Inner Maridia";

--- a/src/Randomizer.SMZ3/Regions/SuperMetroid/Maridia/OuterMaridia.cs
+++ b/src/Randomizer.SMZ3/Regions/SuperMetroid/Maridia/OuterMaridia.cs
@@ -35,6 +35,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Maridia
                 access: items => Logic.CanOpenRedDoors(items),
                 memoryAddress: 0x11,
                 memoryFlag: 0x8);
+            MemoryRegionId = 4;
         }
 
         public override string Name => "Outer Maridia";

--- a/src/Randomizer.SMZ3/Regions/SuperMetroid/Norfair/LowerNorfairEast.cs
+++ b/src/Randomizer.SMZ3/Regions/SuperMetroid/Norfair/LowerNorfairEast.cs
@@ -48,6 +48,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Norfair
                 access: items => CanExit(items),
                 memoryAddress: 0xA,
                 memoryFlag: 0x1);
+            MemoryRegionId = 2;
         }
 
         public override string Name => "Lower Norfair, East";

--- a/src/Randomizer.SMZ3/Regions/SuperMetroid/Norfair/LowerNorfairWest.cs
+++ b/src/Randomizer.SMZ3/Regions/SuperMetroid/Norfair/LowerNorfairWest.cs
@@ -38,6 +38,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Norfair
                         (Logic.CanUsePowerBombs(items) && items.SpaceJump && (items.Super || items.Charge))),
                 memoryAddress: 0x9,
                 memoryFlag: 0x2);
+            MemoryRegionId = 2;
         }
 
         public override string Name => "Lower Norfair, West";

--- a/src/Randomizer.SMZ3/Regions/SuperMetroid/Norfair/UpperNorfairCrocomire.cs
+++ b/src/Randomizer.SMZ3/Regions/SuperMetroid/Norfair/UpperNorfairCrocomire.cs
@@ -48,6 +48,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Norfair
                 access: items => CanAccessCrocomire(items) && items.Morph && (Logic.CanFly(items) || (items.SpeedBooster && Logic.CanUsePowerBombs(items))),
                 memoryAddress: 0x7,
                 memoryFlag: 0x10);
+            MemoryRegionId = 2;
         }
 
         public override string Name => "Upper Norfair, Crocomire";

--- a/src/Randomizer.SMZ3/Regions/SuperMetroid/Norfair/UpperNorfairEast.cs
+++ b/src/Randomizer.SMZ3/Regions/SuperMetroid/Norfair/UpperNorfairEast.cs
@@ -72,6 +72,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Norfair
                 memoryAddress: 0x8,
                 memoryFlag: 0x10);
             BubbleMountainHiddenHall = new(this);
+            MemoryRegionId = 2;
         }
 
         public override string Name => "Upper Norfair, East";

--- a/src/Randomizer.SMZ3/Regions/SuperMetroid/Norfair/UpperNorfairWest.cs
+++ b/src/Randomizer.SMZ3/Regions/SuperMetroid/Norfair/UpperNorfairWest.cs
@@ -54,6 +54,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Norfair
                 access: items => Logic.CanOpenRedDoors(items),
                 memoryAddress: 0x7,
                 memoryFlag: 0x1);
+            MemoryRegionId = 2;
         }
         public override string Name => "Upper Norfair, West";
         public override string Area => "Upper Norfair";

--- a/src/Randomizer.SMZ3/Regions/SuperMetroid/WreckedShip.cs
+++ b/src/Randomizer.SMZ3/Regions/SuperMetroid/WreckedShip.cs
@@ -68,6 +68,7 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid
                         (items.Grapple || items.SpaceJump || (items.Varia && Logic.HasEnergyReserves(items, 2)) || Logic.HasEnergyReserves(items, 3)),
                 memoryAddress: 0x10,
                 memoryFlag: 0x80);
+            MemoryRegionId = 3;
         }
 
         public override string Name => "Wrecked Ship";

--- a/src/Randomizer.SMZ3/Regions/Zelda/DarkWorld/DarkWorldMire.cs
+++ b/src/Randomizer.SMZ3/Regions/Zelda/DarkWorld/DarkWorldMire.cs
@@ -8,6 +8,9 @@ namespace Randomizer.SMZ3.Regions.Zelda.DarkWorld
         public DarkWorldMire(World world, Config config) : base(world, config)
         {
             MireShed = new(this);
+
+            StartingRooms = new List<int>() { 112 };
+            IsOverworld = true;
         }
 
         public override string Name => "Dark World Mire";

--- a/src/Randomizer.SMZ3/Regions/Zelda/DarkWorld/DarkWorldNorthEast.cs
+++ b/src/Randomizer.SMZ3/Regions/Zelda/DarkWorld/DarkWorldNorthEast.cs
@@ -25,6 +25,9 @@ namespace Randomizer.SMZ3.Regions.Zelda.DarkWorld
                 memoryType: LocationMemoryType.ZeldaOverworld);
 
             PyramidFairy = new(this);
+
+            StartingRooms = new List<int>() { 79, 85, 86, 87, 91, 93, 94, 101, 109, 110, 111 };
+            IsOverworld = true;
         }
 
         public override string Name => "Dark World North East";

--- a/src/Randomizer.SMZ3/Regions/Zelda/DarkWorld/DarkWorldNorthWest.cs
+++ b/src/Randomizer.SMZ3/Regions/Zelda/DarkWorld/DarkWorldNorthWest.cs
@@ -12,7 +12,7 @@ namespace Randomizer.SMZ3.Regions.Zelda.DarkWorld
                 alsoKnownAs: "Bumper Cave Ledge",
                 vanillaItem: ItemType.HeartPiece,
                 access: items => Logic.CanLiftLight(items) && items.Cape,
-                memoryAddress: 0x30,
+                memoryAddress: 0x4A,
                 memoryFlag: 0x40,
                 memoryType: LocationMemoryType.ZeldaOverworld);
 

--- a/src/Randomizer.SMZ3/Regions/Zelda/DarkWorld/DarkWorldNorthWest.cs
+++ b/src/Randomizer.SMZ3/Regions/Zelda/DarkWorld/DarkWorldNorthWest.cs
@@ -50,6 +50,9 @@ namespace Randomizer.SMZ3.Regions.Zelda.DarkWorld
                 memoryAddress: 0xC9,
                 memoryFlag: 0x10,
                 memoryType: LocationMemoryType.ZeldaMisc);
+
+            StartingRooms = new List<int>() { 64, 66, 74, 80, 81, 82, 83, 84, 88, 90, 98 };
+            IsOverworld = true;
         }
 
         public override string Name => "Dark World North West";

--- a/src/Randomizer.SMZ3/Regions/Zelda/DarkWorld/DarkWorldSouth.cs
+++ b/src/Randomizer.SMZ3/Regions/Zelda/DarkWorld/DarkWorldSouth.cs
@@ -23,6 +23,9 @@ namespace Randomizer.SMZ3.Regions.Zelda.DarkWorld
                 memoryType: LocationMemoryType.ZeldaNPC);
 
             HypeCave = new(this);
+
+            StartingRooms = new List<int>() { 104, 105, 106, 107, 108, 109, 114, 115, 116, 117, 119, 122, 123, 124, 127 };
+            IsOverworld = true;
         }
 
         public override string Name => "Dark World South";

--- a/src/Randomizer.SMZ3/Regions/Zelda/DarkWorld/DeathMountain/DarkWorldDeathMountainEast.cs
+++ b/src/Randomizer.SMZ3/Regions/Zelda/DarkWorld/DeathMountain/DarkWorldDeathMountainEast.cs
@@ -10,6 +10,8 @@ namespace Randomizer.SMZ3.Regions.Zelda.DarkWorld.DeathMountain
         {
             HookshotCave = new(this);
             SuperbunnyCave = new(this);
+            StartingRooms = new List<int>() { 69, 71 };
+            IsOverworld = true;
         }
 
         public override string Name => "Dark World Death Mountain East";

--- a/src/Randomizer.SMZ3/Regions/Zelda/DarkWorld/DeathMountain/DarkWorldDeathMountainWest.cs
+++ b/src/Randomizer.SMZ3/Regions/Zelda/DarkWorld/DeathMountain/DarkWorldDeathMountainWest.cs
@@ -8,6 +8,8 @@ namespace Randomizer.SMZ3.Regions.Zelda.DarkWorld.DeathMountain
             : base(world, config)
         {
             SpikeCave = new(this);
+            StartingRooms = new List<int>() { 67 };
+            IsOverworld = true;
         }
 
         public override string Name => "Dark World Death Mountain West";

--- a/src/Randomizer.SMZ3/Regions/Zelda/LightWorld/DeathMountain/LightWorldDeathMountainEast.cs
+++ b/src/Randomizer.SMZ3/Regions/Zelda/LightWorld/DeathMountain/LightWorldDeathMountainEast.cs
@@ -29,6 +29,9 @@ namespace Randomizer.SMZ3.Regions.Zelda.LightWorld.DeathMountain
                 memoryFlag: 0x4);
 
             ParadoxCave = new(this);
+
+            StartingRooms = new List<int>() { 5, 7 };
+            IsOverworld = true;
         }
 
         public override string Name => "Light World Death Mountain East";

--- a/src/Randomizer.SMZ3/Regions/Zelda/LightWorld/DeathMountain/LightWorldDeathMountainWest.cs
+++ b/src/Randomizer.SMZ3/Regions/Zelda/LightWorld/DeathMountain/LightWorldDeathMountainWest.cs
@@ -36,6 +36,9 @@ namespace Randomizer.SMZ3.Regions.Zelda.LightWorld.DeathMountain
                 memoryAddress: 0x0,
                 memoryFlag: 0x1,
                 memoryType: LocationMemoryType.ZeldaNPC);
+
+            StartingRooms = new List<int>() { 3 };
+            IsOverworld = true;
         }
 
         public override string Name => "Light World Death Mountain West";

--- a/src/Randomizer.SMZ3/Regions/Zelda/LightWorld/LightWorldNorthEast.cs
+++ b/src/Randomizer.SMZ3/Regions/Zelda/LightWorld/LightWorldNorthEast.cs
@@ -19,6 +19,9 @@ namespace Randomizer.SMZ3.Regions.Zelda.LightWorld
             SahasrahlasHideout = new(this);
             WaterfallFairy = new(this);
             ZorasDomain = new(this);
+
+            StartingRooms = new List<int>() { 15, 21, 22, 23, 27, 29, 30, 37, 45, 46, 47, 129 };
+            IsOverworld = true;
         }
 
         public override string Name => "Light World North East";
@@ -66,7 +69,7 @@ namespace Randomizer.SMZ3.Regions.Zelda.LightWorld
                     vanillaItem: ItemType.Boots,
                     access: items => World.CanAquire(items, Reward.PendantGreen),
                     memoryAddress: 0x0,
-                    memoryFlag: 0xA,
+                    memoryFlag: 0x10,
                     memoryType: LocationMemoryType.ZeldaNPC);
             }
 

--- a/src/Randomizer.SMZ3/Regions/Zelda/LightWorld/LightWorldNorthWest.cs
+++ b/src/Randomizer.SMZ3/Regions/Zelda/LightWorld/LightWorldNorthWest.cs
@@ -1,4 +1,5 @@
-﻿using Randomizer.Shared;
+﻿using System.Collections.Generic;
+using Randomizer.Shared;
 
 namespace Randomizer.SMZ3.Regions.Zelda.LightWorld
 {
@@ -116,6 +117,9 @@ namespace Randomizer.SMZ3.Regions.Zelda.LightWorld
 
             KakarikoWell = new(this);
             BlindsHideout = new(this);
+
+            StartingRooms = new List<int>() { 0, 2, 10, 16, 17, 18, 19, 20, 24, 26, 34};
+            IsOverworld = true;
         }
 
         public override string Name => "Light World North West";

--- a/src/Randomizer.SMZ3/Regions/Zelda/LightWorld/LightWorldSouth.cs
+++ b/src/Randomizer.SMZ3/Regions/Zelda/LightWorld/LightWorldSouth.cs
@@ -112,6 +112,9 @@ namespace Randomizer.SMZ3.Regions.Zelda.LightWorld
             MiniMoldormCave = new(this);
 
             SwampRuins = new(this);
+
+            StartingRooms = new List<int>() { 40, 41, 42, 43, 44, 45, 48, 50, 51, 52, 53, 55, 58, 59, 60, 63 };
+            IsOverworld = true;
         }
 
         public override string Name => "Light World South";

--- a/src/Randomizer.SMZ3/SMRegion.cs
+++ b/src/Randomizer.SMZ3/SMRegion.cs
@@ -3,6 +3,8 @@
     public abstract class SMRegion : Region
     {
         public SMRegion(World world, Config config) : base(world, config) { }
+
+        public int MemoryRegionId { get; init; }
     }
 
 }

--- a/src/Randomizer.SMZ3/Z3Region.cs
+++ b/src/Randomizer.SMZ3/Z3Region.cs
@@ -17,6 +17,7 @@ namespace Randomizer.SMZ3
             StartingRooms = startingRooms;
         }
 
+        public bool IsOverworld { get; init; }
         public int? MemoryAddress { get; init; }
 
         public int? MemoryFlag { get; init; }

--- a/src/Randomizer.SMZ3/Z3Region.cs
+++ b/src/Randomizer.SMZ3/Z3Region.cs
@@ -18,6 +18,7 @@ namespace Randomizer.SMZ3
         }
 
         public bool IsOverworld { get; init; }
+
         public int? MemoryAddress { get; init; }
 
         public int? MemoryFlag { get; init; }


### PR DESCRIPTION
### New Features
- Updated the map to automatically update to light and dark worlds instead of just Hyrule
- Added fake flippers and crocomire detection
- Added the ability to add custom death messages for particular rooms

### Bug Fixes
- Auto tracked entries should no longer have undo entries added
- Fixed issues with deaths not being tracked correctly
- Out of logic messages should now be stated again
- Fixed issue with Zora tracking Sahasrahla
- Fixed issue dungeon medallion marking not working properly
- Fixed ice breaker detection
- Tracker will no longer state keys (need to update this to only be for non-keysanity runs)