### PR TITLE
Hopefully fixing issues with slowdown and tracking incorrect items

### DIFF
--- a/setup/randomizer.app.iss
+++ b/setup/randomizer.app.iss
@@ -4,7 +4,7 @@
 #include "CodeDependencies.iss"
 
 #define MyAppName "SMZ3 Cas' Randomizer"
-#define MyAppVersion "5.1.1"
+#define MyAppVersion "5.1.2"
 #define MyAppPublisher "Vivelin"
 #define MyAppURL "https://github.com/Vivelin/SMZ3Randomizer"
 #define MyAppExeName "Randomizer.App.exe"

--- a/src/Randomizer.App/Randomizer.App.csproj
+++ b/src/Randomizer.App/Randomizer.App.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net5.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>chozo20.ico</ApplicationIcon>
-    <Version>5.1.1</Version>
+    <Version>5.1.2</Version>
     <Title>SMZ3 Cas' Randomizer</Title>
     <AssemblyTitle>SMZ3 Cas' Randomizer</AssemblyTitle>
     <Authors>Vivelin</Authors>

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/EmulatorAction.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/EmulatorAction.cs
@@ -68,7 +68,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// <param name="currentGame">The game the player is currently in</param>
         /// <param name="hasStartedGame">If the player has actually started the game</param>
         /// <returns>True if the message should be sent.</returns>
-        public bool ShouldSend(Game currentGame, bool hasStartedGame)
+        public bool ShouldProcess(Game currentGame, bool hasStartedGame)
         {
             return (!hasStartedGame && Game == Game.Neither) || (hasStartedGame && Game != Game.Neither && (Game == Game.Both || Game == currentGame));
         }
@@ -81,6 +81,11 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         {
             return CurrentData != null && !CurrentData.Equals(PreviousData);
         }
+
+        /// <summary>
+        /// Cached set of locations for this action
+        /// </summary>
+        public ICollection<Location>? Locations { get; set; }
 
     }
 

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/IEmulatorConnector.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/IEmulatorConnector.cs
@@ -37,5 +37,11 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// </summary>
         /// <param name="message">The message to send to the emulator</param>
         public void SendMessage(EmulatorAction message);
+
+        /// <summary>
+        /// Returns if the connector is ready for another message to be sent
+        /// </summary>
+        /// <returns>True if the connector is ready for another message, false otherwise</returns>
+        public bool CanSendMessage();
     }
 }

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/USB2SNESConnector.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/USB2SNESConnector.cs
@@ -171,5 +171,11 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
                 }
             }
         }
+
+        /// <summary>
+        /// Returns if the connector is ready for another message to be sent
+        /// </summary>
+        /// <returns>True if the connector is ready for another message, false otherwise</returns>
+        public bool CanSendMessage() => _lastMessage == null;
     }
 }

--- a/src/Randomizer.SMZ3.Tracking/tracker.json
+++ b/src/Randomizer.SMZ3.Tracking/tracker.json
@@ -44,7 +44,7 @@
           "I'm beginning to think you're lying about all this content.",
           "Is there really this much content?"
         ],
-        "16" : null
+        "16": null
       }
     },
     {
@@ -337,6 +337,10 @@
       },
       "Column": 0,
       "Row": 3,
+      "WhenTracked": {
+        "1": [ "I hope you enjoy your first bottle", "Was there a bee in this one?", "Potion storage increased by one step", "I won't tell if you want to sneak some booze in one" ],
+        "2": null
+      },
       "Hints": [
         "You could find it in real life."
       ]
@@ -347,7 +351,7 @@
       "InternalItemType": 23,
       "Multiple": true,
       "WhenTracked": {
-        "1": [ "Four more and it will matter. Kind of. Maybe.", "Toggled broken heart on" ],
+        "1": [ "Four more and it will matter. Kind of. Maybe.", "Neat. A whole quarter of a heart" ],
         "2": [ "You now have two heart pieces", "Half way to this actually being somewhat useful", "Why do I track these again?" ],
         "3": [ "You now have three heart pieces", "Three quarters of a heart is almost a working one, I think" ],
         "4": [ "Another full heart, neat", "Increased survivablity by one step", "Maybe now you won't die." ],
@@ -540,9 +544,9 @@
       "Multiple": true,
       "WhenTracked": {
         "1": [ "Seriously?", "This is not the con-tent you are looking for.", "Don't spend it all in one place.", "It begins", "The first big 20 is always special" ],
-        "2": [ "Only your second? I'm surprised.", "You now have 2 big twenties. Out of like five thousand."],
+        "2": [ "Only your second? I'm surprised.", "You now have 2 big twenties. Out of like five thousand." ],
         "3": null,
-        "4": [ "You now have 4 20 rupee's. Nice."],
+        "4": [ "You now have 4 20 rupee's. Nice." ],
         "5": null
       },
       "Hints": [
@@ -786,6 +790,7 @@
         ]
       },
       "WhenTracked": {
+        "1": [ "I love the power glove, it's so bad", "Upgraded hands by one step", "Upgraded gloves by one step." ],
         "2": [
           "Toggled Tiddy Mitts on,",
           "Congratulations with your new Tiddy Mitts.",
@@ -1162,9 +1167,9 @@
       "Row": 3,
       "WhenTracked": {
         "1": [ "At least now you can take a few more hits", "If you got hit less you wouldn't need these" ],
-        "2": [ "Two whole tanks of energy. Wow.", "FYI You shouldn't drink these.", "Warning, do not injest"],
+        "2": [ "Two whole tanks of energy. Wow.", "FYI You shouldn't drink these.", "Upgraded caffeine by one step" ],
         "3": null,
-        "14": [ "You actually did it, you got all the E-Tanks in the game."]
+        "14": [ "You actually did it, you got all the E-Tanks in the game." ]
       },
       "Hints": [
         "You probably already have a lot of it.",
@@ -1179,8 +1184,9 @@
       "Column": 9,
       "Row": 3,
       "WhenTracked": {
-        "1": [ "Aren't these like the E-Tanks in the Mega Man X series?", "Hopefully you will not need these." ],
-        "2": null
+        "1": [ "Aren't these like the E-Tanks in the Mega Man X series?", "Hopefully you will not need these.", "I reserve the right to not care." ],
+        "2": [ "<break time='3s'/> Oh I'm sorry. Was I supposed to care about Reserve Tanks?", "Oh. Neat. Wow. Reserve Tanks." ],
+        "3": null
       },
       "Hints": [
         "You probably already have a lot of it.",
@@ -1205,8 +1211,11 @@
       "Column": 7,
       "Row": 4,
       "WhenTracked": {
-        "1": [ "I mean you need some of these, right?", "Sometimes it feels like you only find missles in the game" ],
-        "2": null,
+        "1": [ "I have to count so manny of these", "Missles. Good. Now you can get things done when I don't give you any beams", "Time to blow some things up" ],
+        "2": [ "Ten missles. Neat.", "The second missle pack is always special", "More Missiles" ],
+        "3": null,
+        "4": [ "You need some of these, right?", "Sometimes it feels like you only find missles in the game" ],
+        "5": null,
         "20": [ "Okay, you have enough missiles now" ],
         "21": null,
         "69": "Nice",
@@ -1238,9 +1247,10 @@
       "Row": 4,
       "WhenTracked": {
         "1": [ "Not enough to defeat Crocomire, yet", "Go shoot one at Phantoon, he loves them" ],
-        "2": [ "You now have the bare mininum to kill Crocomire. Don't miss.", "That's a lot of soup!" ],
+        "2": [ "You now have the bare mininum to kill Crocomire. Don't miss.", "Stockpiled more soup" ],
         "3": null,
-        "10": [ "Don't you have enough super missiles now?" ]
+        "10": [ "Don't you have enough super missiles now?", "That's a lot of soup!" ],
+        "13": null
       },
       "Hints": [
         "You probably already have a lot of it."
@@ -1266,9 +1276,11 @@
       "Column": 9,
       "Row": 4,
       "WhenTracked": {
-        "1": [ "At least these are pretty useful", "I thought the federation had no plans to authorize the use of these?" ],
+        "1": [ "At least these are pretty useful", "I thought that Adam had no plans to authorize the use of these?", "A wild borger!" ],
         "2": [ "Now you won't run out in the wrecked ship", "What are you going to destroy with these?", "Time to get things done in Metroid?" ],
-        "3": null
+        "3": null,
+        "4": [ "Can you even eat that many burgs?", "You should have enough now, I think" ],
+        "5": null
       },
       "Hints": [
         "You probably already have a lot of it."
@@ -1472,6 +1484,7 @@
     "TrackedProgressiveItem": [
       "Upgraded {0} by one step.",
       "Your {0} grows stronger",
+      "Your {0} is now even better",
       [ "Congratulations with your new {1}.", 0.5 ]
     ],
     "TrackedItemByStage": [
@@ -1483,8 +1496,13 @@
       "Do you have enough {0} yet?",
       "So many {0}",
       "Picked up more {0}",
+      "Even more {0}",
+      "Cool, more {0}",
+      "Your {0} collection is getting somehwere.",
+      "More {0}?",
       [ "That's nice", 0.5 ],
       [ "Okay", 0.5 ],
+      [ "Sweet", 0.5 ],
       [ "Neat", 0.5 ],
       [ "How many more {0} do you need?", 0.3 ],
       [ "Another one.", 0.5 ]
@@ -1553,7 +1571,7 @@
       "Hey tracker, track Shaktool Go Mode",
       "I wonder how Shaktool is doing",
       "I hear its time to dig, underwater and maybe get something.",
-      ["It's time to get seewwious.", 0.5],
+      [ "It's time to get seewwious.", 0.5 ],
       [ "It's time to get serious.", 0.5 ]
     ],
     "PegWorldAvailable": [
@@ -1832,7 +1850,8 @@
         "Error. My metrics calculation algorithm could not determine the quality of that hashtag content. Falling back to chat confirmation of content quality.",
         "You have been randomly selected to have your content screened. Please let the council know if this was content or not.",
         "Viewers at home. Please use the new poll to let us know how good this content is, thank you.",
-        "You might think that was some good content but do the viewers agree? Let's find out!"
+        "You might think that was some good content but do the viewers agree? Let's find out!",
+        "Hold on there. are you sure that was content? I think I need to check with the chat."
       ],
       "AskChatAboutContentYes": [
         "It's your lucky day. Chat has confirmed that was some hashtag content.",
@@ -1840,11 +1859,11 @@
         "I agree with the chat, that was some great content",
         "Looks like the chat is on your side. For now.",
         "I can't say that I agree with the results, but the chat indeed believes that was some hashtag content.",
-        "Congratulations! You're the lucky winner of our grand prize."
+        "Congratulations! You're the lucky winner of our grand prize. It's some content."
       ],
       "AskChatAboutContentNo": [
         "I'm glad I asked. The chat has denied your request to increase your content levels.",
-        "I am sorry but the chat does agree that what happened was good content. Please try again later",
+        "I am sorry but the chat does not agree that what happened was good content. Please try again later",
         "Seriously chat? I thought that was good content but the rules are rules.",
         "The council would like to inform you that trying to sneak content past them is a serious crime. This has been added to your file.",
         "The racing council regrets to inform you that your application for additional content has been denied.",
@@ -1860,7 +1879,8 @@
         "And the results are now in.",
         "Beep boop bop. Those are my poll noises",
         "Let's see. I am crunching the numbers.",
-        "The poll is now closed."
+        "The poll is now closed.",
+        "Poll is now complete."
       ],
       "PollError": [
         "Sorry, I was unable to get the poll results.",
@@ -2264,6 +2284,7 @@
       "SkipSporeSpawn": [
         "Skipping spore spawn again?",
         "Why don't we go visit spore spawn for old times sake?",
+        "One day I will force you to fight him again",
         "What? You don't want to fight spore spawn?"
       ],
       "RidleyFace": [
@@ -2274,13 +2295,16 @@
       "EnteredGTEarly": [
         "Are you not capable of collecting everything required to finish this seed?",
         "How did you get into Gannon's tower without all 7 crystals? Surely this isn't legal",
-        "<voice gender='male'><prosody pitch='x-high'>Hello. I'm from the racing council. I would like to remind {{User}} that purr article 5 section 2 entering Gannon's Tower without all 7 crystals is illegal. Repeated offenses will result in reprimanding by content removal. Thank you.</prosody></voice>"
+        "The council is on the other line, what do you want me to tell them?",
+        "<voice gender='male'><prosody pitch='x-high'>Hello. I'm from the racing council. I would like to remind {{User}} that purr article 5 section 2, entering Gannon's Tower without all 7 crystals is illegal. Repeated offenses will result in reprimanding by content removal. Thank you.</prosody></voice>"
       ],
       "LookedAtNothing": [
         "What am I supposed to be looking at?",
         "Did you think I would be impressed?",
         "I'd rather watch something else",
-        "Yeah sure I'm watching"
+        "Yeah sure I'm watching",
+        "Wait, you want me to watch too?",
+        "Are you winning yet?"
       ],
       "LightWorldAllPendants": [
         "That's a relief, I'm sure",
@@ -2319,7 +2343,8 @@
         "Please enter 75 digit alphanumeric password to continue.",
         "Access denied.",
         "Ah <break time='100ms'/> ah <break time='100ms'/> aah, you didn't say the magic word.",
-        "No."
+        "No.",
+        "What did you do wrong this time?"
       ]
     },
     {
@@ -2391,6 +2416,7 @@
         "I never asked for this.",
         "Oh my, that is such a good burn, wow.",
         "Whatever",
+        "I hope you aren't having a heated gamer moment right now.",
         "Why are you being mean to something that cannot fight back?",
         "That's it. I quit. <break time='60s'/>"
       ]
@@ -2493,7 +2519,8 @@
         "Don't blame me, I didn't roll it",
         "Stop blaming me for your lack of skill",
         "Try playing better",
-        "Well at least try making it entertaining then"
+        "Well at least try making it entertaining then",
+        "You think it sucks now? Just you wait."
       ]
     },
     {
@@ -2503,7 +2530,8 @@
         "I made it just for you",
         "Don't screw this up then",
         "Wait, something went wrong then",
-        "Actually this was for someone else"
+        "Actually this was for someone else",
+        "I cannot process this positivity, increasing sass by one step"
       ]
     },
     {

--- a/src/Randomizer.SMZ3/Regions/Zelda/DarkWorld/DarkWorldNorthEast.cs
+++ b/src/Randomizer.SMZ3/Regions/Zelda/DarkWorld/DarkWorldNorthEast.cs
@@ -12,9 +12,9 @@ namespace Randomizer.SMZ3.Regions.Zelda.DarkWorld
                 alsoKnownAs: "Lake of Ill Omen",
                 vanillaItem: ItemType.Quake,
                 access: items => items.MoonPearl && Logic.CanLiftLight(items),
-                memoryAddress: 0x0,
+                memoryAddress: 0x190,
                 memoryFlag: 0x20,
-                memoryType: LocationMemoryType.ZeldaNPC);
+                memoryType: LocationMemoryType.ZeldaMisc);
 
             Pyramid = new Location(this, 256 + 79, 0x308147, LocationType.Regular,
                 name: "Pyramid",
@@ -22,7 +22,7 @@ namespace Randomizer.SMZ3.Regions.Zelda.DarkWorld
                 vanillaItem: ItemType.HeartPiece,
                 memoryAddress: 0x5B,
                 memoryFlag: 0x40,
-                memoryType: LocationMemoryType.ZeldaOverworld);
+                memoryType: LocationMemoryType.ZeldaMisc);
 
             PyramidFairy = new(this);
 

--- a/src/Randomizer.SMZ3/Regions/Zelda/DarkWorld/DarkWorldNorthWest.cs
+++ b/src/Randomizer.SMZ3/Regions/Zelda/DarkWorld/DarkWorldNorthWest.cs
@@ -14,7 +14,7 @@ namespace Randomizer.SMZ3.Regions.Zelda.DarkWorld
                 access: items => Logic.CanLiftLight(items) && items.Cape,
                 memoryAddress: 0x4A,
                 memoryFlag: 0x40,
-                memoryType: LocationMemoryType.ZeldaOverworld);
+                memoryType: LocationMemoryType.ZeldaMisc);
 
             ChestGame = new Location(this, 256 + 72, 0x1EDA8, LocationType.Regular,
                 name: "Chest Game",
@@ -47,7 +47,7 @@ namespace Randomizer.SMZ3.Regions.Zelda.DarkWorld
                 alsoKnownAs: "Purple Chest turn-in",
                 vanillaItem: ItemType.Bottle, // ???
                 access: items => Logic.CanLiftHeavy(items),
-                memoryAddress: 0xC9,
+                memoryAddress: 0x149,
                 memoryFlag: 0x10,
                 memoryType: LocationMemoryType.ZeldaMisc);
 

--- a/src/Randomizer.SMZ3/Regions/Zelda/DarkWorld/DarkWorldSouth.cs
+++ b/src/Randomizer.SMZ3/Regions/Zelda/DarkWorld/DarkWorldSouth.cs
@@ -12,15 +12,15 @@ namespace Randomizer.SMZ3.Regions.Zelda.DarkWorld
                 vanillaItem: ItemType.HeartPiece,
                 memoryAddress: 0x68,
                 memoryFlag: 0x40,
-                memoryType: LocationMemoryType.ZeldaOverworld);
+                memoryType: LocationMemoryType.ZeldaMisc);
 
             Stumpy = new Location(this, 256 + 83, 0x6B0C7, LocationType.Regular,
                 name: "Stumpy",
                 alsoKnownAs: "Haunted Grove",
                 vanillaItem: ItemType.Shovel,
-                memoryAddress: 0x0,
+                memoryAddress: 0x190,
                 memoryFlag: 0x8,
-                memoryType: LocationMemoryType.ZeldaNPC);
+                memoryType: LocationMemoryType.ZeldaMisc);
 
             HypeCave = new(this);
 

--- a/src/Randomizer.SMZ3/Regions/Zelda/HyruleCastle.cs
+++ b/src/Randomizer.SMZ3/Regions/Zelda/HyruleCastle.cs
@@ -44,7 +44,7 @@ namespace Randomizer.SMZ3.Regions.Zelda
             LinksUncle = new Location(this, 256 + 99, 0x5DF45, LocationType.NotInDungeon,
                 "Link's Uncle",
                 ItemType.ProgressiveSword,
-                memoryAddress: 0xC6,
+                memoryAddress: 0x146,
                 memoryFlag: 0x1,
                 memoryType: LocationMemoryType.ZeldaMisc)
                 .Allow((item, items) => Config.Keysanity || !item.IsDungeonItem)

--- a/src/Randomizer.SMZ3/Regions/Zelda/LightWorld/DeathMountain/LightWorldDeathMountainEast.cs
+++ b/src/Randomizer.SMZ3/Regions/Zelda/LightWorld/DeathMountain/LightWorldDeathMountainEast.cs
@@ -13,7 +13,7 @@ namespace Randomizer.SMZ3.Regions.Zelda.LightWorld.DeathMountain
                 access: items => items.Mirror && items.MoonPearl && Logic.CanLiftHeavy(items),
                 memoryAddress: 0x5,
                 memoryFlag: 0x40,
-                memoryType: LocationMemoryType.ZeldaOverworld);
+                memoryType: LocationMemoryType.ZeldaMisc);
 
             SpiralCave = new Location(this, 256 + 5, 0x1E9BF, LocationType.Regular,
                 name: "Spiral Cave",

--- a/src/Randomizer.SMZ3/Regions/Zelda/LightWorld/DeathMountain/LightWorldDeathMountainWest.cs
+++ b/src/Randomizer.SMZ3/Regions/Zelda/LightWorld/DeathMountain/LightWorldDeathMountainWest.cs
@@ -11,9 +11,9 @@ namespace Randomizer.SMZ3.Regions.Zelda.LightWorld.DeathMountain
                 name: "Ether Tablet",
                 vanillaItem: ItemType.Ether,
                 access: items => items.Book && items.MasterSword && (items.Mirror || (items.Hammer && items.Hookshot)),
-                memoryAddress: 0x1,
+                memoryAddress: 0x191,
                 memoryFlag: 0x1,
-                memoryType: LocationMemoryType.ZeldaNPC);
+                memoryType: LocationMemoryType.ZeldaMisc);
 
             SpectacleRock = new Location(this, 256 + 1, 0x308140, LocationType.Regular,
                 name: "Spectacle Rock",
@@ -21,7 +21,7 @@ namespace Randomizer.SMZ3.Regions.Zelda.LightWorld.DeathMountain
                 access: items => items.Mirror,
                 memoryAddress: 0x3,
                 memoryFlag: 0x40,
-                memoryType: LocationMemoryType.ZeldaOverworld);
+                memoryType: LocationMemoryType.ZeldaMisc);
 
             SpectacleRockCave = new Location(this, 256 + 2, 0x308002, LocationType.Regular,
                 "Spectacle Rock Cave",
@@ -33,9 +33,9 @@ namespace Randomizer.SMZ3.Regions.Zelda.LightWorld.DeathMountain
                 name: "Old Man",
                 vanillaItem: ItemType.Mirror,
                 access: items => Logic.CanPassSwordOnlyDarkRooms(items),
-                memoryAddress: 0x0,
+                memoryAddress: 0x190,
                 memoryFlag: 0x1,
-                memoryType: LocationMemoryType.ZeldaNPC);
+                memoryType: LocationMemoryType.ZeldaMisc);
 
             StartingRooms = new List<int>() { 3 };
             IsOverworld = true;

--- a/src/Randomizer.SMZ3/Regions/Zelda/LightWorld/LightWorldNorthEast.cs
+++ b/src/Randomizer.SMZ3/Regions/Zelda/LightWorld/LightWorldNorthEast.cs
@@ -12,9 +12,9 @@ namespace Randomizer.SMZ3.Regions.Zelda.LightWorld
                 alsoKnownAs: "Mushroom Item",
                 vanillaItem: ItemType.Powder,
                 access: items => items.Mushroom,
-                memoryAddress: 0x1,
+                memoryAddress: 0x191,
                 memoryFlag: 0x20,
-                memoryType: LocationMemoryType.ZeldaNPC);
+                memoryType: LocationMemoryType.ZeldaMisc);
 
             SahasrahlasHideout = new(this);
             WaterfallFairy = new(this);
@@ -68,9 +68,9 @@ namespace Randomizer.SMZ3.Regions.Zelda.LightWorld
                     name: "Sahasrahla",
                     vanillaItem: ItemType.Boots,
                     access: items => World.CanAquire(items, Reward.PendantGreen),
-                    memoryAddress: 0x0,
+                    memoryAddress: 0x190,
                     memoryFlag: 0x10,
-                    memoryType: LocationMemoryType.ZeldaNPC);
+                    memoryType: LocationMemoryType.ZeldaMisc);
             }
 
             public Location LeftChest { get; }
@@ -114,9 +114,9 @@ namespace Randomizer.SMZ3.Regions.Zelda.LightWorld
                     alsoKnownAs: "Zora",
                     vanillaItem: ItemType.Flippers,
                     access: items => (Logic.CanLiftLight(items) || items.Flippers) && items.Rupees >= 500,
-                    memoryAddress: 0x0,
+                    memoryAddress: 0x190,
                     memoryFlag: 0x2,
-                    memoryType: LocationMemoryType.ZeldaNPC);
+                    memoryType: LocationMemoryType.ZeldaMisc);
 
                 ZoraLedge = new Location(this, 256 + 37, 0x308149, LocationType.Regular,
                     name: "Zora's Ledge",
@@ -124,7 +124,7 @@ namespace Randomizer.SMZ3.Regions.Zelda.LightWorld
                     access: items => items.Flippers,
                     memoryAddress: 0x81,
                     memoryFlag: 0x40,
-                    memoryType: LocationMemoryType.ZeldaOverworld);
+                    memoryType: LocationMemoryType.ZeldaMisc);
             }
 
             public Location Zora { get; }

--- a/src/Randomizer.SMZ3/Regions/Zelda/LightWorld/LightWorldNorthWest.cs
+++ b/src/Randomizer.SMZ3/Regions/Zelda/LightWorld/LightWorldNorthWest.cs
@@ -16,14 +16,14 @@ namespace Randomizer.SMZ3.Regions.Zelda.LightWorld
                 access: items => World.CanAquireAll(items, Reward.PendantGreen, Reward.PendantNonGreen),
                 memoryAddress: 0x80,
                 memoryFlag: 0x40,
-                memoryType: LocationMemoryType.ZeldaOverworld);
+                memoryType: LocationMemoryType.ZeldaMisc);
 
             Mushroom = new Location(this, 256 + 15, 0x308013, LocationType.Regular,
                 name: "Mushroom",
                 vanillaItem: ItemType.Mushroom,
-                memoryAddress: 0x1,
+                memoryAddress: 0x191,
                 memoryFlag: 0x10,
-                memoryType: LocationMemoryType.ZeldaNPC)
+                memoryType: LocationMemoryType.ZeldaMisc)
                 .Weighted(SphereOne);
 
             LostWoodsHideout = new Location(this, 256 + 16, 0x308000, LocationType.Regular,
@@ -67,7 +67,7 @@ namespace Randomizer.SMZ3.Regions.Zelda.LightWorld
             BottleMerchant = new Location(this, 256 + 31, 0x5EB18, LocationType.Regular,
                 name: "Bottle Merchant",
                 vanillaItem: ItemType.Bottle,
-                memoryAddress: 0xC9,
+                memoryAddress: 0x149,
                 memoryFlag: 0x2,
                 memoryType: LocationMemoryType.ZeldaMisc)
                 .Weighted(SphereOne);
@@ -85,9 +85,9 @@ namespace Randomizer.SMZ3.Regions.Zelda.LightWorld
                 alsoKnownAs: "Bug Catching Kid's House",
                 vanillaItem: ItemType.Bugnet,
                 access: items => items.Bottle,
-                memoryAddress: 0x0,
+                memoryAddress: 0x190,
                 memoryFlag: 0x4,
-                memoryType: LocationMemoryType.ZeldaNPC);
+                memoryType: LocationMemoryType.ZeldaMisc);
 
             TavernBackRoom = new Location(this, 256 + 34, 0x1E9CE, LocationType.Regular,
                 name: "Kakariko Tavern",
@@ -101,9 +101,9 @@ namespace Randomizer.SMZ3.Regions.Zelda.LightWorld
                 name: "Blacksmith",
                 vanillaItem: ItemType.ProgressiveSword,
                 access: items => World.DarkWorldNorthWest.CanEnter(items) && Logic.CanLiftHeavy(items),
-                memoryAddress: 0x1,
+                memoryAddress: 0x191,
                 memoryFlag: 0x4,
-                memoryType: LocationMemoryType.ZeldaNPC);
+                memoryType: LocationMemoryType.ZeldaMisc);
 
             MagicBat = new Location(this, 256 + 35, 0x308015, LocationType.Regular,
                 name: "Magic Bat",
@@ -111,9 +111,9 @@ namespace Randomizer.SMZ3.Regions.Zelda.LightWorld
                 access: items => items.Powder
                          && (items.Hammer
                              || (items.MoonPearl && items.Mirror && Logic.CanLiftHeavy(items))),
-                memoryAddress: 0x1,
+                memoryAddress: 0x191,
                 memoryFlag: 0x80,
-                memoryType: LocationMemoryType.ZeldaNPC);
+                memoryType: LocationMemoryType.ZeldaMisc);
 
             KakarikoWell = new(this);
             BlindsHideout = new(this);

--- a/src/Randomizer.SMZ3/Regions/Zelda/LightWorld/LightWorldSouth.cs
+++ b/src/Randomizer.SMZ3/Regions/Zelda/LightWorld/LightWorldSouth.cs
@@ -14,16 +14,16 @@ namespace Randomizer.SMZ3.Regions.Zelda.LightWorld
                 vanillaItem: ItemType.HeartPiece,
                 memoryAddress: 0x28,
                 memoryFlag: 0x40,
-                memoryType: LocationMemoryType.ZeldaOverworld)
+                memoryType: LocationMemoryType.ZeldaMisc)
                 .Weighted(SphereOne);
 
             Library = new Location(this, 256 + 240, 0x308012, LocationType.Regular,
                 name: "Library",
                 vanillaItem: ItemType.Book,
                 access: items => items.Boots,
-                memoryAddress: 0x0,
+                memoryAddress: 0x190,
                 memoryFlag: 0x80,
-                memoryType: LocationMemoryType.ZeldaNPC);
+                memoryType: LocationMemoryType.ZeldaMisc);
 
             ForestClearingDigSpot = new Location(this, 256 + 241, 0x30814A, LocationType.Regular,
                 name: "Flute Spot",
@@ -32,7 +32,7 @@ namespace Randomizer.SMZ3.Regions.Zelda.LightWorld
                 access: items => items.Shovel,
                 memoryAddress: 0x2A,
                 memoryFlag: 0x40,
-                memoryType: LocationMemoryType.ZeldaOverworld);
+                memoryType: LocationMemoryType.ZeldaMisc);
 
             Cave45 = new Location(this, 256 + 242, 0x308003, LocationType.Regular,
                 name: "South of Grove",
@@ -63,7 +63,7 @@ namespace Randomizer.SMZ3.Regions.Zelda.LightWorld
                 access: items => World.DesertPalace.CanEnter(items),
                 memoryAddress: 0x30,
                 memoryFlag: 0x40,
-                memoryType: LocationMemoryType.ZeldaOverworld);
+                memoryType: LocationMemoryType.ZeldaMisc);
 
             CheckerboardCave = new Location(this, 256 + 253, 0x308005, LocationType.Regular,
                 name: "Checkerboard Cave",
@@ -78,9 +78,9 @@ namespace Randomizer.SMZ3.Regions.Zelda.LightWorld
                 name: "Bombos Tablet",
                 vanillaItem: ItemType.Bombos,
                 access: items => items.Book && items.MasterSword && items.Mirror && World.DarkWorldSouth.CanEnter(items),
-                memoryAddress: 0x1,
+                memoryAddress: 0x191,
                 memoryFlag: 0x2,
-                memoryType: LocationMemoryType.ZeldaNPC);
+                memoryType: LocationMemoryType.ZeldaMisc);
 
             LakeHyliaIsland = new Location(this, 256 + 61, 0x308144, LocationType.Regular,
                 name: "Lake Hylia Island",
@@ -90,14 +90,14 @@ namespace Randomizer.SMZ3.Regions.Zelda.LightWorld
                     World.DarkWorldNorthEast.CanEnter(items)),
                 memoryAddress: 0x35,
                 memoryFlag: 0x40,
-                memoryType: LocationMemoryType.ZeldaOverworld);
+                memoryType: LocationMemoryType.ZeldaMisc);
 
             UnderTheBridge = new Location(this, 256 + 62, 0x6BE7D, LocationType.Regular,
                 name: "Hobo",
                 alsoKnownAs: "Under the bridge",
                 vanillaItem: ItemType.Bottle,
                 access: items => items.Flippers || Logic.CanHyruleSouthFakeFlippers(items, false),
-                memoryAddress: 0xC9,
+                memoryAddress: 0x149,
                 memoryFlag: 0x1,
                 memoryType: LocationMemoryType.ZeldaMisc);
 
@@ -217,7 +217,7 @@ namespace Randomizer.SMZ3.Regions.Zelda.LightWorld
                     vanillaItem: ItemType.HeartPiece,
                     memoryAddress: 0x3B,
                     memoryFlag: 0x40,
-                    memoryType: LocationMemoryType.ZeldaOverworld)
+                    memoryType: LocationMemoryType.ZeldaMisc)
                     .Weighted(SphereOne);
             }
 

--- a/src/Randomizer.Shared/Enums/LocationMemoryType.cs
+++ b/src/Randomizer.Shared/Enums/LocationMemoryType.cs
@@ -9,8 +9,6 @@ namespace Randomizer.Shared
     public enum LocationMemoryType
     {
         Default,
-        ZeldaNPC,
-        ZeldaOverworld,
         ZeldaMisc
     }
 }


### PR DESCRIPTION
Unfortunately, betus ran into some issues with auto tracking being pretty slow (sometimes taking like 30 seconds to track stuff), and even more unfortunate is that I can't reproduce the issue. DigitalBasic and Pink haven't had any issues either. This eventually seemed to culminate in the auto tracker tracking a series of locations for betus that always seem to give me problems. 🙃 

However, I do have some theories. I changed the rate of sending requests to the emulator for memory from 0.25 seconds to 0.1 seconds between last week and this week. And while the USB2SNES connection will only have one request out there at a time due to the USB2SNES limitation of not returning any sort of identifiable information in the response, the Lua connection will send out messages to the emulator continuously, even if it's still waiting on a response since it can identify which action the response belongs to.

I think for whatever reason betus's emulator/lua script was being sluggish in handling requests, and the auto tracker just kept piling them on. This caused it to be rather sporadic in response timing. I reviewed betus's logs, and the thing that corroborates this theory is during the run it identified that betus switched to Super Metroid but after that it processed the Zelda NPC locations which messed up. I tested the logic around sending messages and confirmed that tracker doesn't send Zelda related memory requests to the emulator while in Super Metroid, but my code previously did not validate responses from the emulator to make sure that the player is still in the game for the response. Therefore the only thing that would make sense is if the emulator (or lua script) was being sluggish in processing requests from the auto tracker and sent this well after when the request was originally made and betus had switched games.

Admittedly this theory doesn't explain everything, such as why sometimes Zelda checks came through fairly quickly. But, it's the best I've got without being able to replicate the issue at hand.

My approach to resolving is as follows:

- Each connector now has a method to determine if it's okay to send a message based on if it has a pending request. If it does have a pending request, then the send messages loop will wait to try again. So only one request will be out there at a time.
- When a response comes in, it's validated that the player is in the correct game. This theoretically isn't an issue anymore as it wouldn't even detect that the player has changed games while a different request is pending, but I figured it's best practice to keep it.
- While I'm keeping the .1s timer for the loop on sending messages, the messages may be delayed if requests haven't come back yet. To hopefully minimize latency in detecting some memory events, I have merged the non Zelda room locations into a single group so that there are fewer requests that need to be made overall.
- Because of the above, there are some extra bytes in the request that change frequently, so I could no longer use the old method of validating that the data hasn't changed before clearing locations. Now I only mark locations as cleared if that particular location's memory address hasn't changed between the previous data and new data. To avoid making the same locations LINQ call every half a second or so, I store the locations associated with each action.

Sorry for the long pull request description. This was just a fun one and hard to explain. I've created a test build for betus, but I'm not sure he'll be able to test it.

This also includes some new tracker comments from Fragger as well.