### PR TITLE
Fix for not detecting when polls are opened

### DIFF
--- a/src/Randomizer.SMZ3.ChatIntegration/IChatApi.cs
+++ b/src/Randomizer.SMZ3.ChatIntegration/IChatApi.cs
@@ -5,13 +5,14 @@ using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Randomizer.SMZ3.ChatIntegration.Models;
 
 namespace Randomizer.SMZ3.ChatIntegration
 {
     public interface IChatApi
     {
-        Task<T?> MakeApiCallAsync<T>(string api, HttpMethod method, CancellationToken cancellationToken);
-        Task<TResponse?> MakeApiCallAsync<TRequest, TResponse>(string api, TRequest requestData, HttpMethod method, CancellationToken cancellationToken);
+        Task<T?> MakeApiCallAsync<T>(string api, HttpMethod method, CancellationToken cancellationToken) where T : TwitchAPIResponse;
+        Task<TResponse?> MakeApiCallAsync<TRequest, TResponse>(string api, TRequest requestData, HttpMethod method, CancellationToken cancellationToken) where TResponse : TwitchAPIResponse;
         void SetAccessToken(string? authToken);
         string GetClientId();
     }

--- a/src/Randomizer.SMZ3.ChatIntegration/Models/TwitchAPIResponse.cs
+++ b/src/Randomizer.SMZ3.ChatIntegration/Models/TwitchAPIResponse.cs
@@ -11,6 +11,10 @@ namespace Randomizer.SMZ3.ChatIntegration.Models
     /// </summary>
     public class TwitchAPIResponse
     {
+        /// <summary>
+        /// If the Twitch API returned a successful response and
+        /// was able to be parsed successfully
+        /// </summary>
         public bool IsSuccessful { get; set; }
     }
 }

--- a/src/Randomizer.SMZ3.ChatIntegration/Models/TwitchAPIResponse.cs
+++ b/src/Randomizer.SMZ3.ChatIntegration/Models/TwitchAPIResponse.cs
@@ -6,10 +6,11 @@ using System.Threading.Tasks;
 
 namespace Randomizer.SMZ3.ChatIntegration.Models
 {
-    public class ChatPoll
+    /// <summary>
+    /// Base class to be extended for TwitchAPI responses
+    /// </summary>
+    public class TwitchAPIResponse
     {
-        public bool IsPollComplete { get; set; }
-        public bool IsPollSuccessful { get; set; }
-        public string? WinningChoice { get; set; }
+        public bool IsSuccessful { get; set; }
     }
 }

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/ChatIntegrationModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/ChatIntegrationModule.cs
@@ -223,7 +223,7 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
 
             AskChatAboutContentPollId = await ChatClient.CreatePollAsync("Do you think that was some high quality #content?", new List<string>() { "Yes", "No" }, AskChatAboutContentPollTime);
 
-            if (AskChatAboutContentPollId == null)
+            if (string.IsNullOrEmpty(AskChatAboutContentPollId))
             {
                 Tracker.TrackItem(contentItemData);
                 return;
@@ -244,11 +244,11 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
             do
             {
                 var result = await ChatClient.CheckPollAsync(AskChatAboutContentPollId);
-                if (result.IsComplete && AskChatAboutContentCheckPollResults)
+                if (result.IsPollComplete && AskChatAboutContentCheckPollResults)
                 {
                     AskChatAboutContentCheckPollResults = false;
 
-                    if (result.IsSuccessful)
+                    if (result.IsPollSuccessful)
                     {
                         Tracker.Say(x => x.Chat.PollComplete);
 

--- a/src/Randomizer.SMZ3.Twitch/Models/TwitchPoll.cs
+++ b/src/Randomizer.SMZ3.Twitch/Models/TwitchPoll.cs
@@ -4,10 +4,11 @@ using System.Linq;
 using System.Text;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
+using Randomizer.SMZ3.ChatIntegration.Models;
 
 namespace Randomizer.SMZ3.Twitch.Models
 {
-    public class TwitchPoll
+    public class TwitchPoll : TwitchAPIResponse
     {
         [JsonPropertyName("broadcaster_id")]
         public string? BroadcasterId { get; set; }
@@ -27,9 +28,9 @@ namespace Randomizer.SMZ3.Twitch.Models
         [JsonPropertyName("status")]
         public string? Status { get; set; }
 
-        public bool IsComplete => !"ACTIVE".Equals(Status, StringComparison.OrdinalIgnoreCase);
+        public bool IsPollComplete => !"ACTIVE".Equals(Status, StringComparison.OrdinalIgnoreCase);
 
-        public bool Successful => WinningChoice != null && "COMPLETED".Equals(Status, StringComparison.OrdinalIgnoreCase);
+        public bool IsPollSuccessful => WinningChoice != null && "COMPLETED".Equals(Status, StringComparison.OrdinalIgnoreCase);
 
         public TwitchPollChoice? WinningChoice => Choices?.OrderByDescending(x => x.Votes).FirstOrDefault();
     }

--- a/src/Randomizer.SMZ3.Twitch/Models/TwitchPoll.cs
+++ b/src/Randomizer.SMZ3.Twitch/Models/TwitchPoll.cs
@@ -28,10 +28,19 @@ namespace Randomizer.SMZ3.Twitch.Models
         [JsonPropertyName("status")]
         public string? Status { get; set; }
 
+        /// <summary>
+        /// If the poll was finished, be it complete or closed
+        /// </summary>
         public bool IsPollComplete => !"ACTIVE".Equals(Status, StringComparison.OrdinalIgnoreCase);
 
+        /// <summary>
+        /// If a poll was finished successfully
+        /// </summary>
         public bool IsPollSuccessful => WinningChoice != null && "COMPLETED".Equals(Status, StringComparison.OrdinalIgnoreCase);
 
+        /// <summary>
+        /// Returns choice that was voted on the most
+        /// </summary>
         public TwitchPollChoice? WinningChoice => Choices?.OrderByDescending(x => x.Votes).FirstOrDefault();
     }
 }

--- a/src/Randomizer.SMZ3.Twitch/Models/TwitchUser.cs
+++ b/src/Randomizer.SMZ3.Twitch/Models/TwitchUser.cs
@@ -4,10 +4,11 @@ using System.Linq;
 using System.Text;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
+using Randomizer.SMZ3.ChatIntegration.Models;
 
 namespace Randomizer.SMZ3.Twitch.Models
 {
-    public class TwitchUser
+    public class TwitchUser : TwitchAPIResponse
     {
         [JsonPropertyName("id")]
         public string? Id { get; set; }

--- a/src/Randomizer.SMZ3.Twitch/TwitchChatClient.cs
+++ b/src/Randomizer.SMZ3.Twitch/TwitchChatClient.cs
@@ -158,7 +158,7 @@ namespace Randomizer.SMZ3.Twitch
 
             poll = await _chatApi.MakeApiCallAsync<TwitchPoll, TwitchPoll>("polls", poll, HttpMethod.Post, default);
 
-            return poll != null && poll.Successful ? poll.Id : null;
+            return poll != null && poll.IsSuccessful ? poll.Id : null;
         }
 
         public async Task<ChatPoll> CheckPollAsync(string id)
@@ -169,8 +169,8 @@ namespace Randomizer.SMZ3.Twitch
             {
                 return new ChatPoll
                 {
-                    IsComplete = true,
-                    IsSuccessful = false
+                    IsPollComplete = true,
+                    IsPollSuccessful = false
                 };
             }
 
@@ -178,8 +178,8 @@ namespace Randomizer.SMZ3.Twitch
 
             return new()
             {
-                IsComplete = poll.IsComplete,
-                IsSuccessful = poll.Successful,
+                IsPollComplete = poll.IsPollComplete,
+                IsPollSuccessful = poll.IsPollSuccessful,
                 WinningChoice = poll.WinningChoice?.Title
             };
         }

--- a/src/Randomizer.SMZ3.Twitch/TwitchChatClient.cs
+++ b/src/Randomizer.SMZ3.Twitch/TwitchChatClient.cs
@@ -156,16 +156,16 @@ namespace Randomizer.SMZ3.Twitch
                 Duration = duration
             };
 
-            poll = await _chatApi.MakeApiCallAsync<TwitchPoll, TwitchPoll>("polls", poll, HttpMethod.Post, default);
+            var pollApiResponse = await _chatApi.MakeApiCallAsync<TwitchPoll, TwitchPoll>("polls", poll, HttpMethod.Post, default);
 
-            return poll != null && poll.IsSuccessful ? poll.Id : null;
+            return pollApiResponse != null && pollApiResponse.IsSuccessful ? pollApiResponse.Id : null;
         }
 
         public async Task<ChatPoll> CheckPollAsync(string id)
         {
-            var poll = await _chatApi.MakeApiCallAsync<TwitchPoll>($"polls?broadcaster_id={Id}&id={id}", HttpMethod.Get, default);
+            var pollApiResponse = await _chatApi.MakeApiCallAsync<TwitchPoll>($"polls?broadcaster_id={Id}&id={id}", HttpMethod.Get, default);
 
-            if (poll == null)
+            if (pollApiResponse == null)
             {
                 return new ChatPoll
                 {
@@ -174,13 +174,13 @@ namespace Randomizer.SMZ3.Twitch
                 };
             }
 
-            Logger.LogInformation("Poll complete with status {0} and winning choice of {1}", poll.Status, poll.WinningChoice?.Title);
+            Logger.LogInformation("Poll complete with status {0} and winning choice of {1}", pollApiResponse.Status, pollApiResponse.WinningChoice?.Title);
 
             return new()
             {
-                IsPollComplete = poll.IsPollComplete,
-                IsPollSuccessful = poll.IsPollSuccessful,
-                WinningChoice = poll.WinningChoice?.Title
+                IsPollComplete = pollApiResponse.IsPollComplete,
+                IsPollSuccessful = pollApiResponse.IsPollSuccessful,
+                WinningChoice = pollApiResponse.WinningChoice?.Title
             };
         }
 


### PR DESCRIPTION
Trying not to lump literally everything into one massive PR this time to make them easier to review.

This resolves an issue I accidentally introduced with Twitch polls. My ambiguity on some variable names bit me a bit (I used IsSuccessful for if the poll was completed successfully, not for if the request was completed). Now all Twitch API requests need to extend a TwitchAPIResponse class that has an IsSuccessful response for if the api call was successful or not. I've renamed the poll successful variables to remove any ambiguity. 