### PR TITLE
State Check Rewrite

### DIFF
--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/AutoTrackerMetroidState.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/AutoTrackerMetroidState.cs
@@ -1,11 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Randomizer.SMZ3.Tracking.AutoTracking;
-
-namespace Randomizer.SMZ3.Tracking.AutoTracking
+﻿namespace Randomizer.SMZ3.Tracking.AutoTracking
 {
     /// <summary>
     /// Used to retrieve certain states based on the memory in Metroid

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/AutoTrackerViewedAction.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/AutoTrackerViewedAction.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Randomizer.SMZ3.Tracking.AutoTracking

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/AutoTrackerZeldaState.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/AutoTrackerZeldaState.cs
@@ -1,11 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Randomizer.SMZ3.Tracking.AutoTracking;
-
-namespace Randomizer.SMZ3.Tracking.AutoTracking
+﻿namespace Randomizer.SMZ3.Tracking.AutoTracking
 {
     /// <summary>
     /// Used to retrieve certain states based on the memory in Zelda

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/EmulatorAction.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/EmulatorAction.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Randomizer.SMZ3.Tracking.AutoTracking
 {

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/EmulatorDataReceivedEventArgs.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/EmulatorDataReceivedEventArgs.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Randomizer.SMZ3.Tracking.AutoTracking
+﻿namespace Randomizer.SMZ3.Tracking.AutoTracking
 {
     /// <summary>
     /// Event arguments for when connector has received data from the emulator

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/EmulatorDataReceivedEventHandler.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/EmulatorDataReceivedEventHandler.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Randomizer.SMZ3.Tracking.AutoTracking
+﻿namespace Randomizer.SMZ3.Tracking.AutoTracking
 {
     /// <summary>
     /// Event for when the connector has received data from the emulator

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/EmulatorMemoryData.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/EmulatorMemoryData.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Linq;
 
 namespace Randomizer.SMZ3.Tracking.AutoTracking
 {
@@ -83,7 +79,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// <returns>The value from the byte array at that location</returns>
         public int ReadUInt16(int location)
         {
-            return _bytes[location + 1] * 256 +  _bytes[location];
+            return _bytes[location + 1] * 256 + _bytes[location];
         }
 
         /// <summary>

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/Enums/EmulatorActionType.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/Enums/EmulatorActionType.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Randomizer.SMZ3.Tracking.AutoTracking
+﻿namespace Randomizer.SMZ3.Tracking.AutoTracking
 {
     /// <summary>
     /// The type of action

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/Enums/EmulatorConnectorType.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/Enums/EmulatorConnectorType.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.ComponentModel;
 
 namespace Randomizer.SMZ3.Tracking.AutoTracking
 {

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/Enums/Game.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/Enums/Game.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Randomizer.SMZ3.Tracking.AutoTracking
+﻿namespace Randomizer.SMZ3.Tracking.AutoTracking
 {
     /// <summary>
     /// Which game(s) the message should be sent to the emulator in

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/Enums/MemoryDomain.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/Enums/MemoryDomain.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Randomizer.SMZ3.Tracking.AutoTracking
+﻿namespace Randomizer.SMZ3.Tracking.AutoTracking
 {
     /// <summary>
     /// The type of memory

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/IEmulatorConnector.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/IEmulatorConnector.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Randomizer.SMZ3.Tracking.AutoTracking
 {

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/LuaConnector.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/LuaConnector.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/LuaMessage.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/LuaMessage.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Randomizer.SMZ3.Tracking.AutoTracking
+﻿namespace Randomizer.SMZ3.Tracking.AutoTracking
 {
     public class LuaMessage
     {

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/MetroidStateChecks/ChangedMetroidRegion.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/MetroidStateChecks/ChangedMetroidRegion.cs
@@ -1,0 +1,34 @@
+﻿using System.Linq;
+
+namespace Randomizer.SMZ3.Tracking.AutoTracking.MetroidStateChecks
+{
+    /// <summary>
+    /// Metroid state check for changing regions
+    /// Checks if the game is in the overworld state and was either not in the overworld state previously or has changed overworld screens
+    /// </summary>
+    public class ChangedMetroidRegion : MetroidStateCheck
+    {
+        private int _previousMetroidRegionValue = -1;
+
+        /// <summary>
+        /// Executes the check for the current state
+        /// </summary>
+        /// <param name="tracker">The tracker instance</param>
+        /// <param name="currentState">The current state in Zelda</param>
+        /// <param name="prevState">The previous state in Zelda</param>
+        public override bool ExecuteCheck(Tracker tracker, AutoTrackerMetroidState currentState, AutoTrackerMetroidState prevState)
+        {
+            if (currentState.CurrentRegion != _previousMetroidRegionValue)
+            {
+                var newRegion = tracker.World.Regions.Select(x => x as SMRegion).FirstOrDefault(x => x != null && x.MemoryRegionId == currentState.CurrentRegion);
+                if (newRegion != null)
+                {
+                    tracker.UpdateRegion(newRegion, tracker.Options.AutoTrackerChangeMap);
+                }
+                _previousMetroidRegionValue = currentState.CurrentRegion;
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/MetroidStateChecks/ChangedMetroidRegion.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/MetroidStateChecks/ChangedMetroidRegion.cs
@@ -18,7 +18,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking.MetroidStateChecks
         /// <param name="prevState">The previous state in Zelda</param>
         public override bool ExecuteCheck(Tracker tracker, AutoTrackerMetroidState currentState, AutoTrackerMetroidState prevState)
         {
-            if (currentState.CurrentRegion != _previousMetroidRegionValue)
+            if (currentState.CurrentRegion != _previousMetroidRegionValue || tracker.CurrentRegion.GetRegion(tracker.World) is Z3Region)
             {
                 var newRegion = tracker.World.Regions.Select(x => x as SMRegion).FirstOrDefault(x => x != null && x.MemoryRegionId == currentState.CurrentRegion);
                 if (newRegion != null)

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/MetroidStateChecks/Crocomire.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/MetroidStateChecks/Crocomire.cs
@@ -1,0 +1,25 @@
+﻿namespace Randomizer.SMZ3.Tracking.AutoTracking.MetroidStateChecks
+{
+    /// <summary>
+    /// Metroid state check for nearing Crocomire
+    /// Player is in the room above Crocomire and is near the door to Crocomire
+    /// </summary>
+    public class Crocomire : MetroidStateCheck
+    {
+        /// <summary>
+        /// Executes the check for the current state
+        /// </summary>
+        /// <param name="tracker">The tracker instance</param>
+        /// <param name="currentState">The current state in Zelda</param>
+        /// <param name="prevState">The previous state in Zelda</param>
+        public override bool ExecuteCheck(Tracker tracker, AutoTrackerMetroidState currentState, AutoTrackerMetroidState prevState)
+        {
+            if (currentState.CurrentRegion == 2 && currentState.CurrentRoomInRegion == 9 && currentState.SamusX >= 3000 && currentState.SamusY > 500)
+            {
+                tracker.SayOnce(x => x.AutoTracker.NearCrocomire, currentState.SuperMissiles, currentState.MaxSuperMissiles);
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/MetroidStateChecks/KraidsAwfulSon.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/MetroidStateChecks/KraidsAwfulSon.cs
@@ -1,0 +1,27 @@
+﻿namespace Randomizer.SMZ3.Tracking.AutoTracking.MetroidStateChecks
+{
+    /// <summary>
+    /// Metroid state check for nearing Kraid's awful son
+    /// Player enters the same room as KAD from the left
+    /// </summary>
+    public class KraidsAwfulSon : MetroidStateCheck
+    {
+        private int _previousMetroidRegionValue = -1;
+
+        /// <summary>
+        /// Executes the check for the current state
+        /// </summary>
+        /// <param name="tracker">The tracker instance</param>
+        /// <param name="currentState">The current state in Zelda</param>
+        /// <param name="prevState">The previous state in Zelda</param>
+        public override bool ExecuteCheck(Tracker tracker, AutoTrackerMetroidState currentState, AutoTrackerMetroidState prevState)
+        {
+            if (currentState.CurrentRegion == 1 && currentState.CurrentRoomInRegion == 45 && prevState.CurrentRoomInRegion == 44)
+            {
+                tracker.SayOnce(x => x.AutoTracker.NearKraidsAwfulSon);
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/MetroidStateChecks/MetroidDeath.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/MetroidStateChecks/MetroidDeath.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Linq;
+
+namespace Randomizer.SMZ3.Tracking.AutoTracking.MetroidStateChecks
+{
+    /// <summary>
+    /// Metroid state check for detecting deaths in Metroid
+    /// Checks if the player has 0 health and 0 reserve tanks
+    /// </summary>
+    public class MetroidDeath : MetroidStateCheck
+    {
+        /// <summary>
+        /// Executes the check for the current state
+        /// </summary>
+        /// <param name="tracker">The tracker instance</param>
+        /// <param name="currentState">The current state in Zelda</param>
+        /// <param name="prevState">The previous state in Zelda</param>
+        public override bool ExecuteCheck(Tracker tracker, AutoTrackerMetroidState currentState, AutoTrackerMetroidState prevState)
+        {
+            if (currentState.Health == 0 && currentState.ReserveTanks == 0 && prevState.Health != 0 && !(currentState.CurrentRoom == 0 && currentState.CurrentRegion == 0 && currentState.SamusY == 0))
+            {
+                var region = tracker.World.Regions.Select(x => x as SMRegion)
+                    .Where(x => x != null && x.MemoryRegionId == currentState.CurrentRegion)
+                    .Select(x => tracker.WorldInfo.Regions.FirstOrDefault(y => y.GetRegion(tracker.World) == x && y.WhenDiedInRoom != null))
+                    .FirstOrDefault(x => x != null && x.WhenDiedInRoom != null && x.WhenDiedInRoom.ContainsKey(currentState.CurrentRoomInRegion.ToString()));
+                if (region != null)
+                {
+                    tracker.SayOnce(region.WhenDiedInRoom[currentState.CurrentRoomInRegion.ToString()]);
+                }
+                tracker.TrackItem(tracker.Items.First(x => x.ToString().Equals("Death", StringComparison.OrdinalIgnoreCase)));
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/MetroidStateChecks/MetroidStateCheck.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/MetroidStateChecks/MetroidStateCheck.cs
@@ -1,0 +1,16 @@
+﻿namespace Randomizer.SMZ3.Tracking.AutoTracking.MetroidStateChecks
+{
+    /// <summary>
+    /// Abstract class for various Metroid state checks
+    /// </summary>
+    public abstract class MetroidStateCheck
+    {
+        /// <summary>
+        /// Executes the check for the current state
+        /// </summary>
+        /// <param name="tracker">The tracker instance</param>
+        /// <param name="currentState">The current state in Zelda</param>
+        /// <param name="prevState">The previous state in Zelda</param>
+        public abstract bool ExecuteCheck(Tracker tracker, AutoTrackerMetroidState currentState, AutoTrackerMetroidState prevState);
+    }
+}

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/MetroidStateChecks/Mockball.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/MetroidStateChecks/Mockball.cs
@@ -1,0 +1,34 @@
+﻿using Randomizer.Shared;
+
+namespace Randomizer.SMZ3.Tracking.AutoTracking.MetroidStateChecks
+{
+    /// <summary>
+    /// Metroid state check for performing the Mockball trick
+    /// Player gets past the speed gates without the speedbooster
+    /// </summary>
+    public class Mockball : MetroidStateCheck
+    {
+        /// <summary>
+        /// Executes the check for the current state
+        /// </summary>
+        /// <param name="tracker">The tracker instance</param>
+        /// <param name="currentState">The current state in Zelda</param>
+        /// <param name="prevState">The previous state in Zelda</param>
+        public override bool ExecuteCheck(Tracker tracker, AutoTrackerMetroidState currentState, AutoTrackerMetroidState prevState)
+        {
+            // Brinstar Mockball
+            if (currentState.CurrentRegion == 1 && currentState.CurrentRoomInRegion == 3 && currentState.SamusX >= 560 && prevState.SamusX < 560 && currentState.SamusX < 800 && tracker.FindItemByType(ItemType.SpeedBooster)?.TrackingState == 0)
+            {
+                tracker.SayOnce(x => x.AutoTracker.MockBall);
+                return true;
+            }
+            // Norfair Mockball
+            else if (currentState.CurrentRegion == 2 && currentState.CurrentRoomInRegion == 4 && currentState.SamusX <= 1016 && prevState.SamusX > 1016 && currentState.SamusX > 800 && tracker.FindItemByType(ItemType.SpeedBooster)?.TrackingState == 0)
+            {
+                tracker.SayOnce(x => x.AutoTracker.MockBall);
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/MetroidStateChecks/Ridley.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/MetroidStateChecks/Ridley.cs
@@ -1,0 +1,25 @@
+﻿namespace Randomizer.SMZ3.Tracking.AutoTracking.MetroidStateChecks
+{
+    /// <summary>
+    /// Metroid state check related to greeting the Ridley face
+    /// Player is in that room and has reached the face
+    /// </summary>
+    public class Ridley : MetroidStateCheck
+    {
+        /// <summary>
+        /// Executes the check for the current state
+        /// </summary>
+        /// <param name="tracker">The tracker instance</param>
+        /// <param name="currentState">The current state in Zelda</param>
+        /// <param name="prevState">The previous state in Zelda</param>
+        public override bool ExecuteCheck(Tracker tracker, AutoTrackerMetroidState currentState, AutoTrackerMetroidState prevState)
+        {
+            if (currentState.CurrentRegion == 2 && currentState.CurrentRoomInRegion == 37 && currentState.SamusX <= 375 && currentState.SamusX >= 100 && currentState.SamusY <= 200)
+            {
+                tracker.SayOnce(x => x.AutoTracker.RidleyFace);
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/MetroidStateChecks/Shaktool.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/MetroidStateChecks/Shaktool.cs
@@ -1,0 +1,25 @@
+﻿namespace Randomizer.SMZ3.Tracking.AutoTracking.MetroidStateChecks
+{
+    /// <summary>
+    /// Metroid state check for nearing Shaktool
+    /// Player enters the room with the grapple block from the left
+    /// </summary>
+    public class Shaktool : MetroidStateCheck
+    {
+        /// <summary>
+        /// Executes the check for the current state
+        /// </summary>
+        /// <param name="tracker">The tracker instance</param>
+        /// <param name="currentState">The current state in Zelda</param>
+        /// <param name="prevState">The previous state in Zelda</param>
+        public override bool ExecuteCheck(Tracker tracker, AutoTrackerMetroidState currentState, AutoTrackerMetroidState prevState)
+        {
+            if (currentState.CurrentRegion == 4 && currentState.CurrentRoomInRegion == 36 && prevState.CurrentRoomInRegion == 28)
+            {
+                tracker.SayOnce(x => x.AutoTracker.NearShaktool);
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/MetroidStateChecks/SporeSpawn.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/MetroidStateChecks/SporeSpawn.cs
@@ -1,0 +1,25 @@
+﻿namespace Randomizer.SMZ3.Tracking.AutoTracking.MetroidStateChecks
+{
+    /// <summary>
+    /// Metroid state check related to Spore Spawn
+    /// Checks if the player skips Spore Spawn
+    /// </summary>
+    public class SporeSpawn : MetroidStateCheck
+    {
+        /// <summary>
+        /// Executes the check for the current state
+        /// </summary>
+        /// <param name="tracker">The tracker instance</param>
+        /// <param name="currentState">The current state in Zelda</param>
+        /// <param name="prevState">The previous state in Zelda</param>
+        public override bool ExecuteCheck(Tracker tracker, AutoTrackerMetroidState currentState, AutoTrackerMetroidState prevState)
+        {
+            if (currentState.CurrentRegion == 1 && currentState.CurrentRoomInRegion == 22 && prevState.CurrentRoomInRegion == 9)
+            {
+                tracker.SayOnce(x => x.AutoTracker.SkipSporeSpawn);
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/USB2SNESConnector.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/USB2SNESConnector.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.WebSockets;
-using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -111,7 +110,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
                     Operands = new List<string>() { address, length }
                 }));
             }
-            
+
         }
 
         /// <summary>

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/USB2SNESRequest.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/USB2SNESRequest.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace Randomizer.SMZ3.Tracking.AutoTracking
 {

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/USB2SNESResponse.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/USB2SNESResponse.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace Randomizer.SMZ3.Tracking.AutoTracking
 {

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/ChangedOverworld.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/ChangedOverworld.cs
@@ -1,0 +1,32 @@
+﻿using System.Linq;
+
+namespace Randomizer.SMZ3.Tracking.AutoTracking.ZeldaStateChecks
+{
+    /// <summary>
+    /// Zelda State check for changing overworld locations
+    /// Checks if the game is in the overworld state and was either not in the overworld state previously or has changed overworld screens
+    /// </summary>
+    public class ChangedOverworld : ZeldaStateCheck
+    {
+        /// <summary>
+        /// Executes the check for the current state
+        /// </summary>
+        /// <param name="tracker">The tracker instance</param>
+        /// <param name="currentState">The current state in Zelda</param>
+        /// <param name="prevState">The previous state in Zelda</param>
+        public override bool ExecuteCheck(Tracker tracker, AutoTrackerZeldaState currentState, AutoTrackerZeldaState prevState)
+        {
+            if (currentState.State == 0x09 && (prevState.State != 0x09 || currentState.OverworldScreen != prevState.OverworldScreen))
+            {
+                var region = tracker.World.Regions.Where(x => x is Z3Region)
+                    .Select(x => x as Z3Region)
+                    .FirstOrDefault(x => x != null && x.StartingRooms != null && x.StartingRooms.Contains(currentState.OverworldScreen) && x.IsOverworld);
+                if (region == null) return false;
+
+                tracker.UpdateRegion(region, tracker.Options.AutoTrackerChangeMap);
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/DiverDown.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/DiverDown.cs
@@ -1,0 +1,32 @@
+﻿namespace Randomizer.SMZ3.Tracking.AutoTracking.ZeldaStateChecks
+{
+    /// <summary>
+    /// Zelda State check for performing the diver down trick
+    /// Player is walking the lower water area from an unexpected direction
+    /// </summary>
+    public class DiverDown : ZeldaStateCheck
+    {
+        /// <summary>
+        /// Executes the check for the current state
+        /// </summary>
+        /// <param name="tracker">The tracker instance</param>
+        /// <param name="currentState">The current state in Zelda</param>
+        /// <param name="prevState">The previous state in Zelda</param>
+        public override bool ExecuteCheck(Tracker tracker, AutoTrackerZeldaState currentState, AutoTrackerZeldaState prevState)
+        {
+            // Back diver down
+            if (currentState.CurrentRoom == 118 && currentState.LinkX < 3474 && (currentState.LinkX < 3400 || currentState.LinkX > 3430) && currentState.LinkY <= 3975 && prevState.LinkY > 3975 && (currentState.LinkState is 0 or 6 or 3) && currentState.IsOnBottomHalfOfroom && currentState.IsOnRightHalfOfRoom)
+            {
+                tracker.SayOnce(x => x.AutoTracker.DiverDown);
+                return true;
+            }
+            // Left side diver down
+            else if (currentState.CurrentRoom == 53 && currentState.PreviousRoom == 54 && currentState.LinkX > 2800 && currentState.LinkX < 2850 && currentState.LinkY <= 1915 && prevState.LinkY > 1915 && (currentState.LinkState is 0 or 6 or 3))
+            {
+                tracker.SayOnce(x => x.AutoTracker.DiverDown);
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/EnteredDungeon.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/EnteredDungeon.cs
@@ -1,0 +1,65 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Randomizer.Shared;
+using Randomizer.SMZ3.Regions;
+using Randomizer.SMZ3.Regions.Zelda;
+using Randomizer.SMZ3.Tracking.Configuration;
+
+namespace Randomizer.SMZ3.Tracking.AutoTracking.ZeldaStateChecks
+{
+    /// <summary>
+    /// Zelda State check for detecting entering a dungeon
+    /// Player is now in the dungeon state from the overworld in one of the designated starting rooms
+    /// </summary>
+    public class EnteredDungeon : ZeldaStateCheck
+    {
+        private readonly HashSet<DungeonInfo> _enteredDungeons = new();
+
+        /// <summary>
+        /// Executes the check for the current state
+        /// </summary>
+        /// <param name="tracker">The tracker instance</param>
+        /// <param name="currentState">The current state in Zelda</param>
+        /// <param name="prevState">The previous state in Zelda</param>
+        public override bool ExecuteCheck(Tracker tracker, AutoTrackerZeldaState currentState, AutoTrackerZeldaState prevState)
+        {
+            if (currentState.State == 0x07 && (prevState.State == 0x06 || prevState.State == 0x09 || prevState.State == 0x0F || prevState.State == 0x10 || prevState.State == 0x11))
+            {
+                // Get the region for the room 
+                var region = tracker.World.Regions.Where(x => x is Z3Region)
+                    .Select(x => x as Z3Region)
+                    .FirstOrDefault(x => x != null && x.StartingRooms != null && x.StartingRooms.Contains(currentState.CurrentRoom) && !x.IsOverworld);
+                if (region == null) return false;
+
+                // Get the dungeon info for the room
+                var dungeonInfo = tracker.WorldInfo.Dungeons.First(x => x.Is(region));
+
+                if (!_enteredDungeons.Contains(dungeonInfo) && (dungeonInfo.Reward == RewardItem.RedPendant || dungeonInfo.Reward == RewardItem.GreenPendant || dungeonInfo.Reward == RewardItem.BluePendant))
+                {
+                    tracker.Say(tracker.Responses.AutoTracker.EnterPendantDungeon, dungeonInfo.Name, dungeonInfo.Reward.GetName());
+                }
+                else if (region is CastleTower)
+                {
+                    tracker.Say(x => x.AutoTracker.EnterHyruleCastleTower);
+                }
+                else if (region is GanonsTower)
+                {
+                    var clearedCrystalDungeonCount = tracker.WorldInfo.Dungeons
+                                                        .Where(x => x.Cleared)
+                                                        .Select(x => x.GetRegion(tracker.World) as IHasReward)
+                                                        .Count(x => x != null && x.Reward is Reward.CrystalBlue or Reward.CrystalRed);
+                    if (clearedCrystalDungeonCount < 7)
+                    {
+                        tracker.SayOnce(x => x.AutoTracker.EnteredGTEarly, clearedCrystalDungeonCount);
+                    }
+                }
+
+                tracker.UpdateRegion(region, tracker.Options.AutoTrackerChangeMap);
+                _enteredDungeons.Add(dungeonInfo);
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/FakeFlippers.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/FakeFlippers.cs
@@ -1,0 +1,28 @@
+﻿using System.Linq;
+using Randomizer.Shared;
+
+namespace Randomizer.SMZ3.Tracking.AutoTracking.ZeldaStateChecks
+{
+    /// <summary>
+    /// Zelda State check for performing fake flippers
+    /// Checks if the player is in the swimming state for two states without the flippers
+    /// </summary>
+    public class FakeFlippers : ZeldaStateCheck
+    {
+        /// <summary>
+        /// Executes the check for the current state
+        /// </summary>
+        /// <param name="tracker">The tracker instance</param>
+        /// <param name="currentState">The current state in Zelda</param>
+        /// <param name="prevState">The previous state in Zelda</param>
+        public override bool ExecuteCheck(Tracker tracker, AutoTrackerZeldaState currentState, AutoTrackerZeldaState prevState)
+        {
+            if (currentState.LinkState == 0x04 && prevState.LinkState == 0x04 && tracker.Items.Any(x => x.InternalItemType == ItemType.Flippers && x.TrackingState == 0))
+            {
+                tracker.SayOnce(x => x.AutoTracker.FakeFlippers);
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/FallFromGanon.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/FallFromGanon.cs
@@ -1,0 +1,25 @@
+﻿namespace Randomizer.SMZ3.Tracking.AutoTracking.ZeldaStateChecks
+{
+    /// <summary>
+    /// Zelda State check for falling from Ganon's room
+    /// Checks if the current room is the one below Ganon and the previous room was the Ganon room
+    /// </summary>
+    public class FallFromGanon : ZeldaStateCheck
+    {
+        /// <summary>
+        /// Executes the check for the current state
+        /// </summary>
+        /// <param name="tracker">The tracker instance</param>
+        /// <param name="currentState">The current state in Zelda</param>
+        /// <param name="prevState">The previous state in Zelda</param>
+        public override bool ExecuteCheck(Tracker tracker, AutoTrackerZeldaState currentState, AutoTrackerZeldaState prevState)
+        {
+            if (currentState.CurrentRoom == 16 && currentState.PreviousRoom == 0 && prevState.CurrentRoom == 0)
+            {
+                tracker.SayOnce(x => x.AutoTracker.FallFromGanon);
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/FallFromMoldorm.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/FallFromMoldorm.cs
@@ -1,0 +1,25 @@
+﻿namespace Randomizer.SMZ3.Tracking.AutoTracking.ZeldaStateChecks
+{
+    /// <summary>
+    /// Zelda State check for falling from the moldorm room(s)
+    /// Checks if the current room is the one below moldorm and the previous room was the moldorm room
+    /// </summary>
+    public class FallFromMoldorm : ZeldaStateCheck
+    {
+        /// <summary>
+        /// Executes the check for the current state
+        /// </summary>
+        /// <param name="tracker">The tracker instance</param>
+        /// <param name="currentState">The current state in Zelda</param>
+        /// <param name="prevState">The previous state in Zelda</param>
+        public override bool ExecuteCheck(Tracker tracker, AutoTrackerZeldaState currentState, AutoTrackerZeldaState prevState)
+        {
+            if (currentState.CurrentRoom == 23 && currentState.PreviousRoom == 7 && prevState.CurrentRoom == 7)
+            {
+                tracker.SayOnce(x => x.AutoTracker.FallFromMoldorm);
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/HeraPot.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/HeraPot.cs
@@ -1,0 +1,25 @@
+﻿namespace Randomizer.SMZ3.Tracking.AutoTracking.ZeldaStateChecks
+{
+    /// <summary>
+    /// Zelda State check for breaking into the Tower of Hera pot
+    /// player is in the pot room and did not get there from falling from the two rooms above it
+    /// </summary>
+    public class HeraPot : ZeldaStateCheck
+    {
+        /// <summary>
+        /// Executes the check for the current state
+        /// </summary>
+        /// <param name="tracker">The tracker instance</param>
+        /// <param name="currentState">The current state in Zelda</param>
+        /// <param name="prevState">The previous state in Zelda</param>
+        public override bool ExecuteCheck(Tracker tracker, AutoTrackerZeldaState currentState, AutoTrackerZeldaState prevState)
+        {
+            if (currentState.CurrentRoom == 167 && prevState.CurrentRoom == 119 && prevState.PreviousRoom != 49)
+            {
+                tracker.SayOnce(x => x.AutoTracker.HeraPot);
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/IceBreaker.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/IceBreaker.cs
@@ -1,0 +1,25 @@
+﻿namespace Randomizer.SMZ3.Tracking.AutoTracking.ZeldaStateChecks
+{
+    /// <summary>
+    /// Zelda State check for performing the ice breaker trick
+    /// player is on the right side of the wall but was previous in the room to the left
+    /// </summary>
+    public class IceBreaker : ZeldaStateCheck
+    {
+        /// <summary>
+        /// Executes the check for the current state
+        /// </summary>
+        /// <param name="tracker">The tracker instance</param>
+        /// <param name="currentState">The current state in Zelda</param>
+        /// <param name="prevState">The previous state in Zelda</param>
+        public override bool ExecuteCheck(Tracker tracker, AutoTrackerZeldaState currentState, AutoTrackerZeldaState prevState)
+        {
+            if (currentState.CurrentRoom == 31 && currentState.PreviousRoom == 30 && currentState.LinkX >= 8000 && prevState.LinkX < 8000 && currentState.IsOnRightHalfOfRoom && prevState.IsOnRightHalfOfRoom)
+            {
+                tracker.SayOnce(x => x.AutoTracker.IceBreaker);
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/ViewedMap.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/ViewedMap.cs
@@ -1,0 +1,140 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Randomizer.Shared;
+using Randomizer.SMZ3.Regions.Zelda.DarkWorld;
+using Randomizer.SMZ3.Regions.Zelda.DarkWorld.DeathMountain;
+using Randomizer.SMZ3.Regions.Zelda.LightWorld;
+using Randomizer.SMZ3.Regions.Zelda.LightWorld.DeathMountain;
+
+namespace Randomizer.SMZ3.Tracking.AutoTracking.ZeldaStateChecks
+{
+    /// <summary>
+    /// Zelda State check for viewing the map
+    /// Checks if the game state is viewing the map and the value for viewing the full map is set
+    /// </summary>
+    public class ViewedMap : ZeldaStateCheck
+    {
+        private Tracker? _tracker;
+
+        /// <summary>
+        /// Executes the check for the current state
+        /// </summary>
+        /// <param name="tracker">The tracker instance</param>
+        /// <param name="currentState">The current state in Zelda</param>
+        /// <param name="prevState">The previous state in Zelda</param>
+        public override bool ExecuteCheck(Tracker tracker, AutoTrackerZeldaState currentState, AutoTrackerZeldaState prevState)
+        {
+            if (currentState.State == 14 && currentState.Substate == 7 && currentState.ReadUInt8(0xE0) == 0x80 && (tracker.AutoTracker.LatestViewAction == null || !tracker.AutoTracker.LatestViewAction.IsValid))
+            {
+                _tracker = tracker;
+                var currentRegion = tracker.CurrentRegion?.GetRegion(tracker.World);
+                if (currentRegion is LightWorldNorthWest or LightWorldNorthEast or LightWorldSouth or LightWorldDeathMountainEast or LightWorldDeathMountainWest)
+                {
+                    tracker.AutoTracker.LatestViewAction = new AutoTrackerViewedAction(UpdateLightWorldRewards);
+                }
+                else if (currentRegion is DarkWorldNorthWest or DarkWorldNorthEast or DarkWorldSouth or DarkWorldMire or DarkWorldDeathMountainEast or DarkWorldDeathMountainWest)
+                {
+                    tracker.AutoTracker.LatestViewAction = new AutoTrackerViewedAction(UpdateDarkWorldRewards);
+                }
+                
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Marks all of the rewards for the light world dungeons
+        /// </summary>
+        private void UpdateLightWorldRewards()
+        {
+            if (_tracker == null) return;
+            var rewards = new List<Reward>();
+
+            var ep = _tracker.World.EasternPalace;
+            var epInfo = _tracker.WorldInfo.Dungeons.First(x => x.Is(ep));
+            rewards.Add(ep.Reward);
+
+            var dp = _tracker.World.DesertPalace;
+            var dpInfo = _tracker.WorldInfo.Dungeons.First(x => x.Is(dp));
+            rewards.Add(dp.Reward);
+
+            var toh = _tracker.World.TowerOfHera;
+            var tohInfo = _tracker.WorldInfo.Dungeons.First(x => x.Is(toh));
+            rewards.Add(toh.Reward);
+
+            if (rewards.Count(x => x == Reward.CrystalRed || x == Reward.CrystalBlue) == 3)
+            {
+                _tracker.SayOnce(x => x.AutoTracker.LightWorldAllCrystals);
+            }
+
+            _tracker.SetDungeonReward(epInfo, ConvertReward(ep.Reward));
+            _tracker.SetDungeonReward(dpInfo, ConvertReward(dp.Reward));
+            _tracker.SetDungeonReward(tohInfo, ConvertReward(toh.Reward));
+        }
+
+        /// <summary>
+        /// Marks all of the rewards for the dark world dungeons
+        /// </summary>
+        protected void UpdateDarkWorldRewards()
+        {
+            if (_tracker == null) return;
+
+            var pod = _tracker.World.PalaceOfDarkness;
+            var podInfo = _tracker.WorldInfo.Dungeons.First(x => x.Is(pod));
+
+            var sp = _tracker.World.SwampPalace;
+            var spInfo = _tracker.WorldInfo.Dungeons.First(x => x.Is(sp));
+
+            var sw = _tracker.World.SkullWoods;
+            var swInfo = _tracker.WorldInfo.Dungeons.First(x => x.Is(sw));
+
+            var tt = _tracker.World.ThievesTown;
+            var ttInfo = _tracker.WorldInfo.Dungeons.First(x => x.Is(tt));
+
+            var ip = _tracker.World.IcePalace;
+            var ipInfo = _tracker.WorldInfo.Dungeons.First(x => x.Is(ip));
+
+            var mm = _tracker.World.MiseryMire;
+            var mmInfo = _tracker.WorldInfo.Dungeons.First(x => x.Is(mm));
+
+            var tr = _tracker.World.TurtleRock;
+            var trInfo = _tracker.WorldInfo.Dungeons.First(x => x.Is(tr));
+
+            if (mm.Reward != Reward.CrystalRed && mm.Reward != Reward.CrystalBlue && tr.Reward != Reward.CrystalRed && tr.Reward != Reward.CrystalBlue)
+            {
+                _tracker.SayOnce(x => x.AutoTracker.DarkWorldNoMedallions);
+            }
+
+            _tracker.SetDungeonReward(podInfo, ConvertReward(pod.Reward));
+            _tracker.SetDungeonReward(spInfo, ConvertReward(sp.Reward));
+            _tracker.SetDungeonReward(swInfo, ConvertReward(sw.Reward));
+            _tracker.SetDungeonReward(ttInfo, ConvertReward(tt.Reward));
+            _tracker.SetDungeonReward(ipInfo, ConvertReward(ip.Reward));
+            _tracker.SetDungeonReward(mmInfo, ConvertReward(mm.Reward));
+            _tracker.SetDungeonReward(trInfo, ConvertReward(tr.Reward));
+        }
+
+        /// <summary>
+        /// Converts Rewards to RewardItems
+        /// TODO: Try to figure out how to determine between blue and red pendants
+        /// </summary>
+        /// <param name="reward"></param>
+        /// <returns></returns>
+        private RewardItem ConvertReward(Reward reward)
+        {
+            switch (reward)
+            {
+                case Reward.CrystalRed:
+                    return RewardItem.RedCrystal;
+                case Reward.CrystalBlue:
+                    return RewardItem.Crystal;
+                case Reward.PendantGreen:
+                    return RewardItem.GreenPendant;
+                case Reward.PendantNonGreen:
+                    return RewardItem.RedPendant;
+                default:
+                    return RewardItem.Unknown;
+            }
+        }
+    }
+}

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/ZeldaDeath.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/ZeldaDeath.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Linq;
+
+namespace Randomizer.SMZ3.Tracking.AutoTracking.ZeldaStateChecks
+{
+    /// <summary>
+    /// Zelda State check for when dying
+    /// Checks if the player is in the death spiral animation without a fairy
+    /// </summary>
+    public class ZeldaDeath : ZeldaStateCheck
+    {
+        /// <summary>
+        /// Executes the check for the current state
+        /// </summary>
+        /// <param name="tracker">The tracker instance</param>
+        /// <param name="currentState">The current state in Zelda</param>
+        /// <param name="prevState">The previous state in Zelda</param>
+        public override bool ExecuteCheck(Tracker tracker, AutoTrackerZeldaState currentState, AutoTrackerZeldaState prevState)
+        {
+            if (currentState.State == 0x12 && prevState.State != 0x12 && !tracker.AutoTracker.PlayerHasFairy)
+            {
+                // Say specific message for dying in the particular screen/room the player is in
+                if (tracker.CurrentRegion != null && tracker.CurrentRegion.WhenDiedInRoom != null)
+                {
+                    var region = tracker.CurrentRegion.GetRegion(tracker.World) as Z3Region;
+                    if (region != null && region.IsOverworld && tracker.CurrentRegion.WhenDiedInRoom.ContainsKey(prevState.OverworldScreen.ToString()))
+                    {
+                        tracker.Say(tracker.CurrentRegion.WhenDiedInRoom[prevState.OverworldScreen.ToString()]);
+                    }
+                    else if (region != null && !region.IsOverworld && tracker.CurrentRegion.WhenDiedInRoom.ContainsKey(prevState.CurrentRoom.ToString()))
+                    {
+                        tracker.Say(tracker.CurrentRegion.WhenDiedInRoom[prevState.CurrentRoom.ToString()]);
+                    }
+                }
+
+                tracker.TrackItem(tracker.Items.First(x => x.ToString().Equals("Death", StringComparison.OrdinalIgnoreCase)));
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/ZeldaStateCheck.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/ZeldaStateCheck.cs
@@ -1,0 +1,16 @@
+﻿namespace Randomizer.SMZ3.Tracking.AutoTracking.ZeldaStateChecks
+{
+    /// <summary>
+    /// Abstract for Zelda state checks
+    /// </summary>
+    public abstract class ZeldaStateCheck
+    {
+        /// <summary>
+        /// Executes the check for the current state
+        /// </summary>
+        /// <param name="tracker">The tracker instance</param>
+        /// <param name="currentState">The current state in Zelda</param>
+        /// <param name="prevState">The previous state in Zelda</param>
+        public abstract bool ExecuteCheck(Tracker tracker, AutoTrackerZeldaState currentState, AutoTrackerZeldaState prevState);
+    }
+}

--- a/src/Randomizer.SMZ3.Tracking/Tracker.cs
+++ b/src/Randomizer.SMZ3.Tracking/Tracker.cs
@@ -50,6 +50,7 @@ namespace Randomizer.SMZ3.Tracking
         private string? _lastSpokenText;
         private Dictionary<string, Progression> _progression = new();
         private bool _alternateTracker;
+        private HashSet<SchrodingersString> _saidLines = new();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Tracker"/> class.
@@ -920,6 +921,78 @@ namespace Randomizer.SMZ3.Tracking
         public virtual bool Say(Func<ResponseConfig, SchrodingersString?> selectResponse, params object?[] args)
         {
             return Say(selectResponse(Responses), args);
+        }
+
+        /// <summary>
+        /// Speak a sentence using text-to-speech only one time.
+        /// </summary>
+        /// <param name="text">The possible sentences to speak.</param>
+        /// <returns>
+        /// <c>true</c> if a sentence was spoken, <c>false</c> if <paramref
+        /// name="text"/> was <c>null</c>.
+        /// </returns>
+        public virtual bool SayOnce(SchrodingersString? text)
+        {
+            if (text == null)
+                return false;
+
+            if (!_saidLines.Contains(text))
+            {
+                _saidLines.Add(text);
+                return Say(text.ToString());
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Speak a sentence using text-to-speech only one time.
+        /// </summary>
+        /// <param name="selectResponse">Selects the response to use.</param>
+        /// <returns>
+        /// <c>true</c> if a sentence was spoken, <c>false</c> if the selected
+        /// response was <c>null</c>.
+        /// </returns>
+        public virtual bool SayOnce(Func<ResponseConfig, SchrodingersString?> selectResponse)
+        {
+            return SayOnce(selectResponse(Responses));
+        }
+
+        /// <summary>
+        /// Speak a sentence using text-to-speech only one time.
+        /// </summary>
+        /// <param name="text">The possible sentences to speak.</param>
+        /// <param name="args">The arguments used to format the text.</param>
+        /// <returns>
+        /// <c>true</c> if a sentence was spoken, <c>false</c> if <paramref
+        /// name="text"/> was <c>null</c>.
+        /// </returns>
+        public virtual bool SayOnce(SchrodingersString? text, params object?[] args)
+        {
+            if (text == null)
+                return false;
+
+            if (!_saidLines.Contains(text))
+            {
+                _saidLines.Add(text);
+                return Say(text.Format(args), wait: false);
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Speak a sentence using text-to-speech only one time.
+        /// </summary>
+        /// <param name="selectResponse">Selects the response to use.</param>
+        /// <param name="args">The arguments used to format the text.</param>
+        /// <returns>
+        /// <c>true</c> if a sentence was spoken, <c>false</c> if the selected
+        /// response was <c>null</c>.
+        /// </returns>
+        public virtual bool SayOnce(Func<ResponseConfig, SchrodingersString?> selectResponse, params object?[] args)
+        {
+            return SayOnce(selectResponse(Responses), args);
         }
 
         /// <summary>

--- a/src/Randomizer.SMZ3/Progression.cs
+++ b/src/Randomizer.SMZ3/Progression.cs
@@ -66,7 +66,7 @@ namespace Randomizer.SMZ3
         public bool CardWreckedShipBoss => Contains(ItemType.CardWreckedShipBoss);
         public bool CardLowerNorfairL1 => Contains(ItemType.CardLowerNorfairL1);
         public bool CardLowerNorfairBoss => Contains(ItemType.CardLowerNorfairBoss);
-        public bool CanBlockLasers => Contains(ItemType.CardWreckedShipBoss, 3);
+        public bool CanBlockLasers => Contains(ItemType.ProgressiveShield, 3);
         public bool Sword => Contains(ItemType.ProgressiveSword);
         public bool MasterSword => Contains(ItemType.ProgressiveSword, 2);
         public bool Bow => Contains(ItemType.Bow);


### PR DESCRIPTION
This implements the change that we discussed in regards to pulling out state checks into individual classes. I created abstract classes for each game with an ExecuteCheck function that takes in Tracker, the current state, and the previous state. When the auto tracker is first instantiated, it uses reflection to spawn all of the correct classes and save them to execute over.

I wanted to do this clean up before doing any extra work, if I have time this week.

Also pushing in the laser bridge logic fix.