### PR TITLE
Race fixes

### DIFF
--- a/src/Randomizer.App/TrackerLocationSyncer.cs
+++ b/src/Randomizer.App/TrackerLocationSyncer.cs
@@ -207,6 +207,11 @@ namespace Randomizer.App
                     (dungeonInfo.Requirement == Medallion.Ether && Progression.Ether) ||
                     (dungeonInfo.Requirement == Medallion.Quake && Progression.Quake);
             }
+            // Don't show GT in logic unless all crystals are gathered
+            else if (location.Region is GanonsTower)
+            {
+                return _tracker.WorldInfo.Dungeons.Count(x => x.Cleared && x.Reward is RewardItem.Crystal or RewardItem.RedCrystal) >= 7;
+            }
             // Make sure all 3 pendants have been grabbed for Master Sword Pedestal 
             else if (location == _tracker.World.LightWorldNorthWest.MasterSwordPedestal)
             {
@@ -221,6 +226,11 @@ namespace Randomizer.App
             else if (location.Room == _tracker.World.DarkWorldNorthEast.PyramidFairy)
             {
                 return _tracker.WorldInfo.Dungeons.Count(x => x.Cleared && x.Reward is RewardItem.RedCrystal) >= 2;
+            }
+            // Make sure that the green pendant was grabbed for Sahasrahla
+            else if (location == _tracker.World.LightWorldNorthEast.SahasrahlasHideout.Sahasrahla)
+            {
+                return _tracker.WorldInfo.Dungeons.Any(x => x.Cleared && x.Reward is RewardItem.GreenPendant);
             }
             else return true;
         }

--- a/src/Randomizer.App/Windows/TrackerWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/TrackerWindow.xaml.cs
@@ -450,6 +450,7 @@ namespace Randomizer.App
                         turtleRock.Requirement = Medallion.None;
                     if (miseryMire.Requirement == medallion)
                         miseryMire.Requirement = Medallion.None;
+                    _locationSyncer.OnLocationUpdated("");
                     RefreshGridItems();
                 };
 
@@ -463,6 +464,7 @@ namespace Randomizer.App
                     turtleRock.Requirement = medallion;
                     if (miseryMire.Requirement == medallion)
                         miseryMire.Requirement = Medallion.None;
+                    _locationSyncer.OnLocationUpdated("");
                     RefreshGridItems();
                 };
 
@@ -476,6 +478,7 @@ namespace Randomizer.App
                     if (turtleRock.Requirement == medallion)
                         turtleRock.Requirement = Medallion.None;
                     miseryMire.Requirement = medallion;
+                    _locationSyncer.OnLocationUpdated("");
                     RefreshGridItems();
                 };
 
@@ -488,6 +491,7 @@ namespace Randomizer.App
                 {
                     turtleRock.Requirement = medallion;
                     miseryMire.Requirement = medallion;
+                    _locationSyncer.OnLocationUpdated("");
                     RefreshGridItems();
                 };
 
@@ -670,6 +674,8 @@ namespace Randomizer.App
                 var config = SMZ3.Tracking.TrackerState.LoadConfig(Rom);
                 Options = Options.Clone();
                 Options.LogicConfig = config.LogicConfig;
+                Options.SeedOptions.Race = config.Race;
+                Options.SeedOptions.Keysanity = config.Keysanity;
                 if (Rom.GeneratorVersion == 0) Options.LogicConfig.FireRodDarkRooms = true;
                 _romGenerator.GenerateSeed(Options, Rom.Seed);
             }

--- a/src/Randomizer.SMZ3.Tracking/Tracker.cs
+++ b/src/Randomizer.SMZ3.Tracking/Tracker.cs
@@ -298,6 +298,18 @@ namespace Randomizer.SMZ3.Tracking
         public AutoTracker? AutoTracker { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether Tracker may give hints when
+        /// asked about items or locations.
+        /// </summary>
+        public bool HintsEnabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether Tracker may give spoilers
+        /// when asked about items or locations.
+        /// </summary>
+        public bool SpoilersEnabled { get; set; }
+
+        /// <summary>
         /// Formats a string so that it will be pronounced correctly by the
         /// text-to-speech engine.
         /// </summary>
@@ -633,10 +645,11 @@ namespace Randomizer.SMZ3.Tracking
             {
                 if (region is INeedsMedallion medallionRegion
                     && medallionRegion.Medallion != ItemType.Nothing
-                    && medallionRegion.Medallion != medallion.Value.ToItemType())
+                    && medallionRegion.Medallion != medallion.Value.ToItemType()
+                    && (HintsEnabled || SpoilersEnabled))
                 {
                     Say(Responses.DungeonRequirementMismatch?.Format(
-                        medallionRegion.Medallion.ToString(),
+                        HintsEnabled ? "a different medallion" : medallionRegion.Medallion.ToString(),
                         dungeon.Name,
                         medallion.Value.ToString()));
                 }
@@ -1849,7 +1862,7 @@ namespace Randomizer.SMZ3.Tracking
                 var rewardLocation = World.Locations.Single(x => x.Id == dungeon.LocationId);
                 if (!rewardLocation.Cleared)
                 {
-                    if (rewardLocation.Item != null)
+                    if (rewardLocation.Item != null && SpoilersEnabled)
                     {
                         var item = Items.FirstOrDefault(x => x.InternalItemType == rewardLocation.Item.Type);
                         if (item != null)
@@ -2393,13 +2406,15 @@ namespace Randomizer.SMZ3.Tracking
         {
             // Give some sass if the user tracks or marks the wrong item at a
             // location
-            if (location.Item != null && !item.Is(location.Item.Type))
+            if (location.Item != null && !item.Is(location.Item.Type) && (HintsEnabled || SpoilersEnabled))
             {
                 if (confidence == null || confidence < Options.MinimumSassConfidence)
                     return;
 
                 var actualItemName = Items.FirstOrDefault(x => x.InternalItemType == location.Item.Type)?.NameWithArticle
                         ?? location.Item.Name;
+                if (HintsEnabled) actualItemName = "another item";
+
                 Say(Responses.LocationHasDifferentItem?.Format(item.NameWithArticle, actualItemName));
             }
             else

--- a/src/Randomizer.SMZ3.Tracking/Tracker.cs
+++ b/src/Randomizer.SMZ3.Tracking/Tracker.cs
@@ -1854,33 +1854,6 @@ namespace Randomizer.SMZ3.Tracking
 
             dungeon.Cleared = true;
             Say(Responses.DungeonBossCleared.Format(dungeon.Name, dungeon.Boss));
-
-            // Try to track the associated boss reward item
-            Action? undoTrack = null;
-            if (dungeon.LocationId != null)
-            {
-                var rewardLocation = World.Locations.Single(x => x.Id == dungeon.LocationId);
-                if (!rewardLocation.Cleared)
-                {
-                    if (rewardLocation.Item != null && SpoilersEnabled)
-                    {
-                        var item = Items.FirstOrDefault(x => x.InternalItemType == rewardLocation.Item.Type);
-                        if (item != null)
-                        {
-                            TrackItem(item, rewardLocation);
-                            undoTrack = _undoHistory.Pop();
-                        }
-                    }
-
-                    if (undoTrack == null)
-                    {
-                        // Couldn't track an item, so just clear the location
-                        Clear(rewardLocation);
-                        undoTrack = _undoHistory.Pop();
-                    }
-                }
-            }
-
             IsDirty = true;
 
             OnDungeonUpdated(new TrackerEventArgs(confidence));
@@ -1888,7 +1861,6 @@ namespace Randomizer.SMZ3.Tracking
             {
                 UpdateTrackerProgression = true;
                 dungeon.Cleared = false;
-                undoTrack?.Invoke();
             });
         }
 

--- a/src/Randomizer.SMZ3.Tracking/Tracker.cs
+++ b/src/Randomizer.SMZ3.Tracking/Tracker.cs
@@ -1750,7 +1750,7 @@ namespace Randomizer.SMZ3.Tracking
                 var anyMissedLocation = inaccessibleLocations.Random(s_random);
                 var locationInfo = WorldInfo.Location(anyMissedLocation);
                 var missingItemCombinations = Logic.GetMissingRequiredItems(anyMissedLocation, progress);
-                if (missingItemCombinations.Any())
+                if (missingItemCombinations.Any() && (HintsEnabled || SpoilersEnabled))
                 {
                     var missingItems = missingItemCombinations.Random(s_random)
                             .Select(FindItemByType)

--- a/src/Randomizer.SMZ3/Generation/Smz3Randomizer.cs
+++ b/src/Randomizer.SMZ3/Generation/Smz3Randomizer.cs
@@ -62,7 +62,7 @@ namespace Randomizer.SMZ3.Generation
             if (config.Race)
                 rng = new Random(rng.Next());
 
-            _logger.LogDebug($"Seed: {seedNumber}");
+            _logger.LogDebug($"Seed: {seedNumber} | Race: {config.Race} | Keysanity: {config.Keysanity}");
 
             var worlds = new List<World>();
             if (config.SingleWorld)

--- a/src/Randomizer.SMZ3/Regions/Zelda/SkullWoods.cs
+++ b/src/Randomizer.SMZ3/Regions/Zelda/SkullWoods.cs
@@ -56,7 +56,7 @@ namespace Randomizer.SMZ3.Regions.Zelda
             BigKeyChest = new Location(this, 256 + 150, 0x1E99E, LocationType.Regular,
                 name: "Big Key Chest",
                 vanillaItem: ItemType.BigKeySW,
-                memoryAddress: 0x39,
+                memoryAddress: 0x57,
                 memoryFlag: 0x4);
 
             BridgeRoom = new Location(this, 256 + 151, 0x1E9FE, LocationType.Regular,


### PR DESCRIPTION
Closing #144
- Pulled the race/keysanity setting from the generated rom rather than current settings
- Disabling hints/spoilers for races
- Removed corrections when hints/spoilers are disabled
- Removed dungeon boss item tracking when spoilers aren't enabled

Also updating it to no longer spoil medallion rewards when you haven't peeked the dungeons and no longer show certain locations until you collect dungeon rewards since that was brought up during and after the race. I'm not really super fond of having them in the TrackerLocationSyncer, but they're a pretty odd assortment of checks that I'm not sure if they should have anything fancy for them. But, if you have some better place to put the logic you'd prefer, let me know.