### PR TITLE
Keysanity Fixes

### DIFF
--- a/src/Randomizer.App/TrackerLocationSyncer.cs
+++ b/src/Randomizer.App/TrackerLocationSyncer.cs
@@ -178,7 +178,7 @@ namespace Randomizer.App
         public bool IsLocationClearable(Location location, bool allowOutOfLogic = true, bool requireKeys = false)
         {
             return !location.Cleared
-                && ((location.IsAvailable(requireKeys ? Progression : ProgressionWithKeys) && SpecialLocationLogic(location))
+                && ((location.IsAvailable(requireKeys || _tracker.World.Config.Keysanity ? Progression : ProgressionWithKeys) && SpecialLocationLogic(location))
                 || (allowOutOfLogic && ShowOutOfLogicLocations));
         }
 

--- a/src/Randomizer.App/ViewModels/TrackerMapLocationViewModel.cs
+++ b/src/Randomizer.App/ViewModels/TrackerMapLocationViewModel.cs
@@ -51,8 +51,8 @@ namespace Randomizer.App.ViewModels
 
             Locations.ForEach(x =>
             {
-                numClearable += Syncer.IsLocationClearable(x, allowOutOfLogic: false, requireKeys: Region.Name == "Hyrule Castle") ? 1 : 0;
-                numOutOfLogic += Syncer.IsLocationClearable(x, allowOutOfLogic: true) && !Syncer.IsLocationClearable(x, allowOutOfLogic: false) ? 1 : 0;
+                numClearable += Syncer.IsLocationClearable(x, allowOutOfLogic: false, requireKeys: Region.Name == "Hyrule Castle" || syncer.Tracker.World.Config.Keysanity) ? 1 : 0;
+                numOutOfLogic += Syncer.IsLocationClearable(x, allowOutOfLogic: true) && !Syncer.IsLocationClearable(x, allowOutOfLogic: false, requireKeys: Region.Name == "Hyrule Castle" || syncer.Tracker.World.Config.Keysanity) ? 1 : 0;
                 numUncleared += !x.Cleared ? 1 : 0;
                 numCleared += x.Cleared ? 1 : 0;
             });
@@ -199,7 +199,7 @@ namespace Randomizer.App.ViewModels
         /// Get the tag to use for the location. Use the region for dungeons
         ///  and the list of locations for all other places
         /// </summary>
-        public object Tag => Region.Name == Name ? Region : Locations.Where(x => Syncer.IsLocationClearable(x)).ToList();
+        public object Tag => Region.Name == Name ? Region : Locations.Where(x => Syncer.IsLocationClearable(x, true, Syncer.Tracker.World.Config.Keysanity)).ToList();
 
         /// <summary>
         /// LocationSyncer to use for keeping locations in sync between the

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/EnteredDungeon.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/EnteredDungeon.cs
@@ -35,7 +35,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking.ZeldaStateChecks
                 // Get the dungeon info for the room
                 var dungeonInfo = tracker.WorldInfo.Dungeons.First(x => x.Is(region));
 
-                if (!_enteredDungeons.Contains(dungeonInfo) && (dungeonInfo.Reward == RewardItem.RedPendant || dungeonInfo.Reward == RewardItem.GreenPendant || dungeonInfo.Reward == RewardItem.BluePendant))
+                if (!_enteredDungeons.Contains(dungeonInfo) && (dungeonInfo.Reward == RewardItem.RedPendant || dungeonInfo.Reward == RewardItem.GreenPendant || dungeonInfo.Reward == RewardItem.BluePendant || dungeonInfo.Reward == RewardItem.NonGreenPendant))
                 {
                     tracker.Say(tracker.Responses.AutoTracker.EnterPendantDungeon, dungeonInfo.Name, dungeonInfo.Reward.GetName());
                 }

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/ViewedMap.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/ViewedMap.cs
@@ -53,26 +53,47 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking.ZeldaStateChecks
             if (_tracker == null) return;
             var rewards = new List<Reward>();
 
-            var ep = _tracker.World.EasternPalace;
-            var epInfo = _tracker.WorldInfo.Dungeons.First(x => x.Is(ep));
-            rewards.Add(ep.Reward);
+            if (!_tracker.World.Config.Keysanity || _tracker.Items.Any(x => x.TrackingState > 0 && x.InternalItemType == ItemType.MapEP))
+            {
+                var ep = _tracker.World.EasternPalace;
+                var epInfo = _tracker.WorldInfo.Dungeons.First(x => x.Is(ep));
+                if (epInfo.Reward == RewardItem.Unknown)
+                {
+                    rewards.Add(ep.Reward);
+                    _tracker.SetDungeonReward(epInfo, ConvertReward(ep.Reward));
+                }
+            }
 
-            var dp = _tracker.World.DesertPalace;
-            var dpInfo = _tracker.WorldInfo.Dungeons.First(x => x.Is(dp));
-            rewards.Add(dp.Reward);
+            if (!_tracker.World.Config.Keysanity || _tracker.Items.Any(x => x.TrackingState > 0 && x.InternalItemType == ItemType.MapDP))
+            {
+                var dp = _tracker.World.DesertPalace;
+                var dpInfo = _tracker.WorldInfo.Dungeons.First(x => x.Is(dp));
+                if (dpInfo.Reward == RewardItem.Unknown)
+                {
+                    rewards.Add(dp.Reward);
+                    _tracker.SetDungeonReward(dpInfo, ConvertReward(dp.Reward));
+                }
+            }
 
-            var toh = _tracker.World.TowerOfHera;
-            var tohInfo = _tracker.WorldInfo.Dungeons.First(x => x.Is(toh));
-            rewards.Add(toh.Reward);
+            if (!_tracker.World.Config.Keysanity || _tracker.Items.Any(x => x.TrackingState > 0 && x.InternalItemType == ItemType.MapTH))
+            {
+                var toh = _tracker.World.TowerOfHera;
+                var tohInfo = _tracker.WorldInfo.Dungeons.First(x => x.Is(toh));
+                if (tohInfo.Reward == RewardItem.Unknown)
+                {
+                    rewards.Add(toh.Reward);
+                    _tracker.SetDungeonReward(tohInfo, ConvertReward(toh.Reward));
+                }
+            }
 
             if (rewards.Count(x => x == Reward.CrystalRed || x == Reward.CrystalBlue) == 3)
             {
                 _tracker.SayOnce(x => x.AutoTracker.LightWorldAllCrystals);
             }
-
-            _tracker.SetDungeonReward(epInfo, ConvertReward(ep.Reward));
-            _tracker.SetDungeonReward(dpInfo, ConvertReward(dp.Reward));
-            _tracker.SetDungeonReward(tohInfo, ConvertReward(toh.Reward));
+            else if (rewards.Count == 0)
+            {
+                _tracker.Say(x => x.AutoTracker.LookedAtNothing);
+            }
         }
 
         /// <summary>
@@ -82,39 +103,97 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking.ZeldaStateChecks
         {
             if (_tracker == null) return;
 
-            var pod = _tracker.World.PalaceOfDarkness;
-            var podInfo = _tracker.WorldInfo.Dungeons.First(x => x.Is(pod));
+            var stateMedallionMessage = true;
+            var addedReward = false;
 
-            var sp = _tracker.World.SwampPalace;
-            var spInfo = _tracker.WorldInfo.Dungeons.First(x => x.Is(sp));
+            if (!_tracker.World.Config.Keysanity || _tracker.Items.Any(x => x.TrackingState > 0 && x.InternalItemType == ItemType.MapPD))
+            {
+                var pod = _tracker.World.PalaceOfDarkness;
+                var podInfo = _tracker.WorldInfo.Dungeons.First(x => x.Is(pod));
+                if (podInfo.Reward == RewardItem.Unknown)
+                {
+                    _tracker.SetDungeonReward(podInfo, ConvertReward(pod.Reward));
+                    addedReward = true;
+                }
+            }
 
-            var sw = _tracker.World.SkullWoods;
-            var swInfo = _tracker.WorldInfo.Dungeons.First(x => x.Is(sw));
+            if (!_tracker.World.Config.Keysanity || _tracker.Items.Any(x => x.TrackingState > 0 && x.InternalItemType == ItemType.MapSP))
+            {
+                var sp = _tracker.World.SwampPalace;
+                var spInfo = _tracker.WorldInfo.Dungeons.First(x => x.Is(sp));
+                if (spInfo.Reward == RewardItem.Unknown)
+                {
+                    _tracker.SetDungeonReward(spInfo, ConvertReward(sp.Reward));
+                    addedReward = true;
+                }
+            }
 
-            var tt = _tracker.World.ThievesTown;
-            var ttInfo = _tracker.WorldInfo.Dungeons.First(x => x.Is(tt));
+            if (!_tracker.World.Config.Keysanity || _tracker.Items.Any(x => x.TrackingState > 0 && x.InternalItemType == ItemType.MapSW))
+            {
+                var sw = _tracker.World.SkullWoods;
+                var swInfo = _tracker.WorldInfo.Dungeons.First(x => x.Is(sw));
+                if (swInfo.Reward == RewardItem.Unknown)
+                {
+                    _tracker.SetDungeonReward(swInfo, ConvertReward(sw.Reward));
+                    addedReward = true;
+                }
+            }
 
-            var ip = _tracker.World.IcePalace;
-            var ipInfo = _tracker.WorldInfo.Dungeons.First(x => x.Is(ip));
+            if (!_tracker.World.Config.Keysanity || _tracker.Items.Any(x => x.TrackingState > 0 && x.InternalItemType == ItemType.MapTT))
+            {
+                var tt = _tracker.World.ThievesTown;
+                var ttInfo = _tracker.WorldInfo.Dungeons.First(x => x.Is(tt));
+                if (ttInfo.Reward == RewardItem.Unknown)
+                {
+                    _tracker.SetDungeonReward(ttInfo, ConvertReward(tt.Reward));
+                    addedReward = true;
+                }
+            }
 
-            var mm = _tracker.World.MiseryMire;
-            var mmInfo = _tracker.WorldInfo.Dungeons.First(x => x.Is(mm));
+            if (!_tracker.World.Config.Keysanity || _tracker.Items.Any(x => x.TrackingState > 0 && x.InternalItemType == ItemType.MapIP))
+            {
+                var ip = _tracker.World.IcePalace;
+                var ipInfo = _tracker.WorldInfo.Dungeons.First(x => x.Is(ip));
+                if (ipInfo.Reward == RewardItem.Unknown)
+                {
+                    _tracker.SetDungeonReward(ipInfo, ConvertReward(ip.Reward));
+                    addedReward = true;
+                }
+            }
 
-            var tr = _tracker.World.TurtleRock;
-            var trInfo = _tracker.WorldInfo.Dungeons.First(x => x.Is(tr));
+            if (!_tracker.World.Config.Keysanity || _tracker.Items.Any(x => x.TrackingState > 0 && x.InternalItemType == ItemType.MapMM))
+            {
+                var mm = _tracker.World.MiseryMire;
+                var mmInfo = _tracker.WorldInfo.Dungeons.First(x => x.Is(mm));
+                if (mmInfo.Reward == RewardItem.Unknown)
+                {
+                    _tracker.SetDungeonReward(mmInfo, ConvertReward(mm.Reward));
+                    addedReward = true;
+                    if (mm.Reward == Reward.CrystalRed || mm.Reward == Reward.CrystalBlue) stateMedallionMessage = false;
+                }
+            }
 
-            if (mm.Reward != Reward.CrystalRed && mm.Reward != Reward.CrystalBlue && tr.Reward != Reward.CrystalRed && tr.Reward != Reward.CrystalBlue)
+            if (!_tracker.World.Config.Keysanity || _tracker.Items.Any(x => x.TrackingState > 0 && x.InternalItemType == ItemType.MapTR))
+            {
+                var tr = _tracker.World.TurtleRock;
+                var trInfo = _tracker.WorldInfo.Dungeons.First(x => x.Is(tr));
+                if (trInfo.Reward == RewardItem.Unknown)
+                {
+                    _tracker.SetDungeonReward(trInfo, ConvertReward(tr.Reward));
+                    addedReward = true;
+                    if (tr.Reward == Reward.CrystalRed || tr.Reward == Reward.CrystalBlue) stateMedallionMessage = false;
+                }
+            }
+
+            if (stateMedallionMessage)
             {
                 _tracker.SayOnce(x => x.AutoTracker.DarkWorldNoMedallions);
             }
+            else if(!addedReward)
+            {
+                _tracker.Say(x => x.AutoTracker.LookedAtNothing);
+            }
 
-            _tracker.SetDungeonReward(podInfo, ConvertReward(pod.Reward));
-            _tracker.SetDungeonReward(spInfo, ConvertReward(sp.Reward));
-            _tracker.SetDungeonReward(swInfo, ConvertReward(sw.Reward));
-            _tracker.SetDungeonReward(ttInfo, ConvertReward(tt.Reward));
-            _tracker.SetDungeonReward(ipInfo, ConvertReward(ip.Reward));
-            _tracker.SetDungeonReward(mmInfo, ConvertReward(mm.Reward));
-            _tracker.SetDungeonReward(trInfo, ConvertReward(tr.Reward));
         }
 
         /// <summary>

--- a/src/Randomizer.SMZ3.Tracking/Tracker.cs
+++ b/src/Randomizer.SMZ3.Tracking/Tracker.cs
@@ -1633,7 +1633,7 @@ namespace Randomizer.SMZ3.Tracking
                         itemsCleared++;
                         if (!trackItems)
                         {
-                            if (IsTreasure(location.Item))
+                            if (IsTreasure(location.Item) || World.Config.Keysanity)
                                 treasureTracked++;
                             location.Cleared = true;
                             OnLocationCleared(new(location, confidence));
@@ -1646,7 +1646,7 @@ namespace Randomizer.SMZ3.Tracking
                             _logger.LogWarning("Failed to track {itemType} in {area}.", itemType, area.Name); // Probably the compass or something, who cares
                         else
                             itemsTracked.Add(item);
-                        if (IsTreasure(location.Item))
+                        if (IsTreasure(location.Item) || World.Config.Keysanity)
                             treasureTracked++;
 
                         location.Cleared = true;
@@ -1800,7 +1800,7 @@ namespace Randomizer.SMZ3.Tracking
 
             Action? undoTrackTreasure = null;
             var dungeon = GetDungeonFromLocation(location);
-            if (dungeon != null && IsTreasure(location.Item))
+            if (dungeon != null && (IsTreasure(location.Item) || World.Config.Keysanity))
             {
                 TrackDungeonTreasure(dungeon, confidence);
 
@@ -2343,7 +2343,7 @@ namespace Randomizer.SMZ3.Tracking
             }
 
             var dungeon = GetDungeonFromItem(item);
-            if (dungeon != null && IsTreasure(item))
+            if (dungeon != null && (IsTreasure(item) || World.Config.Keysanity))
             {
                 if (TrackDungeonTreasure(dungeon, confidence))
                     return _undoHistory.Pop();
@@ -2364,7 +2364,7 @@ namespace Randomizer.SMZ3.Tracking
                 var region = world.Regions.SingleOrDefault(x => dungeon.Is(x));
                 if (region != null)
                 {
-                    dungeon.TreasureRemaining = region.Locations.Count(x => !x.Item.IsDungeonItem && x.Type != LocationType.NotInDungeon);
+                    dungeon.TreasureRemaining = region.Locations.Count(x => (IsTreasure(x.Item) || World.Config.Keysanity) && x.Type != LocationType.NotInDungeon);
                     _logger.LogDebug("Found {TreasureRemaining} item(s) in {dungeon}", dungeon.TreasureRemaining, dungeon.Name);
                 }
                 else


### PR DESCRIPTION
This resolves various fixes for keysanity mode that came up during Pink's playthrough. No tracker window updates as of yet. I'd need to look into exactly how it works first. But, this should at least get location tracking working properly. I feel like people are more likely to use autotracking with keysanity mode anyway just because of the sheer annoyance of keeping track of all the keys.

Issues resolved
- Forced the map to not assume keys for keysanity rather than the one that assumes keys as it'll show what's actually in logic. The location list should work the same as before though.
- The "take a look at this" should now require the map for keysanity to avoid spoiling locations.
- All locations in dungeons should now be counted as treasure for keysanity mode.
- Fixed non green pendant rewards not triggering the pendant dip message (not related to keysanity, but resolved nonetheless).