### PR TITLE
Plando support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -133,6 +133,9 @@ csharp_style_pattern_local_over_anonymous_function = false:none
 # IDE0058: Expression value is never used
 csharp_style_unused_value_expression_statement_preference = discard_variable:none
 
+# CS1591: Missing XML comment for publicly visible type or member
+dotnet_diagnostic.CS1591.severity = suggestion
+
 # Space preferences
 csharp_space_after_cast = false
 csharp_space_after_colon_in_inheritance_clause = true

--- a/src/Randomizer.App/App.xaml.cs
+++ b/src/Randomizer.App/App.xaml.cs
@@ -3,12 +3,13 @@ using System.Windows;
 using System.Windows.Controls;
 
 using BunLabs.IO;
+
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Win32;
+
 using Randomizer.Shared.Models;
-using Randomizer.SMZ3;
 using Randomizer.SMZ3.ChatIntegration;
 using Randomizer.SMZ3.Contracts;
 using Randomizer.SMZ3.Generation;
@@ -76,6 +77,7 @@ namespace Randomizer.App
             // Randomizer + Tracker
             services.AddSingleton<RandomizerContext>();
             services.AddSingleton<IFiller, StandardFiller>();
+            services.AddSingleton<PlandoFillerFactory>();
             services.AddSingleton<IWorldAccessor, WorldAccessor>();
             services.AddSingleton<Smz3Randomizer>();
             services.AddTracker()

--- a/src/Randomizer.App/App.xaml.cs
+++ b/src/Randomizer.App/App.xaml.cs
@@ -75,11 +75,8 @@ namespace Randomizer.App
         protected static void ConfigureServices(IServiceCollection services)
         {
             // Randomizer + Tracker
-            services.AddSingleton<RandomizerContext>();
-            services.AddSingleton<IFiller, StandardFiller>();
-            services.AddSingleton<PlandoFillerFactory>();
-            services.AddSingleton<IWorldAccessor, WorldAccessor>();
-            services.AddSingleton<Smz3Randomizer>();
+            services.AddSmz3Randomizer();
+            services.AddPlandomizer();
             services.AddTracker()
                 .AddOptionalModule<PegWorldModeModule>()
                 .AddOptionalModule<SpoilerModule>()

--- a/src/Randomizer.App/RomGenerator.cs
+++ b/src/Randomizer.App/RomGenerator.cs
@@ -275,6 +275,7 @@ namespace Randomizer.App
         protected GeneratedRom SaveSeedToDatabase(RandomizerOptions options, SeedData seed, string romPath, string spoilerPath)
         {
             var config = seed.Playthrough.Config;
+            var trackerState = seed.Worlds[0].World.CreateTrackerState();
 
             var rom = new GeneratedRom()
             {
@@ -283,7 +284,8 @@ namespace Randomizer.App
                 SpoilerPath = Path.GetRelativePath(options.RomOutputPath, spoilerPath),
                 Date = DateTimeOffset.Now,
                 Settings = config.SettingsString ?? Config.ToConfigString(config, true),
-                GeneratorVersion = Smz3Randomizer.Version.Major
+                GeneratorVersion = Smz3Randomizer.Version.Major,
+                TrackerState = trackerState
             };
             _dbContext.GeneratedRoms.Add(rom);
             _dbContext.SaveChanges();

--- a/src/Randomizer.App/RomGenerator.cs
+++ b/src/Randomizer.App/RomGenerator.cs
@@ -112,11 +112,12 @@ namespace Randomizer.App
         {
             var bytes = GenerateRomBytes(options, seed);
             var config = seed.Playthrough.Config;
+            var safeSeed = seed.Seed.ReplaceAny(Path.GetInvalidFileNameChars(), '_');
 
-            var folderPath = Path.Combine(options.RomOutputPath, $"{DateTimeOffset.Now:yyyyMMdd-HHmmss}_{seed.Seed}");
+            var folderPath = Path.Combine(options.RomOutputPath, $"{DateTimeOffset.Now:yyyyMMdd-HHmmss}_{safeSeed}");
             Directory.CreateDirectory(folderPath);
 
-            var fileSuffix = $"{DateTimeOffset.Now:yyyyMMdd-HHmmss}_{seed.Seed}";
+            var fileSuffix = $"{DateTimeOffset.Now:yyyyMMdd-HHmmss}_{safeSeed}";
             var romFileName = $"SMZ3_Cas_{fileSuffix}.sfc";
             var romPath = Path.Combine(folderPath, romFileName);
             EnableMsu1Support(options, bytes, romPath, out var msuError);

--- a/src/Randomizer.App/RomGenerator.cs
+++ b/src/Randomizer.App/RomGenerator.cs
@@ -50,7 +50,8 @@ namespace Randomizer.App
         {
             try
             {
-                var bytes = GenerateRomBytes(options, out var seed);
+                var seed = GenerateSeed(options);
+                var bytes = GenerateRomBytes(options, seed);
 
                 var config = seed.Playthrough.Config;
                 if (!_randomizer.ValidateSeedSettings(seed, seed.Playthrough.Config))
@@ -132,12 +133,10 @@ namespace Randomizer.App
         /// Uses the options to generate the rom
         /// </summary>
         /// <param name="options">The randomizer generation options</param>
-        /// <param name="seed">The generated seed data</param>
+        /// <param name="seed">The seed data to write to the ROM.</param>
         /// <returns>The bytes of the rom file</returns>
-        protected byte[] GenerateRomBytes(RandomizerOptions options, out SeedData seed)
+        protected byte[] GenerateRomBytes(RandomizerOptions options, SeedData seed)
         {
-            seed = GenerateSeed(options);
-
             var assembly = GetType().Assembly;
             var smIpsFiles = new List<Stream>();
             if (options.PatchOptions.CasualSuperMetroidPatches)

--- a/src/Randomizer.App/ViewModels/RandomizerOptions.cs
+++ b/src/Randomizer.App/ViewModels/RandomizerOptions.cs
@@ -114,19 +114,7 @@ namespace Randomizer.App.ViewModels
                 var config = new Config()
                 {
                     GameMode = GameMode.Normal,
-                    Z3Logic = Z3Logic.Normal,
-                    SMLogic = SMLogic.Normal,
-                    ItemLocations =
-                    {
-                        [ItemType.ProgressiveSword] = SeedOptions.SwordLocation,
-                        [ItemType.Morph] = SeedOptions.MorphLocation,
-                        [ItemType.Bombs] = SeedOptions.MorphBombsLocation,
-                        [ItemType.Boots] = SeedOptions.PegasusBootsLocation,
-                        [ItemType.SpaceJump] = SeedOptions.SpaceJumpLocation,
-                    },
-                    ShaktoolItemPool = SeedOptions.ShaktoolItem,
-                    PegWorldItemPool = SeedOptions.PegWorldItem,
-                    KeyShuffle = SeedOptions.Keysanity ? KeyShuffle.Keysanity : KeyShuffle.None,
+                    Keysanity = SeedOptions.Keysanity,
                     Race = SeedOptions.Race,
                     DisableSpoilerLog = SeedOptions.DisableSpoilerLog,
                     DisableTrackerHints = SeedOptions.DisableTrackerHints,
@@ -154,7 +142,7 @@ namespace Randomizer.App.ViewModels
             {
                 var oldConfig = Config.FromConfigString(SeedOptions.ConfigString);
 
-                var keyShuffle = SeedOptions.Keysanity ? KeyShuffle.Keysanity : KeyShuffle.None;
+                var keysanity = SeedOptions.Keysanity;
                 var race = SeedOptions.Race;
                 var disableSpoilerLog = SeedOptions.DisableSpoilerLog;
                 var disableTrackerHints = SeedOptions.DisableTrackerHints;
@@ -164,7 +152,7 @@ namespace Randomizer.App.ViewModels
 
                 if (SeedOptions.CopySeedAndRaceSettings)
                 {
-                    keyShuffle = oldConfig.KeyShuffle;
+                    keysanity = oldConfig.Keysanity;
                     race = oldConfig.Race;
                     disableSpoilerLog = oldConfig.DisableSpoilerLog;
                     disableTrackerHints = oldConfig.DisableTrackerHints;
@@ -177,19 +165,7 @@ namespace Randomizer.App.ViewModels
                 return new Config()
                 {
                     GameMode = GameMode.Normal,
-                    Z3Logic = Z3Logic.Normal,
-                    SMLogic = SMLogic.Normal,
-                    ItemLocations =
-                    {
-                        [ItemType.ProgressiveSword] = SeedOptions.SwordLocation,
-                        [ItemType.Morph] = SeedOptions.MorphLocation,
-                        [ItemType.Bombs] = SeedOptions.MorphBombsLocation,
-                        [ItemType.Boots] = SeedOptions.PegasusBootsLocation,
-                        [ItemType.SpaceJump] = SeedOptions.SpaceJumpLocation,
-                    },
-                    ShaktoolItemPool = SeedOptions.ShaktoolItem,
-                    PegWorldItemPool = SeedOptions.PegWorldItem,
-                    KeyShuffle = keyShuffle,
+                    Keysanity = keysanity,
                     Race = race,
                     DisableSpoilerLog = disableSpoilerLog,
                     DisableTrackerHints = disableTrackerHints,

--- a/src/Randomizer.App/Windows/GenerateRomWindow.xaml
+++ b/src/Randomizer.App/Windows/GenerateRomWindow.xaml
@@ -1,4 +1,5 @@
 ﻿<Window x:Class="Randomizer.App.GenerateRomWindow"
+        x:Name="ugh"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -35,46 +36,58 @@
         <StackPanel Orientation="Vertical">
           <Expander Header="Early Items"
                     x:Name="EarlyItemsExpander"
+                    Visibility="{Binding InvisibleInPlando, Mode=OneTime, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Window}}"
                     IsExpanded="{Binding EarlyItemsExpanded}">
             <StackPanel Orientation="Vertical"
                         Margin="24,11,11,11">
-              <UniformGrid Columns="2" Name="EarlyItemsGrid" />
+              <UniformGrid Columns="2"
+                           Name="EarlyItemsGrid" />
             </StackPanel>
           </Expander>
 
           <Expander Header="Locations"
+                    Visibility="{Binding InvisibleInPlando, Mode=OneTime, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Window}}"
                     x:Name="Locations">
             <StackPanel Orientation="Vertical"
                         Margin="24,11,11,11">
-              <ComboBox Name="LocationsRegionFilter" SelectionChanged="LocationsRegionFilter_SelectionChanged" />
+              <ComboBox Name="LocationsRegionFilter"
+                        SelectionChanged="LocationsRegionFilter_SelectionChanged" />
               <ScrollViewer VerticalScrollBarVisibility="Auto"
-                    HorizontalScrollBarVisibility="Disabled" MaxHeight="200" Margin="0,10,0,10" VerticalAlignment="Top">
-                <Grid Name="LocationsGrid" VerticalAlignment="Top">
+                            HorizontalScrollBarVisibility="Disabled"
+                            MaxHeight="200"
+                            Margin="0,10,0,10"
+                            VerticalAlignment="Top">
+                <Grid Name="LocationsGrid"
+                      VerticalAlignment="Top">
                   <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto"></ColumnDefinition>
                     <ColumnDefinition></ColumnDefinition>
                   </Grid.ColumnDefinitions>
                 </Grid>
               </ScrollViewer>
-              <Button Content="Reset All" Click="ResetAllLocationsButton_Click" Name="ResetAllLocationsButton"/>
+              <Button Content="Reset All"
+                      Click="ResetAllLocationsButton_Click"
+                      Name="ResetAllLocationsButton" />
             </StackPanel>
           </Expander>
-          
+
           <Expander Header="Logic Options"
                     x:Name="LogicOptionsExpander"
                     IsExpanded="{Binding LogicExpanded}">
             <StackPanel Orientation="Vertical"
                         Margin="24,11,11,11"
                         DataContext="{Binding LogicConfig}">
-              
+
               <GroupBox Header="Basic Logic"
                         Padding="0,5,0,0">
-                <UniformGrid Columns="2" Name="LogicGrid" />
+                <UniformGrid Columns="2"
+                             Name="LogicGrid" />
               </GroupBox>
 
               <GroupBox Header="Tricks"
                         Padding="0,5,0,0">
-                <StackPanel Orientation="Vertical" Grid.IsSharedSizeScope="True">
+                <StackPanel Orientation="Vertical"
+                            Grid.IsSharedSizeScope="True">
                   <UniformGrid Columns="2"
                                Name="TricksGrid" />
                   <controls:LabeledControl Text="Wall jump difficulty:"
@@ -90,7 +103,7 @@
 
             </StackPanel>
           </Expander>
-          
+
           <Expander Header="Customization"
                     x:Name="CustomizationExpander"
                     IsExpanded="{Binding CustomizationExpanded}">
@@ -124,7 +137,7 @@
                           HorizontalAlignment="Left"
                           MinWidth="75" />
               </controls:LabeledControl>
-              
+
               <controls:LabeledControl Text="ALttP Menu speed:">
                 <ComboBox SelectedItem="{Binding MenuSpeed}"
                           ItemsSource="{Binding Source={local:EnumBindingSource {x:Type smz3:MenuSpeed}}}"
@@ -147,7 +160,7 @@
                 <CheckBox.ToolTip>
                   <TextBlock>
                     Enables the following patches:
-                    <LineBreak/>
+                    <LineBreak />
                     • Infinite Space Jump: space jump is easier to use <LineBreak />
                     • Respin: space jump can be restarted in mid-air
                   </TextBlock>
@@ -198,6 +211,7 @@
                         DataContext="{Binding SeedOptions}">
 
               <GroupBox Header="Game Mode Settings"
+                        IsEnabled="{Binding DisabledInPlando, Mode=OneTime, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Window}}"
                         Padding="0,5,0,0"
                         Margin="0,0,0,10">
                 <UniformGrid Columns="2">
@@ -213,7 +227,7 @@
                             Checked="RaceCheckBox_Checked"
                             Unchecked="RaceCheckBox_Unchecked"
                             Content="Generate Race Seed"
-                            ToolTip="Generates a seed used for races and disables all forms of hints and spoilers"/>
+                            ToolTip="Generates a seed used for races and disables all forms of hints and spoilers" />
                   <CheckBox IsChecked="{Binding DisableSpoilerLog}"
                             Name="DisableSpoilerLogCheckBox"
                             Content="Disable Spoiler Log" />
@@ -224,21 +238,24 @@
                             Name="DisableTrackerSpoilersCheckBox"
                             Content="Disable Tracker Spoilers" />
                   <CheckBox IsChecked="{Binding DisableCheats}"
-                    x:Name="DisableCheatsCheckBox"
-                    Content="Disable Cheats" />
+                            x:Name="DisableCheatsCheckBox"
+                            Content="Disable Cheats" />
                 </UniformGrid>
               </GroupBox>
 
-              <controls:LabeledControl Text="Seed (optional):">
+              <controls:LabeledControl Text="Seed (optional):"
+                                       IsEnabled="{Binding DisabledInPlando, Mode=OneTime, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Window}}">
                 <TextBox x:Name="SeedInput"
                          Text="{Binding Seed}" />
               </controls:LabeledControl>
 
-              <controls:LabeledControl Text="Import settings (optional):">
+              <controls:LabeledControl Text="Import settings (optional):"
+                                       IsEnabled="{Binding DisabledInPlando, Mode=OneTime, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Window}}">
                 <StackPanel Orientation="Vertical">
                   <TextBox x:Name="ConfigString"
-                         Text="{Binding ConfigString}" />
-                  <CheckBox IsChecked="{Binding CopySeedAndRaceSettings}" Margin="0,5,0,0">Also import seed and race settings</CheckBox>
+                           Text="{Binding ConfigString}" />
+                  <CheckBox IsChecked="{Binding CopySeedAndRaceSettings}"
+                            Margin="0,5,0,0">Also import seed and race settings</CheckBox>
                 </StackPanel>
               </controls:LabeledControl>
             </StackPanel>
@@ -251,8 +268,8 @@
             Style="{StaticResource BottomPanel}">
       <Grid>
         <Grid.ColumnDefinitions>
-          <ColumnDefinition Width="265*"/>
-          <ColumnDefinition Width="213*"/>
+          <ColumnDefinition Width="265*" />
+          <ColumnDefinition Width="213*" />
         </Grid.ColumnDefinitions>
         <StackPanel Orientation="Horizontal"
                     HorizontalAlignment="Left">
@@ -260,13 +277,16 @@
                   Click="GenerateStatsButton_Click">Generate _Stats</Button>
         </StackPanel>
         <StackPanel Orientation="Horizontal"
-                    HorizontalAlignment="Left" Grid.Column="1" Margin="49,0,0,0">
+                    HorizontalAlignment="Left"
+                    Grid.Column="1"
+                    Margin="49,0,0,0">
 
           <Button x:Name="GenerateRomButton"
-                  Click="GenerateRomButton_Click" Margin="0">_Generate</Button>
+                  Click="GenerateRomButton_Click"
+                  Margin="0">_Generate</Button>
 
           <Button x:Name="CancelButton"
-                          Click="CancelButton_Click">_Cancel</Button>
+                  Click="CancelButton_Click">_Cancel</Button>
         </StackPanel>
       </Grid>
     </Border>

--- a/src/Randomizer.App/Windows/GenerateRomWindow.xaml
+++ b/src/Randomizer.App/Windows/GenerateRomWindow.xaml
@@ -34,6 +34,24 @@
       <ScrollViewer VerticalScrollBarVisibility="Auto"
                     HorizontalScrollBarVisibility="Disabled">
         <StackPanel Orientation="Vertical">
+          <Border Margin="11"
+                  Padding="8"
+                  Visibility="{Binding VisibleInPlando, Mode=OneTime, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Window}}"
+                  Background="{DynamicResource {x:Static SystemColors.InfoBrushKey}}"
+                  BorderBrush="{DynamicResource {x:Static SystemColors.InfoTextBrushKey}}"
+                  BorderThickness="1"
+                  CornerRadius="2">
+            <TextBlock TextWrapping="Wrap"
+                       Foreground="{DynamicResource {x:Static SystemColors.InfoTextBrushKey}}">
+        You’re starting a plando seed. Items, rewards and other aspects of a
+        seed are manually placed according to the plando configuration file
+        you’ve selected.
+        <LineBreak /><LineBreak />
+        Plando games do not follow the usual logic of a randomized seed and may
+        or may not be completable.
+            </TextBlock>
+          </Border>
+          
           <Expander Header="Early Items"
                     x:Name="EarlyItemsExpander"
                     Visibility="{Binding InvisibleInPlando, Mode=OneTime, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Window}}"
@@ -73,6 +91,7 @@
 
           <Expander Header="Logic Options"
                     x:Name="LogicOptionsExpander"
+                    Visibility="{Binding InvisibleInPlando, Mode=OneTime, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Window}}"
                     IsExpanded="{Binding LogicExpanded}">
             <StackPanel Orientation="Vertical"
                         Margin="24,11,11,11"

--- a/src/Randomizer.App/Windows/GenerateRomWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/GenerateRomWindow.xaml.cs
@@ -315,7 +315,10 @@ namespace Randomizer.App
 
         private void GenerateRomButton_Click(object sender, RoutedEventArgs e)
         {
-            var successful = _romGenerator.GenerateRandomRom(Options, out var romPath, out var error, out var rom);
+            string error;
+            var successful = PlandoMode
+                ? _romGenerator.GeneratePlandoRom(Options, PlandoConfig, out _, out error, out _)
+                : _romGenerator.GenerateRandomRom(Options, out _, out error, out _);
             if (!successful)
             {
                 if (!string.IsNullOrEmpty(error))

--- a/src/Randomizer.App/Windows/GenerateRomWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/GenerateRomWindow.xaml.cs
@@ -15,6 +15,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Threading;
+
 using Microsoft.Extensions.DependencyInjection;
 
 using Randomizer.App.ViewModels;
@@ -59,14 +60,20 @@ namespace Randomizer.App
         public bool Plando => PlandoFiller != null;
 
         /// <summary>
-        /// Gets a value specifying the visibility of a control, if it should be
-        /// hidden when plando mode is active.
+        /// Gets the visibility of controls which should be hidden when plando
+        /// mode is active.
         /// </summary>
         public Visibility InvisibleInPlando => Plando ? Visibility.Collapsed : Visibility.Visible;
 
         /// <summary>
-        /// Gets a value indicating whether a control should be enabled, if it
-        /// should be disabled when plando mode is active.
+        /// Gets the visibility of controls which should be shown only when
+        /// plando mode is active.
+        /// </summary>
+        public Visibility VisibleInPlando => Plando ? Visibility.Visible : Visibility.Collapsed;
+
+        /// <summary>
+        /// Gets the IsEnabled value for controls which should be disabled when
+        /// plando mode is active.
         /// </summary>
         public bool DisabledInPlando => !Plando;
 
@@ -119,7 +126,8 @@ namespace Randomizer.App
         }
 
         /// <summary>
-        /// Populates the two grids with the logic option controls using reflection
+        /// Populates the two grids with the logic option controls using
+        /// reflection
         /// </summary>
         public void PopulateLogicOptions()
         {
@@ -165,7 +173,8 @@ namespace Randomizer.App
                 LocationsRegionFilter.Items.Add(name);
             }
 
-            // Create rows for each location to be able to specify the items at that location
+            // Create rows for each location to be able to specify the items at
+            // that location
             var row = 0;
             foreach (var location in world.Locations.OrderBy(x => x.Room == null ? "" : x.Room.Name).ThenBy(x => x.Name))
             {
@@ -243,7 +252,9 @@ namespace Randomizer.App
         /// <summary>
         /// Creates a combo box for the item options for a location
         /// </summary>
-        /// <param name="location">The location to generate the combo box for</param>
+        /// <param name="location">
+        /// The location to generate the combo box for
+        /// </param>
         /// <returns>The generated combo box</returns>
         private ComboBox CreateLocationComboBox(Location location)
         {
@@ -301,6 +312,7 @@ namespace Randomizer.App
 
             return comboBox;
         }
+
         private void GenerateRomButton_Click(object sender, RoutedEventArgs e)
         {
             var successful = _romGenerator.GenerateRom(Options, out var romPath, out var error, out var rom);
@@ -508,7 +520,8 @@ namespace Randomizer.App
         }
 
         /// <summary>
-        /// Updates the LogicOptions based on when a checkbox is checked/unchecked using reflection
+        /// Updates the LogicOptions based on when a checkbox is
+        /// checked/unchecked using reflection
         /// </summary>
         /// <param name="sender">The checkbox that was checked</param>
         /// <param name="e">The event object</param>
@@ -539,7 +552,7 @@ namespace Randomizer.App
         }
 
         /// <summary>
-        /// Handles updates 
+        /// Handles updates
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
@@ -575,7 +588,8 @@ namespace Randomizer.App
         }
 
         /// <summary>
-        /// Updates the EarlyItems based on when a checkbox is checked/unchecked using reflection
+        /// Updates the EarlyItems based on when a checkbox is checked/unchecked
+        /// using reflection
         /// </summary>
         /// <param name="sender">The checkbox that was checked</param>
         /// <param name="e">The event object</param>
@@ -614,6 +628,7 @@ namespace Randomizer.App
         {
             public int Value { get; set; }
             public string Text { get; set; }
+
             public override string ToString() => Text;
         }
     }

--- a/src/Randomizer.App/Windows/GenerateRomWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/GenerateRomWindow.xaml.cs
@@ -54,28 +54,28 @@ namespace Randomizer.App
         }
 
 #nullable enable
-        public PlandoFiller? PlandoFiller { get; set; }
+        public PlandoConfig? PlandoConfig { get; set; }
 #nullable disable
 
-        public bool Plando => PlandoFiller != null;
+        public bool PlandoMode => PlandoConfig != null;
 
         /// <summary>
         /// Gets the visibility of controls which should be hidden when plando
         /// mode is active.
         /// </summary>
-        public Visibility InvisibleInPlando => Plando ? Visibility.Collapsed : Visibility.Visible;
+        public Visibility InvisibleInPlando => PlandoMode ? Visibility.Collapsed : Visibility.Visible;
 
         /// <summary>
         /// Gets the visibility of controls which should be shown only when
         /// plando mode is active.
         /// </summary>
-        public Visibility VisibleInPlando => Plando ? Visibility.Visible : Visibility.Collapsed;
+        public Visibility VisibleInPlando => PlandoMode ? Visibility.Visible : Visibility.Collapsed;
 
         /// <summary>
         /// Gets the IsEnabled value for controls which should be disabled when
         /// plando mode is active.
         /// </summary>
-        public bool DisabledInPlando => !Plando;
+        public bool DisabledInPlando => !PlandoMode;
 
         public ObservableCollection<Sprite> SamusSprites { get; } = new();
 
@@ -315,7 +315,7 @@ namespace Randomizer.App
 
         private void GenerateRomButton_Click(object sender, RoutedEventArgs e)
         {
-            var successful = _romGenerator.GenerateRom(Options, out var romPath, out var error, out var rom);
+            var successful = _romGenerator.GenerateRandomRom(Options, out var romPath, out var error, out var rom);
             if (!successful)
             {
                 if (!string.IsNullOrEmpty(error))

--- a/src/Randomizer.App/Windows/RomListWindow.xaml
+++ b/src/Randomizer.App/Windows/RomListWindow.xaml
@@ -126,10 +126,10 @@
                     HorizontalAlignment="Right">
           <Button x:Name="QuickPlayButton"
                   Click="QuickPlayButton_Click">_Quick play</Button>
-          <Button x:Name="GenerateRomButton"
-                  Click="GenerateRomButton_Click">Generate custom game...</Button>
           <Button x:Name="StartPlandoButton"
                   Click="StartPlandoButton_Click">Start plando...</Button>
+          <Button x:Name="GenerateRomButton"
+                  Click="GenerateRomButton_Click">Generate custom game...</Button>
         </StackPanel>
       </Grid>
     </Border>

--- a/src/Randomizer.App/Windows/RomListWindow.xaml
+++ b/src/Randomizer.App/Windows/RomListWindow.xaml
@@ -128,6 +128,8 @@
                   Click="QuickPlayButton_Click">_Quick play</Button>
           <Button x:Name="GenerateRomButton"
                   Click="GenerateRomButton_Click">Generate custom game...</Button>
+          <Button x:Name="StartPlandoButton"
+                  Click="StartPlandoButton_Click">Start plando...</Button>
         </StackPanel>
       </Grid>
     </Border>

--- a/src/Randomizer.App/Windows/RomListWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/RomListWindow.xaml.cs
@@ -170,7 +170,7 @@ namespace Randomizer.App
             catch (YamlException ex)
             {
                 _logger.LogWarning(ex, "Plando config '{FileName}' is malformed.", plandoBrowser.FileName);
-                MessageBox.Show(this, "The selected plando configuration is malformed:\n\n" + ex.Message,
+                MessageBox.Show(this, $"The selected plando configuration contains errors in line {ex.Start.Line}, col {ex.Start.Column}:\n\n{ex.InnerException?.Message ?? ex.Message}",
                     "SMZ3 Cas’ Randomizer", MessageBoxButton.OK, MessageBoxImage.Warning);
             }
             catch (Exception ex)

--- a/src/Randomizer.App/Windows/RomListWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/RomListWindow.xaml.cs
@@ -15,6 +15,7 @@ using Microsoft.Win32;
 
 using Randomizer.App.ViewModels;
 using Randomizer.Shared.Models;
+using Randomizer.SMZ3.Contracts;
 using Randomizer.SMZ3.Generation;
 using Randomizer.SMZ3.Tracking.Services;
 using Randomizer.SMZ3.Tracking.VoiceCommands;
@@ -94,7 +95,7 @@ namespace Randomizer.App
         /// <param name="e"></param>
         private void QuickPlayButton_Click(object sender, RoutedEventArgs e)
         {
-            var successful = _romGenerator.GenerateRom(Options, out var romPath, out var error, out var rom);
+            var successful = _romGenerator.GenerateRandomRom(Options, out var romPath, out var error, out var rom);
 
             if (!successful)
             {
@@ -135,7 +136,6 @@ namespace Randomizer.App
         private async void StartPlandoButton_Click(object sender, RoutedEventArgs e)
         {
             using var scope = _serviceProvider.CreateScope();
-            var plandoFactory = scope.ServiceProvider.GetRequiredService<PlandoFillerFactory>();
 
             var plandoBrowser = new OpenFileDialog
             {
@@ -147,10 +147,11 @@ namespace Randomizer.App
 
             try
             {
-                var plandoFiller = await plandoFactory.CreateFromFileAsync(plandoBrowser.FileName);
+                var plandoConfigLoader = scope.ServiceProvider.GetRequiredService<IPlandoConfigLoader>();
+                var plandoConfig = await plandoConfigLoader.LoadAsync(plandoBrowser.FileName);
 
                 var generateWindow = scope.ServiceProvider.GetRequiredService<GenerateRomWindow>();
-                generateWindow.PlandoFiller = plandoFiller;
+                generateWindow.PlandoConfig = plandoConfig;
                 generateWindow.Owner = this;
                 generateWindow.Options = Options;
                 if (generateWindow.ShowDialog() == true)

--- a/src/Randomizer.App/Windows/RomListWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/RomListWindow.xaml.cs
@@ -95,7 +95,7 @@ namespace Randomizer.App
         /// <param name="e"></param>
         private void QuickPlayButton_Click(object sender, RoutedEventArgs e)
         {
-            var successful = _romGenerator.GenerateRandomRom(Options, out var romPath, out var error, out var rom);
+            var successful = _romGenerator.GenerateRandomRom(Options, out _, out var error, out var rom);
 
             if (!successful)
             {

--- a/src/Randomizer.App/Windows/TrackerMapWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/TrackerMapWindow.xaml.cs
@@ -125,6 +125,9 @@ namespace Randomizer.App
         /// <param name="mapName">The name of the map to display</param>
         public void UpdateMap(string mapName)
         {
+            if (mapName == null)
+                return;
+
             UpdateMap(Maps.First(x => x.ToString() == mapName));
         }
 

--- a/src/Randomizer.SMZ3.Tracking/Configuration/ConfigTypes/HintsConfig.cs
+++ b/src/Randomizer.SMZ3.Tracking/Configuration/ConfigTypes/HintsConfig.cs
@@ -42,6 +42,13 @@ namespace Randomizer.SMZ3.Tracking.Configuration
             = new("Reply hazy, try again.", "Ask again later.", "Better not tell you now.", "Cannot predict now.", "Concentrate and ask again.");
 
         /// <summary>
+        /// Gets the phrases to rspond with when asked about hints on a seed
+        /// where a complete playthrough is likely impossible.
+        /// </summary>
+        public SchrodingersString PlaythroughImpossible { get; init; }
+            = new("Sorry, you're on your own with this one.");
+
+        /// <summary>
         /// Gets the hints for items that are not in logic.
         /// </summary>
         /// <remarks>

--- a/src/Randomizer.SMZ3.Tracking/TrackerState.cs
+++ b/src/Randomizer.SMZ3.Tracking/TrackerState.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Threading.Tasks;
+
 using Randomizer.Shared;
 using Randomizer.Shared.Models;
 using Randomizer.SMZ3.Contracts;
@@ -348,7 +349,6 @@ namespace Randomizer.SMZ3.Tracking
 
             if (rom.TrackerState == null)
             {
-
                 var trackerState = new Shared.Models.TrackerState()
                 {
                     StartDateTime = DateTimeOffset.Now,
@@ -555,9 +555,7 @@ namespace Randomizer.SMZ3.Tracking
         /// <summary>
         /// Represents the tracking state of a boss
         /// </summary>
-        /// <param name="Name">
-        /// The name of the boss
-        /// </param>
+        /// <param name="Name">The name of the boss</param>
         /// <param name="Defeated">
         /// Indicates whether the boss has been defeated or not.
         /// </param>

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/SpoilerModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/SpoilerModule.cs
@@ -218,6 +218,13 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
                 return;
             }
 
+            // Now that we're ready to give hints, make sure they're turned on
+            if (!Tracker.HintsEnabled && !Tracker.SpoilersEnabled)
+            {
+                Tracker.Say(x => x.Hints.PromptEnableItemHints);
+                return;
+            }
+
             // Once we're done being a smartass, see if the item can be found at all
             var locations = Tracker.World.Locations
                 .Where(x => x.Item.Type == item.InternalItemType)
@@ -234,13 +241,6 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
             {
                 // The item exists, but all locations are cleared
                 Tracker.Say(x => x.Spoilers.LocationsCleared, item.NameWithArticle);
-                return;
-            }
-
-            // Now that we're ready to give hints, make sure they're turned on
-            if (!Tracker.HintsEnabled && !Tracker.SpoilersEnabled)
-            {
-                Tracker.Say(x => x.Hints.PromptEnableItemHints);
                 return;
             }
 

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/SpoilerModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/SpoilerModule.cs
@@ -30,22 +30,24 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
 
         private readonly Dictionary<ItemType, int> _itemHintsGiven = new();
         private readonly Dictionary<int, int> _locationHintsGiven = new();
-        private readonly Playthrough _playthrough;
+        private readonly Playthrough? _playthrough;
         private readonly IItemService _itemService;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SpoilerModule"/> class.
         /// </summary>
         /// <param name="tracker">The tracker instance.</param>
+        /// <param name="itemService">Used to manage item information.</param>
         /// <param name="logger">Used to write logging information.</param>
         public SpoilerModule(Tracker tracker, IItemService itemService, ILogger<SpoilerModule> logger)
             : base(tracker, itemService, logger)
         {
             Tracker.HintsEnabled = !tracker.World.Config.Race && !tracker.World.Config.DisableTrackerHints && tracker.Options.HintsEnabled;
             Tracker.SpoilersEnabled = !tracker.World.Config.Race && !tracker.World.Config.DisableTrackerSpoilers && tracker.Options.SpoilersEnabled;
-            if (tracker.World.Config.Race) return;
-            _playthrough = Playthrough.Generate(new[] { tracker.World }, tracker.World.Config);
             _itemService = itemService;
+            if (tracker.World.Config.Race) return;
+
+            Playthrough.TryGenerate(new[] { tracker.World }, tracker.World.Config, out _playthrough);
 
             if (!tracker.World.Config.DisableTrackerHints)
             {
@@ -580,6 +582,11 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
                                 if (randomMissingItem != null)
                                     return GiveItemHint(x => x.ItemRequiresOtherItem, item, randomMissingItem.NameWithArticle);
                             }
+                        }
+
+                        if (_playthrough == null)
+                        {
+                            return GiveItemHint(x => x.PlaythroughImpossible, item);
                         }
 
                         var sphere = _playthrough.Spheres.IndexOf(x => x.Items.Any(i => i.Type == item.InternalItemType));

--- a/src/Randomizer.SMZ3/Config.cs
+++ b/src/Randomizer.SMZ3/Config.cs
@@ -6,7 +6,9 @@ using System.IO.Compression;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
+
 using Randomizer.Shared;
+using Randomizer.SMZ3.Generation;
 
 namespace Randomizer.SMZ3
 {
@@ -211,6 +213,9 @@ namespace Randomizer.SMZ3
         public IDictionary<int, int> LocationItems { get; set; } = new Dictionary<int, int>();
         public ISet<ItemType> EarlyItems { get; set; } = new HashSet<ItemType>();
         public LogicConfig LogicConfig { get; set; } = new LogicConfig();
+#nullable enable
+        public PlandoConfig? PlandoConfig { get; set; }
+#nullable disable
         public bool ShaktoolWithoutGrapple { get; set; }
 
         public Config SeedOnly()

--- a/src/Randomizer.SMZ3/Config.cs
+++ b/src/Randomizer.SMZ3/Config.cs
@@ -174,16 +174,6 @@ namespace Randomizer.SMZ3
         };
 
         public GameMode GameMode { get; set; } = GameMode.Normal;
-        public Z3Logic Z3Logic { get; set; } = Z3Logic.Normal;
-        public SMLogic SMLogic { get; set; } = SMLogic.Normal;
-
-        public IDictionary<ItemType, ItemPlacement> ItemLocations { get; }
-            = new Dictionary<ItemType, ItemPlacement>();
-
-        public ItemPool ShaktoolItemPool { get; set; } = ItemPool.Any;
-        public ItemPool PegWorldItemPool { get; set; } = ItemPool.Any;
-        public Goal Goal { get; set; } = Goal.DefeatBoth;
-        public KeyShuffle KeyShuffle { get; set; } = KeyShuffle.None;
         public bool Race { get; set; } = false;
         public bool DisableSpoilerLog { get; set; } = false;
         public bool DisableTrackerSpoilers { get; set; } = false;
@@ -206,7 +196,7 @@ namespace Randomizer.SMZ3
 
         public bool SingleWorld => GameMode == GameMode.Normal;
         public bool MultiWorld => GameMode == GameMode.Multiworld;
-        public bool Keysanity => KeyShuffle != KeyShuffle.None;
+        public bool Keysanity { get; set; }
         public string Seed { get; set; }
         public string SettingsString { get; set; }
         public bool CopySeedAndRaceSettings { get; set; }

--- a/src/Randomizer.SMZ3/Contracts/IFiller.cs
+++ b/src/Randomizer.SMZ3/Contracts/IFiller.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Threading;
 
-namespace Randomizer.SMZ3.Generation
+namespace Randomizer.SMZ3.Contracts
 {
     /// <summary>
     /// Defines an algorithm for filling items into one or more SMZ3 worlds.

--- a/src/Randomizer.SMZ3/Contracts/IPlandoConfigLoader.cs
+++ b/src/Randomizer.SMZ3/Contracts/IPlandoConfigLoader.cs
@@ -1,0 +1,12 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+using Randomizer.SMZ3.Generation;
+
+namespace Randomizer.SMZ3.Contracts
+{
+    public interface IPlandoConfigLoader
+    {
+        Task<PlandoConfig> LoadAsync(string path, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Randomizer.SMZ3/Contracts/IRandomizer.cs
+++ b/src/Randomizer.SMZ3/Contracts/IRandomizer.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Threading;
+
+using Randomizer.SMZ3.Generation;
+
+namespace Randomizer.SMZ3.Contracts
+{
+    public interface IRandomizer
+    {
+        SeedData GenerateSeed(Config config, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Randomizer.SMZ3/Contracts/ISeededRandomizer.cs
+++ b/src/Randomizer.SMZ3/Contracts/ISeededRandomizer.cs
@@ -1,0 +1,13 @@
+﻿using System.Threading;
+
+using Randomizer.SMZ3.Generation;
+
+namespace Randomizer.SMZ3.Contracts
+{
+    public interface ISeededRandomizer : IRandomizer
+    {
+        SeedData GenerateSeed(Config config, string seed, CancellationToken cancellationToken = default);
+
+        bool ValidateSeedSettings(SeedData seedData, Config config);
+    }
+}

--- a/src/Randomizer.SMZ3/FileData/Patcher.cs
+++ b/src/Randomizer.SMZ3/FileData/Patcher.cs
@@ -693,12 +693,21 @@ namespace Randomizer.SMZ3.FileData
             _patches.Add((Snes(0x309200), Dialog.Simple(ganonThirdPhaseInvincible)));
             // ---
 
-            var silversLocation = _allWorlds.SelectMany(world => world.Locations).Where(l => l.ItemIs(ItemType.SilverArrows, _myWorld)).First();
-            var silvers = config.MultiWorld ?
-                Texts.GanonThirdPhaseMulti(silversLocation.Region, _myWorld) :
-                Texts.GanonThirdPhaseSingle(silversLocation.Region);
-            _patches.Add((Snes(0x308700), Dialog.Simple(silvers)));
-            _stringTable.SetGanonThirdPhaseText(silvers);
+            var silversLocation = _allWorlds.SelectMany(world => world.Locations).Where(l => l.ItemIs(ItemType.SilverArrows, _myWorld)).FirstOrDefault();
+            if (silversLocation != null)
+            {
+                var silvers = config.MultiWorld
+                    ? Texts.GanonThirdPhaseMulti(silversLocation.Region, _myWorld)
+                    : Texts.GanonThirdPhaseSingle(silversLocation.Region);
+                _patches.Add((Snes(0x308700), Dialog.Simple(silvers)));
+                _stringTable.SetGanonThirdPhaseText(silvers);
+            }
+            else
+            {
+                var silvers = Texts.GanonThirdPhraseNone();
+                _patches.Add((Snes(0x308700), Dialog.Simple(silvers)));
+                _stringTable.SetGanonThirdPhaseText(silvers);
+            }
 
             var triforceRoom = Texts.TriforceRoom(_rnd);
             _patches.Add((Snes(0x308400), Dialog.Simple(triforceRoom)));

--- a/src/Randomizer.SMZ3/FileData/Patcher.cs
+++ b/src/Randomizer.SMZ3/FileData/Patcher.cs
@@ -735,8 +735,6 @@ namespace Randomizer.SMZ3.FileData
                 ((_myWorld.Config.Race ? 1 : 0) << 15) |
                 ((_myWorld.Config.Keysanity ? 1 : 0) << 13) |
                 ((_enableMultiworld ? 1 : 0) << 12) |
-                ((int)_myWorld.Config.Z3Logic << 10) |
-                ((int)_myWorld.Config.SMLogic << 8) |
                 (Generation.Smz3Randomizer.Version.Major << 4) |
                 (Generation.Smz3Randomizer.Version.Minor << 0);
 
@@ -760,18 +758,6 @@ namespace Randomizer.SMZ3.FileData
 
         private void WriteGameTitle()
         {
-            var z3Glitch = _myWorld.Config.Z3Logic switch
-            {
-                Z3Logic.Nmg => "N",
-                Z3Logic.Owg => "O",
-                _ => "C",
-            };
-            var smGlitch = _myWorld.Config.SMLogic switch
-            {
-                SMLogic.Normal => "N",
-                SMLogic.Hard => "H",
-                _ => "X",
-            };
             var title = AsAscii($"SMZ3 Cas' [{_seed:X8}]".PadRight(21)[..21]);
             _patches.Add((Snes(0x00FFC0), title));
             _patches.Add((Snes(0x80FFC0), title));

--- a/src/Randomizer.SMZ3/Generation/IFiller.cs
+++ b/src/Randomizer.SMZ3/Generation/IFiller.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Threading;
 
-namespace Randomizer.SMZ3
+namespace Randomizer.SMZ3.Generation
 {
     /// <summary>
     /// Defines an algorithm for filling items into one or more SMZ3 worlds.
@@ -18,7 +18,7 @@ namespace Randomizer.SMZ3
         void SetRandom(Random random);
 
         /// <summary>
-        /// Randomly distributes items across locations in the specified worlds.
+        /// Distributes items across locations in the specified worlds.
         /// </summary>
         /// <param name="worlds">The world or worlds to initialize.</param>
         /// <param name="config">The configuration to use.</param>

--- a/src/Randomizer.SMZ3/Generation/PlandoConfig.cs
+++ b/src/Randomizer.SMZ3/Generation/PlandoConfig.cs
@@ -1,9 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO.Enumeration;
 using System.Linq;
 
 using Randomizer.Shared;
 using Randomizer.SMZ3.Regions;
+
+using SharpYaml.Serialization;
 
 namespace Randomizer.SMZ3.Generation
 {
@@ -36,6 +39,13 @@ namespace Randomizer.SMZ3.Generation
                 .ToDictionary(x => x.ToString(), x => ((INeedsMedallion)x).Medallion);
             Logic = world.Config.LogicConfig.Clone();
         }
+
+        /// <summary>
+        /// Gets or sets the name of the file from which the plando config was
+        /// deserialized.
+        /// </summary>
+        [YamlIgnore]
+        public string FileName { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether Keysanity should be enabled.

--- a/src/Randomizer.SMZ3/Generation/PlandoConfig.cs
+++ b/src/Randomizer.SMZ3/Generation/PlandoConfig.cs
@@ -1,12 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO.Enumeration;
 using System.Linq;
 
 using Randomizer.Shared;
 using Randomizer.SMZ3.Regions;
 
-using SharpYaml.Serialization;
+using YamlDotNet.Serialization;
 
 namespace Randomizer.SMZ3.Generation
 {

--- a/src/Randomizer.SMZ3/Generation/PlandoConfig.cs
+++ b/src/Randomizer.SMZ3/Generation/PlandoConfig.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Randomizer.Shared;
+
+namespace Randomizer.SMZ3.Generation
+{
+    /// <summary>
+    /// Represents the configuration for a plandomizer world.
+    /// </summary>
+    public class PlandoConfig
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether Keysanity should be enabled.
+        /// </summary>
+        public bool Keysanity { get; set; }
+
+        /// <summary>
+        /// Gets or sets a dictionary that contains the names of locations and
+        /// the types of items they should be filled with.
+        /// </summary>
+        public Dictionary<string, ItemType> Items { get; set; }
+
+        /// <summary>
+        /// Gets or sets a dictionary that contains the names of regions and the
+        /// boss rewards they should be filled with.
+        /// </summary>
+        public Dictionary<string, RewardType> Rewards { get; set; }
+
+        /// <summary>
+        /// Gets or sets a dictionary that contains the names of regions and the
+        /// medallions they require.
+        /// </summary>
+        public Dictionary<string, Medallion> Medallions { get; set; }
+    }
+}

--- a/src/Randomizer.SMZ3/Generation/PlandoConfig.cs
+++ b/src/Randomizer.SMZ3/Generation/PlandoConfig.cs
@@ -1,15 +1,42 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using Randomizer.Shared;
+using Randomizer.SMZ3.Regions;
 
 namespace Randomizer.SMZ3.Generation
 {
     /// <summary>
     /// Represents the configuration for a plandomizer world.
     /// </summary>
-    public class PlandoConfig
+    public class PlandoConfig // TODO: Consider using this instead of SeedData?
     {
+        /// <summary>
+        /// Initializes a new empty instance of the <see cref="PlandoConfig"/>
+        /// class.
+        /// </summary>
+        public PlandoConfig()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PlandoConfig"/> based
+        /// on the specified world.
+        /// </summary>
+        /// <param name="world">The world instance to export to a config.</param>
+        public PlandoConfig(World world)
+        {
+            Keysanity = world.Config.Keysanity;
+            Items = world.Locations
+                .ToDictionary(x => x.ToString(), x => x.Item.Type);
+            Rewards = world.Regions.Where(x => x is IHasReward)
+                .ToDictionary(x => x.ToString(), x => ((IHasReward)x).Reward);
+            Medallions = world.Regions.Where(x => x is INeedsMedallion)
+                .ToDictionary(x => x.ToString(), x => ((INeedsMedallion)x).Medallion);
+            Logic = world.Config.LogicConfig.Clone();
+        }
+
         /// <summary>
         /// Gets or sets a value indicating whether Keysanity should be enabled.
         /// </summary>
@@ -31,7 +58,7 @@ namespace Randomizer.SMZ3.Generation
         /// Gets or sets a dictionary that contains the names of regions and the
         /// medallions they require.
         /// </summary>
-        public Dictionary<string, Medallion> Medallions { get; set; }
+        public Dictionary<string, ItemType> Medallions { get; set; }
 
         /// <summary>
         /// Gets or sets the logic options that apply to the plando.

--- a/src/Randomizer.SMZ3/Generation/PlandoConfig.cs
+++ b/src/Randomizer.SMZ3/Generation/PlandoConfig.cs
@@ -32,5 +32,10 @@ namespace Randomizer.SMZ3.Generation
         /// medallions they require.
         /// </summary>
         public Dictionary<string, Medallion> Medallions { get; set; }
+
+        /// <summary>
+        /// Gets or sets the logic options that apply to the plando.
+        /// </summary>
+        public LogicConfig Logic { get; set; }
     }
 }

--- a/src/Randomizer.SMZ3/Generation/PlandoConfigLoader.cs
+++ b/src/Randomizer.SMZ3/Generation/PlandoConfigLoader.cs
@@ -17,7 +17,9 @@ namespace Randomizer.SMZ3.Generation
         {
             var serializer = new SharpYaml.Serialization.Serializer();
             var yaml = await File.ReadAllTextAsync(path, Encoding.UTF8, cancellationToken);
-            return serializer.Deserialize<PlandoConfig>(yaml);
+            var config = serializer.Deserialize<PlandoConfig>(yaml);
+            config.FileName = Path.GetFileName(path);
+            return config;
         }
     }
 }

--- a/src/Randomizer.SMZ3/Generation/PlandoConfigLoader.cs
+++ b/src/Randomizer.SMZ3/Generation/PlandoConfigLoader.cs
@@ -18,7 +18,7 @@ namespace Randomizer.SMZ3.Generation
             var serializer = new SharpYaml.Serialization.Serializer();
             var yaml = await File.ReadAllTextAsync(path, Encoding.UTF8, cancellationToken);
             var config = serializer.Deserialize<PlandoConfig>(yaml);
-            config.FileName = Path.GetFileName(path);
+            config.FileName = Path.GetFileNameWithoutExtension(path);
             return config;
         }
     }

--- a/src/Randomizer.SMZ3/Generation/PlandoConfigLoader.cs
+++ b/src/Randomizer.SMZ3/Generation/PlandoConfigLoader.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Randomizer.SMZ3.Contracts;
+
+namespace Randomizer.SMZ3.Generation
+{
+    public class PlandoConfigLoader : IPlandoConfigLoader
+    {
+        public async Task<PlandoConfig> LoadAsync(string path,
+            CancellationToken cancellationToken = default)
+        {
+            var serializer = new SharpYaml.Serialization.Serializer();
+            var yaml = await File.ReadAllTextAsync(path, Encoding.UTF8, cancellationToken);
+            return serializer.Deserialize<PlandoConfig>(yaml);
+        }
+    }
+}

--- a/src/Randomizer.SMZ3/Generation/PlandoConfigLoader.cs
+++ b/src/Randomizer.SMZ3/Generation/PlandoConfigLoader.cs
@@ -15,7 +15,7 @@ namespace Randomizer.SMZ3.Generation
         public async Task<PlandoConfig> LoadAsync(string path,
             CancellationToken cancellationToken = default)
         {
-            var serializer = new SharpYaml.Serialization.Serializer();
+            var serializer = new YamlDotNet.Serialization.Deserializer();
             var yaml = await File.ReadAllTextAsync(path, Encoding.UTF8, cancellationToken);
             var config = serializer.Deserialize<PlandoConfig>(yaml);
             config.FileName = Path.GetFileNameWithoutExtension(path);

--- a/src/Randomizer.SMZ3/Generation/PlandoConfigurationException.cs
+++ b/src/Randomizer.SMZ3/Generation/PlandoConfigurationException.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.ExceptionServices;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Randomizer.SMZ3.Generation
+{
+    public class PlandoConfigurationException : Exception
+    {
+        public PlandoConfigurationException()
+        {
+        }
+
+        public PlandoConfigurationException(string message) : base(message)
+        {
+        }
+
+        public PlandoConfigurationException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        protected PlandoConfigurationException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/src/Randomizer.SMZ3/Generation/PlandoFiller.cs
+++ b/src/Randomizer.SMZ3/Generation/PlandoFiller.cs
@@ -110,9 +110,9 @@ namespace Randomizer.SMZ3.Generation
 
                 dungeon.Medallion = medallion switch
                 {
-                    Medallion.Bombos => ItemType.Bombos,
-                    Medallion.Ether => ItemType.Ether,
-                    Medallion.Quake => ItemType.Quake,
+                    ItemType.Bombos => ItemType.Bombos,
+                    ItemType.Ether => ItemType.Ether,
+                    ItemType.Quake => ItemType.Quake,
                     _ => throw new PlandoConfigurationException($"{medallion} is not a valid type of medallion.")
                 };
             }
@@ -143,7 +143,7 @@ namespace Randomizer.SMZ3.Generation
             foreach (var locationName in PlandoConfig.Items.Keys)
             {
                 var itemType = PlandoConfig.Items[locationName];
-                var location = world.FindLocation(locationName);
+                var location = world.FindLocation(locationName, StringComparison.OrdinalIgnoreCase);
                 if (location == null)
                     throw new PlandoConfigurationException($"Could not find a location with the specified name.\nName: '{locationName}'");
 

--- a/src/Randomizer.SMZ3/Generation/PlandoFiller.cs
+++ b/src/Randomizer.SMZ3/Generation/PlandoFiller.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using Microsoft.Extensions.Logging;
 
 using Randomizer.Shared;
+using Randomizer.SMZ3.Contracts;
 using Randomizer.SMZ3.Regions;
 
 namespace Randomizer.SMZ3.Generation

--- a/src/Randomizer.SMZ3/Generation/PlandoFiller.cs
+++ b/src/Randomizer.SMZ3/Generation/PlandoFiller.cs
@@ -1,0 +1,155 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+using Microsoft.Extensions.Logging;
+
+using Randomizer.Shared;
+using Randomizer.SMZ3.Regions;
+
+namespace Randomizer.SMZ3.Generation
+{
+    /// <summary>
+    /// Fills an SMZ3 world with items according to pre-planned configuration.
+    /// </summary>
+    public class PlandoFiller : IFiller
+    {
+        private readonly ILogger<PlandoFiller> _logger;
+        private Random _random;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PlandoFiller"/> class
+        /// with the specified configuration.
+        /// </summary>
+        /// <param name="plandoConfig">
+        /// The plando configuration that determines how items are placed.
+        /// </param>
+        /// <param name="logger">Used to write logging information.</param>
+        public PlandoFiller(PlandoConfig plandoConfig, ILogger<PlandoFiller> logger)
+        {
+            PlandoConfig = plandoConfig;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Gets the plando configuration for the current filler.
+        /// </summary>
+        public PlandoConfig PlandoConfig { get; }
+
+        /// <summary>
+        /// Randomly distributes items across locations in the specified worlds.
+        /// </summary>
+        /// <param name="worlds">The world or worlds to initialize.</param>
+        /// <param name="config">The configuration to use.</param>
+        /// <param name="cancellationToken">
+        /// A token to monitor for cancellation requests.
+        /// </param>
+        /// <exception cref="PlandoConfigurationException">
+        /// The plando configuration contains one or more errors.
+        /// </exception>
+        public void Fill(List<World> worlds, Config config, CancellationToken cancellationToken)
+        {
+            if (worlds.Count == 0) return;
+            if (worlds.Count > 1) throw new NotSupportedException(nameof(PlandoFiller) + " does not suport multi-world generation.");
+
+            var world = worlds.First();
+
+            FillItems(world);
+            AssignRewards(world);
+            AssignMedallions(world);
+        }
+
+        public void SetRandom(Random random)
+        {
+            _random = random ?? throw new ArgumentNullException(nameof(random));
+        }
+
+        private static void EnsureDungeonsHaveMedallions(World world)
+        {
+            var emptyMedallions = world.Regions.Where(x => x is INeedsMedallion dungeon && dungeon.Medallion == ItemType.Nothing);
+            if (emptyMedallions.Any())
+            {
+                throw new PlandoConfigurationException($"Not all dungeons have had their medallions set. Missing:\n"
+                    + string.Join('\n', emptyMedallions.Select(x => x.Name)));
+            }
+        }
+
+        private static void EnsureDungeonsHaveRewards(World world)
+        {
+            var emptyDungeons = world.Regions.Where(x => x is IHasReward dungeon && dungeon.Reward == Shared.RewardType.None);
+            if (emptyDungeons.Any())
+            {
+                throw new PlandoConfigurationException($"Not all dungeons have had their rewards set. Missing:\n"
+                    + string.Join('\n', emptyDungeons.Select(x => x.Name)));
+            }
+        }
+
+        private static void EnsureLocationsHaveItems(World world)
+        {
+            var emptyLocations = world.Locations.Where(x => x.Item == null);
+            if (emptyLocations.Any())
+            {
+                throw new PlandoConfigurationException($"Not all locations have been filled. Missing:\n"
+                    + string.Join('\n', emptyLocations.Select(x => x.Name)));
+            }
+        }
+
+        private void AssignMedallions(World world)
+        {
+            foreach (var regionName in PlandoConfig.Medallions.Keys)
+            {
+                var medallion = PlandoConfig.Medallions[regionName];
+                var region = world.Regions.FirstOrDefault(x => x.Name.Equals(regionName, StringComparison.OrdinalIgnoreCase));
+                if (region == null)
+                    throw new PlandoConfigurationException($"Could not find a region with the specified name.\nName: '{regionName}'");
+
+                if (region is not INeedsMedallion dungeon)
+                    throw new PlandoConfigurationException($"{region.Name} is configured with a medallion but that region cannot be configured with medallions.");
+
+                dungeon.Medallion = medallion switch
+                {
+                    Medallion.Bombos => ItemType.Bombos,
+                    Medallion.Ether => ItemType.Ether,
+                    Medallion.Quake => ItemType.Quake,
+                    _ => throw new PlandoConfigurationException($"{medallion} is not a valid type of medallion.")
+                };
+            }
+
+            EnsureDungeonsHaveMedallions(world);
+        }
+
+        private void AssignRewards(World world)
+        {
+            foreach (var regionName in PlandoConfig.Rewards.Keys)
+            {
+                var rewardType = PlandoConfig.Rewards[regionName];
+                var region = world.Regions.FirstOrDefault(x => x.Name.Equals(regionName, StringComparison.OrdinalIgnoreCase));
+                if (region == null)
+                    throw new PlandoConfigurationException($"Could not find a region with the specified name.\nName: '{regionName}'");
+
+                if (region is not IHasReward dungeon)
+                    throw new PlandoConfigurationException($"{region.Name} is configured with a reward but that region cannot be configured with rewards.");
+
+                dungeon.Reward = rewardType;
+            }
+
+            EnsureDungeonsHaveRewards(world);
+        }
+
+        private void FillItems(World world)
+        {
+            foreach (var locationName in PlandoConfig.Items.Keys)
+            {
+                var itemType = PlandoConfig.Items[locationName];
+                var location = world.FindLocation(locationName);
+                if (location == null)
+                    throw new PlandoConfigurationException($"Could not find a location with the specified name.\nName: '{locationName}'");
+
+                location.Item = new Item(itemType, world);
+            }
+
+            EnsureLocationsHaveItems(world);
+        }
+    }
+}

--- a/src/Randomizer.SMZ3/Generation/PlandoFillerFactory.cs
+++ b/src/Randomizer.SMZ3/Generation/PlandoFillerFactory.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging;
+
+namespace Randomizer.SMZ3.Generation
+{
+    public class PlandoFillerFactory
+    {
+        private readonly ILoggerFactory _loggerFactory;
+
+        public PlandoFillerFactory(ILoggerFactory loggerFactory)
+        {
+            _loggerFactory = loggerFactory;
+        }
+
+        public async Task<PlandoFiller> CreateFromFileAsync(string path,
+            CancellationToken cancellationToken = default)
+        {
+            var plandoConfig = await LoadPlandoConfigAsync(path, cancellationToken);
+            var logger = _loggerFactory.CreateLogger<PlandoFiller>();
+            return new PlandoFiller(plandoConfig, logger);
+        }
+
+        private static async Task<PlandoConfig> LoadPlandoConfigAsync(string path,
+            CancellationToken cancellationToken)
+        {
+            var serializer = new SharpYaml.Serialization.Serializer();
+            var yaml = await File.ReadAllTextAsync(path, Encoding.UTF8, cancellationToken);
+            return serializer.Deserialize<PlandoConfig>(yaml);
+        }
+    }
+}

--- a/src/Randomizer.SMZ3/Generation/PlandoFillerFactory.cs
+++ b/src/Randomizer.SMZ3/Generation/PlandoFillerFactory.cs
@@ -17,20 +17,10 @@ namespace Randomizer.SMZ3.Generation
             _loggerFactory = loggerFactory;
         }
 
-        public async Task<PlandoFiller> CreateFromFileAsync(string path,
-            CancellationToken cancellationToken = default)
+        public PlandoFiller Create(PlandoConfig plandoConfig)
         {
-            var plandoConfig = await LoadPlandoConfigAsync(path, cancellationToken);
             var logger = _loggerFactory.CreateLogger<PlandoFiller>();
             return new PlandoFiller(plandoConfig, logger);
-        }
-
-        private static async Task<PlandoConfig> LoadPlandoConfigAsync(string path,
-            CancellationToken cancellationToken)
-        {
-            var serializer = new SharpYaml.Serialization.Serializer();
-            var yaml = await File.ReadAllTextAsync(path, Encoding.UTF8, cancellationToken);
-            return serializer.Deserialize<PlandoConfig>(yaml);
         }
     }
 }

--- a/src/Randomizer.SMZ3/Generation/SeedData.cs
+++ b/src/Randomizer.SMZ3/Generation/SeedData.cs
@@ -7,7 +7,6 @@ namespace Randomizer.SMZ3.Generation
         public string Guid { get; set; }
         public string Seed { get; set; }
         public string Game { get; set; }
-        public string Logic { get; set; }
         public string Mode { get; set; }
         public List<(World World, Dictionary<int, byte[]> Patches)> Worlds { get; set; }
 

--- a/src/Randomizer.SMZ3/Generation/Smz3Plandomizer.cs
+++ b/src/Randomizer.SMZ3/Generation/Smz3Plandomizer.cs
@@ -48,7 +48,6 @@ namespace Randomizer.SMZ3.Generation
                 Seed = null,
                 Game = "SMZ3 Cas’ Plando",
                 Mode = config.GameMode.ToLowerString(),
-                Logic = $"{config.SMLogic.ToLowerString()}+{config.Z3Logic.ToLowerString()}",
                 Playthrough = config.Race ? new Playthrough(config, Enumerable.Empty<Playthrough.Sphere>()) : playthrough,
                 Worlds = new List<(World World, Dictionary<int, byte[]> Patches)>()
             };

--- a/src/Randomizer.SMZ3/Generation/Smz3Plandomizer.cs
+++ b/src/Randomizer.SMZ3/Generation/Smz3Plandomizer.cs
@@ -3,59 +3,65 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
-using System.Xml.Linq;
 
 using Randomizer.SMZ3.Contracts;
 using Randomizer.SMZ3.FileData;
-using Randomizer.SMZ3.Infrastructure;
 
 namespace Randomizer.SMZ3.Generation
 {
     public class Smz3Plandomizer : IRandomizer
     {
-        private readonly PlandoFiller _plandoFiller;
+        private readonly PlandoFillerFactory _fillerFactory;
+        private readonly IWorldAccessor _worldAccessor;
 
-        public Smz3Plandomizer(PlandoFiller plandoFiller)
+        public Smz3Plandomizer(PlandoFillerFactory fillerFactory, IWorldAccessor worldAccessor)
         {
-            _plandoFiller = plandoFiller;
+            _fillerFactory = fillerFactory;
+            _worldAccessor = worldAccessor;
         }
 
         public SeedData GenerateSeed(Config config, CancellationToken cancellationToken = default)
         {
             var worlds = new List<World>
             {
-                // TODO: How to get keysanity in here? Maybe pass plando config
-                // around in Config and construct PlandoFiller here using
-                // injected factory?
+                // TODO: How to get keysanity in here?
+                // - Inject PlandoFillerFactory instead
+                // - Instead of passing around PlandoFiller, pass around
+                //   selected file (deserialized or just name) instead (through
+                //   config?)
                 new World(config, "Player", 0, Guid.NewGuid().ToString("N"))
             };
 
-            _plandoFiller.Fill(worlds, config, cancellationToken);
+            var filler = _fillerFactory.Create(config.PlandoConfig);
+            filler.Fill(worlds, config, cancellationToken);
+
+            Playthrough playthrough = null;
+            try
+            {
+                playthrough = Playthrough.Generate(worlds, config);
+            }
+            catch (RandomizerGenerationException) { }
 
             var seedData = new SeedData
             {
                 Guid = Guid.NewGuid().ToString("N"),
-                Seed = seed,
-                Game = Name,
+                Seed = null,
+                Game = "SMZ3 Cas’ Plando",
                 Mode = config.GameMode.ToLowerString(),
                 Logic = $"{config.SMLogic.ToLowerString()}+{config.Z3Logic.ToLowerString()}",
                 Playthrough = config.Race ? new Playthrough(config, Enumerable.Empty<Playthrough.Sphere>()) : playthrough,
                 Worlds = new List<(World World, Dictionary<int, byte[]> Patches)>()
             };
 
-
-            /* Make sure RNG is the same when applying patches to the ROM to have consistent RNG for seed identifer etc */
-            var patchSeed = rng.Next();
             foreach (var world in worlds)
             {
-                var patchRnd = new Random(patchSeed);
-                var patch = new Patcher(world, worlds, seedData.Guid, config.Race ? 0 : seedNumber, patchRnd);
+                var patchRnd = new Random();
+                var patch = new Patcher(world, worlds, seedData.Guid, 0, patchRnd);
                 seedData.Worlds.Add((world, patch.CreatePatch(config)));
-}
+            }
 
             Debug.WriteLine("Generated seed on randomizer instance " + GetHashCode());
             _worldAccessor.World = worlds[0];
-            LastGeneratedSeed = seedData;
             return seedData;
         }
     }

--- a/src/Randomizer.SMZ3/Generation/Smz3Plandomizer.cs
+++ b/src/Randomizer.SMZ3/Generation/Smz3Plandomizer.cs
@@ -48,7 +48,7 @@ namespace Randomizer.SMZ3.Generation
             var seedData = new SeedData
             {
                 Guid = Guid.NewGuid().ToString("N"),
-                Seed = "Plando",
+                Seed = $"Plando: {config.PlandoConfig?.FileName ?? "unknown"}",
                 Game = "SMZ3 Cas’ Plando",
                 Mode = config.GameMode.ToLowerString(),
                 Playthrough = config.Race ? new Playthrough(config, Enumerable.Empty<Playthrough.Sphere>()) : playthrough,

--- a/src/Randomizer.SMZ3/Generation/Smz3Plandomizer.cs
+++ b/src/Randomizer.SMZ3/Generation/Smz3Plandomizer.cs
@@ -48,7 +48,7 @@ namespace Randomizer.SMZ3.Generation
             var seedData = new SeedData
             {
                 Guid = Guid.NewGuid().ToString("N"),
-                Seed = null,
+                Seed = "Plando",
                 Game = "SMZ3 Cas’ Plando",
                 Mode = config.GameMode.ToLowerString(),
                 Playthrough = config.Race ? new Playthrough(config, Enumerable.Empty<Playthrough.Sphere>()) : playthrough,

--- a/src/Randomizer.SMZ3/Generation/Smz3Plandomizer.cs
+++ b/src/Randomizer.SMZ3/Generation/Smz3Plandomizer.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Xml.Linq;
+
+using Randomizer.SMZ3.Contracts;
+using Randomizer.SMZ3.FileData;
+using Randomizer.SMZ3.Infrastructure;
+
+namespace Randomizer.SMZ3.Generation
+{
+    public class Smz3Plandomizer : IRandomizer
+    {
+        private readonly PlandoFiller _plandoFiller;
+
+        public Smz3Plandomizer(PlandoFiller plandoFiller)
+        {
+            _plandoFiller = plandoFiller;
+        }
+
+        public SeedData GenerateSeed(Config config, CancellationToken cancellationToken = default)
+        {
+            var worlds = new List<World>
+            {
+                // TODO: How to get keysanity in here? Maybe pass plando config
+                // around in Config and construct PlandoFiller here using
+                // injected factory?
+                new World(config, "Player", 0, Guid.NewGuid().ToString("N"))
+            };
+
+            _plandoFiller.Fill(worlds, config, cancellationToken);
+
+            var seedData = new SeedData
+            {
+                Guid = Guid.NewGuid().ToString("N"),
+                Seed = seed,
+                Game = Name,
+                Mode = config.GameMode.ToLowerString(),
+                Logic = $"{config.SMLogic.ToLowerString()}+{config.Z3Logic.ToLowerString()}",
+                Playthrough = config.Race ? new Playthrough(config, Enumerable.Empty<Playthrough.Sphere>()) : playthrough,
+                Worlds = new List<(World World, Dictionary<int, byte[]> Patches)>()
+            };
+
+
+            /* Make sure RNG is the same when applying patches to the ROM to have consistent RNG for seed identifer etc */
+            var patchSeed = rng.Next();
+            foreach (var world in worlds)
+            {
+                var patchRnd = new Random(patchSeed);
+                var patch = new Patcher(world, worlds, seedData.Guid, config.Race ? 0 : seedNumber, patchRnd);
+                seedData.Worlds.Add((world, patch.CreatePatch(config)));
+}
+
+            Debug.WriteLine("Generated seed on randomizer instance " + GetHashCode());
+            _worldAccessor.World = worlds[0];
+            LastGeneratedSeed = seedData;
+            return seedData;
+        }
+    }
+}

--- a/src/Randomizer.SMZ3/Generation/Smz3Randomizer.cs
+++ b/src/Randomizer.SMZ3/Generation/Smz3Randomizer.cs
@@ -14,7 +14,7 @@ using Randomizer.SMZ3.FileData;
 
 namespace Randomizer.SMZ3.Generation
 {
-    public class Smz3Randomizer
+    public class Smz3Randomizer : ISeededRandomizer
     {
         private static readonly Regex s_illegalCharacters = new(@"[^A-Z0-9]", RegexOptions.IgnoreCase);
         private static readonly Regex s_continousSpace = new(@" +");
@@ -57,6 +57,9 @@ namespace Randomizer.SMZ3.Generation
             input = seed.ToString("D", CultureInfo.InvariantCulture);
             return seed;
         }
+
+        public SeedData GenerateSeed(Config config, CancellationToken cancellationToken = default)
+            => GenerateSeed(config, "", cancellationToken);
 
         public SeedData GenerateSeed(Config config, string seed, CancellationToken cancellationToken = default)
         {
@@ -162,7 +165,7 @@ namespace Randomizer.SMZ3.Generation
             }
 
             // Through and make sure the early items are populated in early spheres
-            foreach ( var itemType in config.EarlyItems)
+            foreach (var itemType in config.EarlyItems)
             {
                 var sphereIndex = seedData.Playthrough.Spheres.IndexOf(x => x.Items.Any(y => y.Progression && y.Type == itemType));
                 if (sphereIndex > 2)

--- a/src/Randomizer.SMZ3/Generation/Smz3Randomizer.cs
+++ b/src/Randomizer.SMZ3/Generation/Smz3Randomizer.cs
@@ -101,7 +101,6 @@ namespace Randomizer.SMZ3.Generation
                 Seed = seed,
                 Game = Name,
                 Mode = config.GameMode.ToLowerString(),
-                Logic = $"{config.SMLogic.ToLowerString()}+{config.Z3Logic.ToLowerString()}",
                 Playthrough = config.Race ? new Playthrough(config, Enumerable.Empty<Playthrough.Sphere>()) : playthrough,
                 Worlds = new List<(World World, Dictionary<int, byte[]> Patches)>()
             };

--- a/src/Randomizer.SMZ3/Generation/StandardFiller.cs
+++ b/src/Randomizer.SMZ3/Generation/StandardFiller.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using Microsoft.Extensions.Logging;
 
 using Randomizer.Shared;
+using Randomizer.SMZ3.Contracts;
 using Randomizer.SMZ3.Regions;
 
 namespace Randomizer.SMZ3.Generation

--- a/src/Randomizer.SMZ3/Playthrough.cs
+++ b/src/Randomizer.SMZ3/Playthrough.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+
 using Randomizer.SMZ3.Regions;
 
 namespace Randomizer.SMZ3
@@ -22,6 +24,43 @@ namespace Randomizer.SMZ3
             => (keysanity && (location.Item.Progression || location.Item.IsDungeonItem || location.Item.IsKeycard))
             || (!keysanity && location.Item.Progression);
 
+        /// <summary>
+        /// Simulates a rough playthrough and returns a value indicating whether
+        /// the playthrough is likely possible.
+        /// </summary>
+        /// <param name="worlds">A list of the worlds to play through.</param>
+        /// <param name="config">The config used to generate the worlds.</param>
+        /// <param name="playthrough">
+        /// If this method returns <see langword="true"/>, the generated
+        /// playthrough; otherwise, <see langword="null"/>.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if the playthrough is possible; otherwise,
+        /// <see langword="false"/>.
+        /// </returns>
+        public static bool TryGenerate(IReadOnlyCollection<World> worlds, Config config, [MaybeNullWhen(true)] out Playthrough playthrough)
+        {
+            try
+            {
+                playthrough = Generate(worlds, config);
+                return true;
+            }
+            catch (RandomizerGenerationException)
+            {
+                playthrough = null;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Simulates a rough playthrough of the specified worlds.
+        /// </summary>
+        /// <param name="worlds">A list of the worlds to play through.</param>
+        /// <param name="config">The config used to generate the worlds.</param>
+        /// <returns>A new <see cref="Playthrough"/>.</returns>
+        /// <exception cref="RandomizerGenerationException">
+        /// The seed is likely impossible.
+        /// </exception>
         public static Playthrough Generate(IReadOnlyCollection<World> worlds, Config config)
         {
             var spheres = new List<Sphere>();

--- a/src/Randomizer.SMZ3/Randomizer.SMZ3.csproj
+++ b/src/Randomizer.SMZ3/Randomizer.SMZ3.csproj
@@ -31,8 +31,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="SharpYaml" Version="1.6.6" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="SharpYaml" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Randomizer.SMZ3/Randomizer.SMZ3.csproj
+++ b/src/Randomizer.SMZ3/Randomizer.SMZ3.csproj
@@ -32,7 +32,8 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="SharpYaml" Version="2.0.0" />
+    <PackageReference Include="SharpYaml" Version="2.1.0" />
+    <PackageReference Include="YamlDotNet" Version="12.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Randomizer.SMZ3/RandomizerServiceCollectionExtensions.cs
+++ b/src/Randomizer.SMZ3/RandomizerServiceCollectionExtensions.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Randomizer.Shared.Models;
+using Randomizer.SMZ3.Contracts;
+using Randomizer.SMZ3.Generation;
+using Randomizer.SMZ3.Infrastructure;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class RandomizerServiceCollectionExtensions
+    {
+        public static IServiceCollection AddSmz3Randomizer(this IServiceCollection services)
+        {
+            services.AddSingleton<RandomizerContext>();
+            services.AddSingleton<IFiller, StandardFiller>();
+            services.AddSingleton<IWorldAccessor, WorldAccessor>();
+            services.AddSingleton<Smz3Randomizer>();
+            return services;
+        }
+
+        public static IServiceCollection AddPlandomizer(this IServiceCollection services)
+        {
+            services.AddSingleton<IPlandoConfigLoader, PlandoConfigLoader>();
+            services.AddSingleton<PlandoFillerFactory>();
+            services.AddSingleton<Smz3Plandomizer>();
+            return services;
+        }
+    }
+}

--- a/src/Randomizer.SMZ3/Text/Scripts/General.yaml
+++ b/src/Randomizer.SMZ3/Text/Scripts/General.yaml
@@ -35,6 +35,9 @@ GanonSilversReveal:
       Seek the sage
       <player>
       for the arrows
+  none: |-
+    Silver arrows?
+    What's that?
 
 Items:
 

--- a/src/Randomizer.SMZ3/Text/Texts.cs
+++ b/src/Randomizer.SMZ3/Text/Texts.cs
@@ -56,6 +56,12 @@ namespace Randomizer.SMZ3.Text
             return text.Replace("<first>", first.Area).Replace("<second>", second.Area);
         }
 
+        public static string GanonThirdPhraseNone()
+        {
+            var text = ((scripts["GanonSilversReveal"] as YamlMapping)["none"] as YamlValue).Value;
+            return text;
+        }
+
         public static string GanonThirdPhaseSingle(Region silvers)
         {
             var node = (scripts["GanonSilversReveal"] as YamlMapping)["single"] as YamlMapping;

--- a/src/Randomizer.SMZ3/World.cs
+++ b/src/Randomizer.SMZ3/World.cs
@@ -141,7 +141,8 @@ namespace Randomizer.SMZ3
         public Location FindLocation(string name, StringComparison comparisonType = StringComparison.Ordinal)
         {
             return Locations.FirstOrDefault(x => x.Name.Equals(name, comparisonType))
-                ?? Locations.FirstOrDefault(x => x.AlternateNames.Contains(name, StringComparer.FromComparison(comparisonType)));
+                ?? Locations.FirstOrDefault(x => x.AlternateNames.Contains(name, StringComparer.FromComparison(comparisonType)))
+                ?? Locations.FirstOrDefault(x => x.ToString().Equals(name, comparisonType));
         }
 
         public bool CanAquire(Progression items, RewardType reward)

--- a/src/Randomizer.SMZ3/World.cs
+++ b/src/Randomizer.SMZ3/World.cs
@@ -2,7 +2,9 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+
 using Randomizer.Shared;
+using Randomizer.Shared.Models;
 using Randomizer.SMZ3.Regions;
 using Randomizer.SMZ3.Regions.SuperMetroid;
 using Randomizer.SMZ3.Regions.SuperMetroid.Brinstar;
@@ -162,6 +164,48 @@ namespace Randomizer.SMZ3
         {
             SetMedallions(rnd);
             SetRewards(rnd);
+        }
+
+        /// <summary>
+        /// Creates a new empty <see cref="TrackerState"/> for this world
+        /// instance.
+        /// </summary>
+        /// <returns>
+        /// A new <see cref="TrackerState"/> with the items, rewards and
+        /// medallions from this world.
+        /// </returns>
+        public TrackerState CreateTrackerState()
+        {
+            var locationStates = Locations
+                .Select(x => new TrackerLocationState
+                {
+                    LocationId = x.Id,
+                    Item = x.Item?.Type,
+                    Cleared = false
+                })
+                .ToList();
+
+            var regionStates = Regions
+                .Select(x => new TrackerRegionState
+                {
+                    TypeName = x.GetType().Name,
+                    Reward = x is IHasReward rewardRegion ? rewardRegion.Reward : null,
+                    Medallion = x is INeedsMedallion medallionRegion ? medallionRegion.Medallion : null
+                })
+                .ToList();
+
+            return new TrackerState
+            {
+                //ItemStates = new List<TrackerItemState>(),
+                LocationStates = locationStates,
+                RegionStates = regionStates,
+                //DungeonStates = new List<TrackerDungeonState>(),
+                //MarkedLocations = new List<TrackerMarkedLocation>(),
+                //BossStates = new List<TrackerBossState>(),
+                //History = new List<TrackerHistoryEvent>(),
+                StartDateTime = DateTimeOffset.Now,
+                UpdatedDateTime = DateTimeOffset.Now
+            };
         }
 
         private void SetMedallions(Random rnd)

--- a/src/Randomizer.Shared/Models/TrackerState.cs
+++ b/src/Randomizer.Shared/Models/TrackerState.cs
@@ -1,8 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.ComponentModel.DataAnnotations.Schema;
 
-namespace Randomizer.Shared.Models {
+using Randomizer.Shared.Migrations;
+
+namespace Randomizer.Shared.Models
+{
 
     public class TrackerState
     {

--- a/src/Randomizer.Shared/StringExtensions.cs
+++ b/src/Randomizer.Shared/StringExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 
 namespace Randomizer.Shared
 {
@@ -44,6 +45,26 @@ namespace Randomizer.Shared
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Replaces all instances of all specified characters with the
+        /// specified character.
+        /// </summary>
+        /// <param name="text">The string to replace.</param>
+        /// <param name="oldChars">A collection of chars to find,</param>
+        /// <param name="newChar">The char to replace with.</param>
+        /// <returns>
+        /// A new string with all instances of all characters in <paramref
+        /// name="oldChars"/> replaced by <paramref name="newChar"/>.
+        /// </returns>
+        public static string ReplaceAny(this string text,
+            char[] oldChars, char newChar)
+        {
+            var value = new StringBuilder(text);
+            foreach (var oldChar in oldChars)
+                value.Replace(oldChar, newChar);
+            return value.ToString();
         }
     }
 }

--- a/tests/Randomizer.SMZ3.Tests/Randomizer.SMZ3.Tests.csproj
+++ b/tests/Randomizer.SMZ3.Tests/Randomizer.SMZ3.Tests.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.2.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">


### PR DESCRIPTION
I think I've got working plando support. It's still a little hacky, but the basis is here.

Basically, when generating a new seed, a plando config YAML file will be generated alongside the spoiler log. This file can be edited and used to start a new plando seed. For example, I generated a seed with only Big 20s.

I haven't done proper testing yet, and I still want to add support for changing enemy drops, but it should be fine in its current state. I might just postpone that as a nice-to-have.

Resolves #96