### PR TITLE
Additional Race Options

### DIFF
--- a/src/Randomizer.App/ViewModels/RandomizerOptions.cs
+++ b/src/Randomizer.App/ViewModels/RandomizerOptions.cs
@@ -119,6 +119,9 @@ namespace Randomizer.App.ViewModels
                     PegWorldItemPool = SeedOptions.PegWorldItem,
                     KeyShuffle = SeedOptions.Keysanity ? KeyShuffle.Keysanity : KeyShuffle.None,
                     Race = SeedOptions.Race,
+                    DisableSpoilerLog = SeedOptions.DisableSpoilerLog,
+                    DisableTrackerHints = SeedOptions.DisableTrackerHints,
+                    DisableTrackerSpoilers = SeedOptions.DisableTrackerSpoilers,
                     ExtendedMsuSupport = PatchOptions.CanEnableExtendedSoundtrack && PatchOptions.EnableExtendedSoundtrack,
                     ShuffleDungeonMusic = PatchOptions.ShuffleDungeonMusic,
                     HeartColor = PatchOptions.HeartColor,
@@ -130,7 +133,8 @@ namespace Randomizer.App.ViewModels
                     SamusName = PatchOptions.SamusSprite == Sprite.DefaultSamus ? "Samus" : PatchOptions.SamusSprite.Name,
                     LocationItems = SeedOptions.LocationItems,
                     EarlyItems = SeedOptions.EarlyItems,
-                    LogicConfig = LogicConfig.Clone()
+                    LogicConfig = LogicConfig.Clone(),
+                    Seed = SeedOptions.Seed,
                 };
             }
             else
@@ -152,7 +156,10 @@ namespace Randomizer.App.ViewModels
                     ShaktoolItemPool = SeedOptions.ShaktoolItem,
                     PegWorldItemPool = SeedOptions.PegWorldItem,
                     KeyShuffle = SeedOptions.Keysanity ? KeyShuffle.Keysanity : KeyShuffle.None,
-                    Race = SeedOptions.Race,
+                    Race = SeedOptions.CopySeedAndRaceSettings ? oldConfig.Race : SeedOptions.Race,
+                    DisableSpoilerLog = SeedOptions.CopySeedAndRaceSettings ? oldConfig.DisableSpoilerLog : SeedOptions.DisableSpoilerLog,
+                    DisableTrackerHints = SeedOptions.CopySeedAndRaceSettings ? oldConfig.DisableTrackerHints : SeedOptions.DisableTrackerHints,
+                    DisableTrackerSpoilers = SeedOptions.CopySeedAndRaceSettings ? oldConfig.DisableTrackerSpoilers : SeedOptions.DisableTrackerSpoilers,
                     ExtendedMsuSupport = PatchOptions.CanEnableExtendedSoundtrack && PatchOptions.EnableExtendedSoundtrack,
                     ShuffleDungeonMusic = PatchOptions.ShuffleDungeonMusic,
                     HeartColor = PatchOptions.HeartColor,
@@ -164,7 +171,8 @@ namespace Randomizer.App.ViewModels
                     SamusName = PatchOptions.SamusSprite == Sprite.DefaultSamus ? "Samus" : PatchOptions.SamusSprite.Name,
                     LocationItems = oldConfig.LocationItems,
                     EarlyItems = oldConfig.EarlyItems,
-                    LogicConfig = oldConfig.LogicConfig
+                    LogicConfig = oldConfig.LogicConfig,
+                    Seed = SeedOptions.CopySeedAndRaceSettings ? oldConfig.Seed : SeedOptions.Seed,
                 };
             }
         }

--- a/src/Randomizer.App/ViewModels/SeedOptions.cs
+++ b/src/Randomizer.App/ViewModels/SeedOptions.cs
@@ -40,6 +40,15 @@ namespace Randomizer.App.ViewModels
 
         public bool Race { get; set; }
 
+        public bool DisableSpoilerLog { get; set; }
+
+        public bool DisableTrackerHints { get; set; }
+
+        public bool DisableTrackerSpoilers { get; set; }
+
+        [JsonIgnore]
+        public bool CopySeedAndRaceSettings { get; set; }
+
         public ISet<ItemType> EarlyItems { get; set; } = new HashSet<ItemType>();
 
         public IDictionary<int, int> LocationItems { get; set; } = new Dictionary<int, int>();

--- a/src/Randomizer.App/Windows/GenerateRomWindow.xaml
+++ b/src/Randomizer.App/Windows/GenerateRomWindow.xaml
@@ -192,11 +192,35 @@
             <StackPanel Orientation="Vertical"
                         Margin="24,11,11,11"
                         DataContext="{Binding SeedOptions}">
-              <StackPanel Orientation="Horizontal"
-                          Margin="0,0,0,4">
-                <CheckBox IsChecked="{Binding Keysanity}">Keysanity</CheckBox>
-                <CheckBox IsChecked="{Binding Race}">Race</CheckBox>
-              </StackPanel>
+
+              <GroupBox Header="Game Mode Settings"
+                        Padding="0,5,0,0"
+                        Margin="0,0,0,10">
+                <UniformGrid Columns="2">
+                  <CheckBox IsChecked="{Binding Keysanity}">Keysanity</CheckBox>
+                </UniformGrid>
+              </GroupBox>
+
+              <GroupBox Header="Race Settings"
+                        Padding="0,5,0,0"
+                        Margin="0,0,0,10">
+                <UniformGrid Columns="2">
+                  <CheckBox IsChecked="{Binding Race}"
+                            Checked="RaceCheckBox_Checked"
+                            Unchecked="RaceCheckBox_Unchecked"
+                            Content="Generate Race Seed"
+                            ToolTip="Generates a seed used for races and disables all forms of hints and spoilers"/>
+                  <CheckBox IsChecked="{Binding DisableSpoilerLog}"
+                            Name="DisableSpoilerLogCheckBox"
+                            Content="Disable Spoiler Log" />
+                  <CheckBox IsChecked="{Binding DisableTrackerHints}"
+                            Name="DisableTrackerHintsCheckBox"
+                            Content="Disable Tracker Hints" />
+                  <CheckBox IsChecked="{Binding DisableTrackerSpoilers}"
+                            Name="DisableTrackerSpoilersCheckBox"
+                            Content="Disable Tracker Spoilers" />
+                </UniformGrid>
+              </GroupBox>
 
               <controls:LabeledControl Text="Seed (optional):">
                 <TextBox x:Name="SeedInput"
@@ -204,8 +228,11 @@
               </controls:LabeledControl>
 
               <controls:LabeledControl Text="Import settings (optional):">
-                <TextBox x:Name="ConfigString"
+                <StackPanel Orientation="Vertical">
+                  <TextBox x:Name="ConfigString"
                          Text="{Binding ConfigString}" />
+                  <CheckBox IsChecked="{Binding CopySeedAndRaceSettings}" Margin="0,5,0,0">Also import seed and race settings</CheckBox>
+                </StackPanel>
               </controls:LabeledControl>
             </StackPanel>
           </Expander>

--- a/src/Randomizer.App/Windows/GenerateRomWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/GenerateRomWindow.xaml.cs
@@ -68,6 +68,7 @@ namespace Randomizer.App
                 PopulateItemOptions();
                 PopulateLogicOptions();
                 PopulateLocationOptions();
+                UpdateRaceCheckBoxes();
             }
         }
 
@@ -579,6 +580,23 @@ namespace Randomizer.App
             public int Value { get; set; }
             public string Text { get; set; }
             public override string ToString() => Text;
+        }
+
+        private void RaceCheckBox_Checked(object sender, RoutedEventArgs e)
+        {
+            UpdateRaceCheckBoxes();
+        }
+
+        private void RaceCheckBox_Unchecked(object sender, RoutedEventArgs e)
+        {
+            UpdateRaceCheckBoxes();
+        }
+
+        private void UpdateRaceCheckBoxes()
+        {
+            DisableSpoilerLogCheckBox.IsEnabled = !Options?.SeedOptions.Race ?? true;
+            DisableTrackerHintsCheckBox.IsEnabled = !Options?.SeedOptions.Race ?? true;
+            DisableTrackerSpoilersCheckBox.IsEnabled = !Options?.SeedOptions.Race ?? true;
         }
     }
 }

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/SpoilerModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/SpoilerModule.cs
@@ -38,54 +38,61 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
         public SpoilerModule(Tracker tracker, ILogger<SpoilerModule> logger)
             : base(tracker, logger)
         {
-            Tracker.HintsEnabled = !tracker.World.Config.Race && tracker.Options.HintsEnabled;
-            Tracker.SpoilersEnabled = !tracker.World.Config.Race && tracker.Options.SpoilersEnabled;
+            Tracker.HintsEnabled = !tracker.World.Config.Race && !tracker.World.Config.DisableTrackerHints && tracker.Options.HintsEnabled;
+            Tracker.SpoilersEnabled = !tracker.World.Config.Race && !tracker.World.Config.DisableTrackerSpoilers && tracker.Options.SpoilersEnabled;
             if (tracker.World.Config.Race) return;
             _playthrough = Playthrough.Generate(new[] { tracker.World }, tracker.World.Config);
 
-            AddCommand("Enable hints", GetEnableHintsRule(), (tracker, result) =>
+            if (!tracker.World.Config.DisableTrackerHints)
             {
-                Tracker.HintsEnabled = true;
-                tracker.Say(x => x.Hints.EnabledHints);
-            });
-            AddCommand("Disable hints", GetDisableHintsRule(), (tracker, result) =>
-            {
-                Tracker.HintsEnabled = false;
-                tracker.Say(x => x.Hints.DisabledHints);
-            });
-            AddCommand("Enable spoilers", GetEnableSpoilersRule(), (tracker, result) =>
-            {
-                Tracker.SpoilersEnabled = true;
-                tracker.Say(x => x.Spoilers.EnabledSpoilers);
-            });
-            AddCommand("Disable spoilers", GetDisableSpoilersRule(), (tracker, result) =>
-            {
-                Tracker.SpoilersEnabled = false;
-                tracker.Say(x => x.Spoilers.DisabledSpoilers);
-            });
+                AddCommand("Enable hints", GetEnableHintsRule(), (tracker, result) =>
+                {
+                    Tracker.HintsEnabled = true;
+                    tracker.Say(x => x.Hints.EnabledHints);
+                });
+                AddCommand("Disable hints", GetDisableHintsRule(), (tracker, result) =>
+                {
+                    Tracker.HintsEnabled = false;
+                    tracker.Say(x => x.Hints.DisabledHints);
+                });
+                AddCommand("Give progression hint", GetProgressionHintRule(), (tracker, result) =>
+                {
+                    GiveProgressionHint();
+                });
 
-            AddCommand("Reveal item location", GetItemSpoilerRule(), (tracker, result) =>
-            {
-                var item = GetItemFromResult(tracker, result, out var itemName);
-                RevealItemLocation(item);
-            });
+                AddCommand("Give area hint", GetLocationUsefulnessHintRule(), (tracker, result) =>
+                {
+                    var area = GetAreaFromResult(tracker, result);
+                    GiveAreaHint(area);
+                });
+            }
 
-            AddCommand("Reveal location item", GetLocationSpoilerRule(), (tracker, result) =>
+            if (!tracker.World.Config.DisableTrackerSpoilers)
             {
-                var location = GetLocationFromResult(tracker, result);
-                RevealLocationItem(location);
-            });
+                AddCommand("Enable spoilers", GetEnableSpoilersRule(), (tracker, result) =>
+                {
+                    Tracker.SpoilersEnabled = true;
+                    tracker.Say(x => x.Spoilers.EnabledSpoilers);
+                });
+                AddCommand("Disable spoilers", GetDisableSpoilersRule(), (tracker, result) =>
+                {
+                    Tracker.SpoilersEnabled = false;
+                    tracker.Say(x => x.Spoilers.DisabledSpoilers);
+                });
 
-            AddCommand("Give progression hint", GetProgressionHintRule(), (tracker, result) =>
-            {
-                GiveProgressionHint();
-            });
+                AddCommand("Reveal item location", GetItemSpoilerRule(), (tracker, result) =>
+                {
+                    var item = GetItemFromResult(tracker, result, out var itemName);
+                    RevealItemLocation(item);
+                });
 
-            AddCommand("Give area hint", GetLocationUsefulnessHintRule(), (tracker, result) =>
-            {
-                var area = GetAreaFromResult(tracker, result);
-                GiveAreaHint(area);
-            });
+                AddCommand("Reveal location item", GetLocationSpoilerRule(), (tracker, result) =>
+                {
+                    var location = GetLocationFromResult(tracker, result);
+                    RevealLocationItem(location);
+                });
+            }
+            
         }
 
         

--- a/src/Randomizer.SMZ3/Config.cs
+++ b/src/Randomizer.SMZ3/Config.cs
@@ -183,6 +183,9 @@ namespace Randomizer.SMZ3
         public Goal Goal { get; set; } = Goal.DefeatBoth;
         public KeyShuffle KeyShuffle { get; set; } = KeyShuffle.None;
         public bool Race { get; set; } = false;
+        public bool DisableSpoilerLog { get; set; } = false;
+        public bool DisableTrackerSpoilers { get; set; } = false;
+        public bool DisableTrackerHints { get; set; } = false;
         public GanonInvincible GanonInvincible { get; set; } = GanonInvincible.BeforeCrystals;
         public bool ExtendedMsuSupport { get; set; } = false;
         public MusicShuffleMode ShuffleDungeonMusic { get; set; } = MusicShuffleMode.Default;
@@ -201,6 +204,7 @@ namespace Randomizer.SMZ3
         public bool SingleWorld => GameMode == GameMode.Normal;
         public bool MultiWorld => GameMode == GameMode.Multiworld;
         public bool Keysanity => KeyShuffle != KeyShuffle.None;
+        public string Seed { get; set; }
 
         public IDictionary<int, int> LocationItems { get; set; } = new Dictionary<int, int>();
         public ISet<ItemType> EarlyItems { get; set; } = new HashSet<ItemType>();


### PR DESCRIPTION
Some folks wanted additional options to disable hints/spoilers piecemeal without enabling the race option and disabling everything.

I also updated it so that when the race mode is enabled or the option to disable spoiler log is enabled, it actually fully disables location printing in the spoiler log.