### PR TITLE
Update rooms and screens to uint16 instead of uint8

### DIFF
--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/AutoTrackerZeldaState.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/AutoTrackerZeldaState.cs
@@ -21,59 +21,59 @@
         /// <summary>
         /// The current room the player is in
         /// </summary>
-        public int CurrentRoom => _data.ReadUInt8(0xA0);
+        public int CurrentRoom => ReadUInt16(0xA0);
 
         /// <summary>
         /// The previous room the player was in
         /// </summary>
-        public int PreviousRoom => _data.ReadUInt8(0xA2);
+        public int PreviousRoom => ReadUInt16(0xA2);
 
         /// <summary>
         /// The state of the game (Overworld, Dungeon, etc.)
         /// </summary>
-        public int State => _data.ReadUInt8(0x10);
+        public int State => ReadUInt8(0x10);
 
         /// <summary>
         /// The secondary state value
         /// </summary>
-        public int Substate => _data.ReadUInt8(0x11);
+        public int Substate => ReadUInt8(0x11);
 
         /// <summary>
         /// The player's Y location
         /// </summary>
-        public int LinkY => _data.ReadUInt16(0x20);
+        public int LinkY => ReadUInt16(0x20);
 
         /// <summary>
         /// The player's X Location
         /// </summary>
-        public int LinkX => _data.ReadUInt16(0x22);
+        public int LinkX => ReadUInt16(0x22);
 
         /// <summary>
         /// What the player is currently doing
         /// </summary>
-        public int LinkState => _data.ReadUInt8(0x5D);
+        public int LinkState => ReadUInt8(0x5D);
 
         /// <summary>
         /// Value used to determine if the player is in the light or dark world
         /// Apparently this is used for other calculations as well, so need to be a bit careful
         /// Transitioning from Super Metroid also seems to break this until you go through a portal
         /// </summary>
-        public int OverworldValue => _data.ReadUInt8(0x7B);
+        public int OverworldValue => ReadUInt8(0x7B);
 
         /// <summary>
         /// True if Link is on the bottom half of the current room
         /// </summary>
-        public bool IsOnBottomHalfOfroom => _data.ReadUInt8(0xAA) == 2;
+        public bool IsOnBottomHalfOfroom => ReadUInt8(0xAA) == 2;
 
         /// <summary>
         /// True if Link is on the right half of the current room
         /// </summary>
-        public bool IsOnRightHalfOfRoom => _data.ReadUInt8(0xA9) == 1;
+        public bool IsOnRightHalfOfRoom => ReadUInt8(0xA9) == 1;
 
         /// <summary>
         /// The overworld screen that the player is on
         /// </summary>
-        public int OverworldScreen => _data.ReadUInt8(0x8A);
+        public int OverworldScreen => ReadUInt16(0x8A);
 
         /// <summary>
         /// Reads a specific block of memory

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/FallFromMoldorm.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/FallFromMoldorm.cs
@@ -15,7 +15,14 @@
         /// <returns>True if the check was identified, false otherwise</returns>
         public bool ExecuteCheck(Tracker tracker, AutoTrackerZeldaState currentState, AutoTrackerZeldaState prevState)
         {
+            // Tower of Hera
             if (currentState.CurrentRoom == 23 && currentState.PreviousRoom == 7 && prevState.CurrentRoom == 7)
+            {
+                tracker.SayOnce(x => x.AutoTracker.FallFromMoldorm);
+                return true;
+            }
+            // Ganon's Tower
+            else if (currentState.CurrentRoom == 166 && currentState.PreviousRoom == 77 && prevState.CurrentRoom == 77)
             {
                 tracker.SayOnce(x => x.AutoTracker.FallFromMoldorm);
                 return true;

--- a/src/Randomizer.SMZ3/Regions/Zelda/CastleTower.cs
+++ b/src/Randomizer.SMZ3/Regions/Zelda/CastleTower.cs
@@ -13,7 +13,7 @@ namespace Randomizer.SMZ3.Regions.Zelda
             Foyer = new(this);
             DarkMaze = new(this);
 
-            StartingRooms = new List<int>() { 0xE0 };
+            StartingRooms = new List<int>() { 224 };
         }
 
         public override string Name => "Castle Tower";

--- a/src/Randomizer.SMZ3/Regions/Zelda/DesertPalace.cs
+++ b/src/Randomizer.SMZ3/Regions/Zelda/DesertPalace.cs
@@ -61,7 +61,7 @@ namespace Randomizer.SMZ3.Regions.Zelda
 
             MemoryAddress = 0x33;
             MemoryFlag = 0xB;
-            StartingRooms = new List<int> { 0x63, 0x83, 0x84 };
+            StartingRooms = new List<int> { 99, 131, 132, 133 };
         }
 
         public override string Name => "Desert Palace";

--- a/src/Randomizer.SMZ3/Regions/Zelda/EasternPalace.cs
+++ b/src/Randomizer.SMZ3/Regions/Zelda/EasternPalace.cs
@@ -54,7 +54,7 @@ namespace Randomizer.SMZ3.Regions.Zelda
 
             MemoryAddress = 0xC8;
             MemoryFlag = 0xB;
-            StartingRooms = new List<int> { 0xC9 };
+            StartingRooms = new List<int> { 201 };
         }
 
         public override string Name => "Eastern Palace";

--- a/src/Randomizer.SMZ3/Regions/Zelda/HyruleCastle.cs
+++ b/src/Randomizer.SMZ3/Regions/Zelda/HyruleCastle.cs
@@ -60,7 +60,7 @@ namespace Randomizer.SMZ3.Regions.Zelda
 
             BackOfEscape = new(this);
 
-            StartingRooms = new List<int> { 0x61 };
+            StartingRooms = new List<int> { 96, 97, 98 };
         }
 
         public override string Name => "Hyrule Castle";

--- a/src/Randomizer.SMZ3/Regions/Zelda/IcePalace.cs
+++ b/src/Randomizer.SMZ3/Regions/Zelda/IcePalace.cs
@@ -76,7 +76,7 @@ namespace Randomizer.SMZ3.Regions.Zelda
 
             MemoryAddress = 0xDE;
             MemoryFlag = 0xB;
-            StartingRooms = new List<int> { 0xE };
+            StartingRooms = new List<int> { 14 };
         }
 
         public override string Name => "Ice Palace";

--- a/src/Randomizer.SMZ3/Regions/Zelda/LightWorld/LightWorldNorthWest.cs
+++ b/src/Randomizer.SMZ3/Regions/Zelda/LightWorld/LightWorldNorthWest.cs
@@ -118,7 +118,7 @@ namespace Randomizer.SMZ3.Regions.Zelda.LightWorld
             KakarikoWell = new(this);
             BlindsHideout = new(this);
 
-            StartingRooms = new List<int>() { 0, 2, 10, 16, 17, 18, 19, 20, 24, 26, 34};
+            StartingRooms = new List<int>() { 0, 2, 10, 16, 17, 18, 19, 20, 24, 26, 34, 128};
             IsOverworld = true;
         }
 

--- a/src/Randomizer.SMZ3/Regions/Zelda/MiseryMire.cs
+++ b/src/Randomizer.SMZ3/Regions/Zelda/MiseryMire.cs
@@ -70,7 +70,7 @@ namespace Randomizer.SMZ3.Regions.Zelda
 
             MemoryAddress = 0x90;
             MemoryFlag = 0xB;
-            StartingRooms = new List<int> { 0x98 };
+            StartingRooms = new List<int> { 152 };
         }
 
         public override string Name => "Misery Mire";

--- a/src/Randomizer.SMZ3/Regions/Zelda/PalaceOfDarkness.cs
+++ b/src/Randomizer.SMZ3/Regions/Zelda/PalaceOfDarkness.cs
@@ -92,7 +92,7 @@ namespace Randomizer.SMZ3.Regions.Zelda
 
             MemoryAddress = 0x5A;
             MemoryFlag = 0xB;
-            StartingRooms = new List<int> { 0x4A };
+            StartingRooms = new List<int> { 74 };
         }
 
         public override string Name => "Palace of Darkness";

--- a/src/Randomizer.SMZ3/Regions/Zelda/SkullWoods.cs
+++ b/src/Randomizer.SMZ3/Regions/Zelda/SkullWoods.cs
@@ -75,7 +75,7 @@ namespace Randomizer.SMZ3.Regions.Zelda
 
             MemoryAddress = 0x29;
             MemoryFlag = 0xB;
-            StartingRooms = new List<int> { 0x57, 0x58, 0x67, 0x68 };
+            StartingRooms = new List<int> { 86, 87, 88, 89, 103, 104 };
         }
 
         public override string Name => "Skull Woods";

--- a/src/Randomizer.SMZ3/Regions/Zelda/SwampPalace.cs
+++ b/src/Randomizer.SMZ3/Regions/Zelda/SwampPalace.cs
@@ -74,7 +74,7 @@ namespace Randomizer.SMZ3.Regions.Zelda
 
             MemoryAddress = 0x6;
             MemoryFlag = 0xB;
-            StartingRooms = new List<int> { 0x28 };
+            StartingRooms = new List<int> { 40 };
         }
 
         public override string Name => "Swamp Palace";

--- a/src/Randomizer.SMZ3/Regions/Zelda/ThievesTown.cs
+++ b/src/Randomizer.SMZ3/Regions/Zelda/ThievesTown.cs
@@ -68,7 +68,7 @@ namespace Randomizer.SMZ3.Regions.Zelda
 
             MemoryAddress = 0xAC;
             MemoryFlag = 0xB;
-            StartingRooms = new List<int> { 0xDB };
+            StartingRooms = new List<int> { 219 };
         }
 
         public override string Name => "Thieves' Town";

--- a/src/Randomizer.SMZ3/Regions/Zelda/TowerOfHera.cs
+++ b/src/Randomizer.SMZ3/Regions/Zelda/TowerOfHera.cs
@@ -58,7 +58,7 @@ namespace Randomizer.SMZ3.Regions.Zelda
 
             MemoryAddress = 0x7;
             MemoryFlag = 0xB;
-            StartingRooms = new List<int> { 0x77 };
+            StartingRooms = new List<int> { 119 };
         }
 
         public override string Name => "Tower of Hera";

--- a/src/Randomizer.SMZ3/Regions/Zelda/TurtleRock.cs
+++ b/src/Randomizer.SMZ3/Regions/Zelda/TurtleRock.cs
@@ -65,7 +65,7 @@ namespace Randomizer.SMZ3.Regions.Zelda
 
             MemoryAddress = 0xA4;
             MemoryFlag = 0xB;
-            StartingRooms = new List<int> { 0xD6 };
+            StartingRooms = new List<int> { 35, 36, 213, 214 };
         }
 
         public override string Name => "Turtle Rock";


### PR DESCRIPTION
skelebro had an issue with auto tracker thinking that he entered GT when he entered the mimic cave. Looked back at the memory documentation, and dungeon rooms and overworld screens are still in two bytes rather than one, and it happened that the GT entrance and mimic care share the same first byte. I went through and looked at all of the other entrances and trick room numbers, and that was the only one I found.

Along with these changes, I went ahead and added some of the extra entrances for some of the dungeons where you can leave and come back (desert, turtle rock, etc.). Also converted them to regular integers since that's what's printed in the logs. Not sure why I did that originally since I had to find them all through walking around and looking at the logs. lol

Also went and added the other moldorm room.