### PR TITLE
Vanilla item response + auto-tracker map fix

### DIFF
--- a/src/Randomizer.SMZ3.Tracking/Configuration/ConfigFiles/RegionConfig.cs
+++ b/src/Randomizer.SMZ3.Tracking/Configuration/ConfigFiles/RegionConfig.cs
@@ -32,48 +32,56 @@ namespace Randomizer.SMZ3.Tracking.Configuration.ConfigFiles
                     Type = typeof(Regions.SuperMetroid.Brinstar.BlueBrinstar),
                     Name = new("Blue Brinstar"),
                     Hints = new("Samus might have been there before."),
+                    MapName = "Brinstar"
                 },
                 new RegionInfo()
                 {
                     Region = "Green Brinstar",
                     Type = typeof(Regions.SuperMetroid.Brinstar.GreenBrinstar),
                     Name = new("Green Brinstar"),
+                    MapName = "Brinstar"
                 },
                 new RegionInfo()
                 {
                     Region = "Kraid's Lair",
                     Type = typeof(Regions.SuperMetroid.Brinstar.KraidsLair),
                     Name = new("Kraid's Lair"),
+                    MapName = "Brinstar"
                 },
                 new RegionInfo()
                 {
                     Region = "Pink Brinstar",
                     Type = typeof(Regions.SuperMetroid.Brinstar.PinkBrinstar),
                     Name = new("Pink Brinstar"),
+                    MapName = "Brinstar"
                 },
                 new RegionInfo()
                 {
                     Region = "Red Brinstar",
                     Type = typeof(Regions.SuperMetroid.Brinstar.RedBrinstar),
                     Name = new("Red Brinstar"),
+                    MapName = "Brinstar"
                 },
                 new RegionInfo()
                 {
                     Region = "Central Crateria",
                     Type = typeof(Regions.SuperMetroid.Crateria.CentralCrateria),
                     Name = new("Central Crateria"),
+                    MapName = "Crateria"
                 },
                 new RegionInfo()
                 {
                     Region = "East Crateria",
                     Type = typeof(Regions.SuperMetroid.Crateria.EastCrateria),
                     Name = new("East Crateria"),
+                    MapName = "Crateria"
                 },
                 new RegionInfo()
                 {
                     Region = "West Crateria",
                     Type = typeof(Regions.SuperMetroid.Crateria.WestCrateria),
                     Name = new("West Crateria"),
+                    MapName = "Crateria"
                 },
                 new RegionInfo()
                 {
@@ -81,6 +89,7 @@ namespace Randomizer.SMZ3.Tracking.Configuration.ConfigFiles
                     Type = typeof(Regions.SuperMetroid.Maridia.InnerMaridia),
                     Name = new("Inner Maridia"),
                     Hints = new("You should go see Shaktool when you're in the area.", "It's in a wet place."),
+                    MapName = "Maridia"
                 },
                 new RegionInfo()
                 {
@@ -88,6 +97,7 @@ namespace Randomizer.SMZ3.Tracking.Configuration.ConfigFiles
                     Type = typeof(Regions.SuperMetroid.Maridia.OuterMaridia),
                     Name = new("Outer Maridia"),
                     Hints = new("It's in a wet place."),
+                    MapName = "Maridia"
                 },
                 new RegionInfo()
                 {
@@ -95,42 +105,49 @@ namespace Randomizer.SMZ3.Tracking.Configuration.ConfigFiles
                     Type = typeof(Regions.SuperMetroid.Norfair.LowerNorfairEast),
                     Name = new("Lower Norfair, East"),
                     Hints = new("I heard Ridley hangs out around there."),
+                    MapName = "Norfair"
                 },
                 new RegionInfo()
                 {
                     Region = "Lower Norfair, West",
                     Type = typeof(Regions.SuperMetroid.Norfair.LowerNorfairWest),
                     Name = new("Lower Norfair, West"),
+                    MapName = "Norfair"
                 },
                 new RegionInfo()
                 {
                     Region = "Upper Norfair, Crocomire",
                     Type = typeof(Regions.SuperMetroid.Norfair.UpperNorfairCrocomire),
                     Name = new("Upper Norfair, Crocomire"),
+                    MapName = "Norfair"
                 },
                 new RegionInfo()
                 {
                     Region = "Upper Norfair, East",
                     Type = typeof(Regions.SuperMetroid.Norfair.UpperNorfairEast),
                     Name = new("Upper Norfair, East"),
+                    MapName = "Norfair"
                 },
                 new RegionInfo()
                 {
                     Region = "Upper Norfair, West",
                     Type = typeof(Regions.SuperMetroid.Norfair.UpperNorfairWest),
                     Name = new("Upper Norfair, West"),
+                    MapName = "Norfair"
                 },
                 new RegionInfo()
                 {
                     Region = "Wrecked Ship",
                     Type = typeof(Regions.SuperMetroid.WreckedShip),
                     Name = new("Wrecked Ship"),
+                    MapName = "Wrecked Ship"
                 },
                 new RegionInfo()
                 {
                     Region = "Castle Tower",
                     Type = typeof(Regions.Zelda.CastleTower),
                     Name = new("Castle Tower", "Agahnim's Tower", "Hyrule Castle Tower"),
+                    MapName = "Light World"
                 },
                 new RegionInfo()
                 {
@@ -138,12 +155,14 @@ namespace Randomizer.SMZ3.Tracking.Configuration.ConfigFiles
                     Type = typeof(Regions.Zelda.DarkWorld.DarkWorldMire),
                     Name = new("Dark World Mire"),
                     Hints = new("It's in a wet place."),
+                    MapName = "Dark World"
                 },
                 new RegionInfo()
                 {
                     Region = "Dark World North East",
                     Type = typeof(Regions.Zelda.DarkWorld.DarkWorldNorthEast),
                     Name = new("Dark World North East"),
+                    MapName = "Dark World"
                 },
                 new RegionInfo()
                 {
@@ -151,36 +170,42 @@ namespace Randomizer.SMZ3.Tracking.Configuration.ConfigFiles
                     Type = typeof(Regions.Zelda.DarkWorld.DarkWorldNorthWest),
                     Name = new("Dark World North West"),
                     Hints = new("Check around the villages."),
+                    MapName = "Dark World"
                 },
                 new RegionInfo()
                 {
                     Region = "Dark World South",
                     Type = typeof(Regions.Zelda.DarkWorld.DarkWorldSouth),
                     Name = new("Dark World South"),
+                    MapName = "Dark World"
                 },
                 new RegionInfo()
                 {
                     Region = "Dark World Death Mountain East",
                     Type = typeof(Regions.Zelda.DarkWorld.DeathMountain.DarkWorldDeathMountainEast),
                     Name = new("Dark World Death Mountain East"),
+                    MapName = "Dark World"
                 },
                 new RegionInfo()
                 {
                     Region = "Dark World Death Mountain West",
                     Type = typeof(Regions.Zelda.DarkWorld.DeathMountain.DarkWorldDeathMountainWest),
                     Name = new("Dark World Death Mountain West"),
+                    MapName = "Dark World"
                 },
                 new RegionInfo()
                 {
                     Region = "Desert Palace",
                     Type = typeof(Regions.Zelda.DesertPalace),
                     Name = new("Desert Palace"),
+                    MapName = "Light World"
                 },
                 new RegionInfo()
                 {
                     Region = "Eastern Palace",
                     Type = typeof(Regions.Zelda.EasternPalace),
                     Name = new("Eastern Palace"),
+                    MapName = "Light World"
                 },
                 new RegionInfo()
                 {
@@ -188,36 +213,42 @@ namespace Randomizer.SMZ3.Tracking.Configuration.ConfigFiles
                     Type = typeof(Regions.Zelda.GanonsTower),
                     Name = new("Ganon's Tower"),
                     Hints = new("I hope you don't need it."),
+                    MapName = "Dark World"
                 },
                 new RegionInfo()
                 {
                     Region = "Hyrule Castle",
                     Type = typeof(Regions.Zelda.HyruleCastle),
                     Name = new("Hyrule Castle"),
+                    MapName = "Light World"
                 },
                 new RegionInfo()
                 {
                     Region = "Ice Palace",
                     Type = typeof(Regions.Zelda.IcePalace),
                     Name = new("Ice Palace"),
+                    MapName = "Dark World"
                 },
                 new RegionInfo()
                 {
                     Region = "Light World Death Mountain East",
                     Type = typeof(Regions.Zelda.LightWorld.DeathMountain.LightWorldDeathMountainEast),
                     Name = new("Light World Death Mountain East"),
+                    MapName = "Light World"
                 },
                 new RegionInfo()
                 {
                     Region = "Light World Death Mountain West",
                     Type = typeof(Regions.Zelda.LightWorld.DeathMountain.LightWorldDeathMountainWest),
                     Name = new("Light World Death Mountain West"),
+                    MapName = "Light World"
                 },
                 new RegionInfo()
                 {
                     Region = "Light World North East",
                     Type = typeof(Regions.Zelda.LightWorld.LightWorldNorthEast),
                     Name = new("Light World North East"),
+                    MapName = "Light World"
                 },
                 new RegionInfo()
                 {
@@ -225,12 +256,14 @@ namespace Randomizer.SMZ3.Tracking.Configuration.ConfigFiles
                     Type = typeof(Regions.Zelda.LightWorld.LightWorldNorthWest),
                     Name = new("Light World North West"),
                     Hints = new("Check around the villages."),
+                    MapName = "Light World"
                 },
                 new RegionInfo()
                 {
                     Region = "Light World South",
                     Type = typeof(Regions.Zelda.LightWorld.LightWorldSouth),
                     Name = new("Light World South"),
+                    MapName = "Light World"
                 },
                 new RegionInfo()
                 {
@@ -238,18 +271,21 @@ namespace Randomizer.SMZ3.Tracking.Configuration.ConfigFiles
                     Type = typeof(Regions.Zelda.MiseryMire),
                     Name = new("Misery Mire"),
                     Hints = new("It's in a wet place.", "You need a medallion to get in there."),
+                    MapName = "Dark World"
                 },
                 new RegionInfo()
                 {
                     Region = "Palace of Darkness",
                     Type = typeof(Regions.Zelda.PalaceOfDarkness),
                     Name = new("Palace of Darkness"),
+                    MapName = "Dark World"
                 },
                 new RegionInfo()
                 {
                     Region = "Skull Woods",
                     Type = typeof(Regions.Zelda.SkullWoods),
                     Name = new("Skull Woods"),
+                    MapName = "Dark World"
                 },
                 new RegionInfo()
                 {
@@ -257,18 +293,21 @@ namespace Randomizer.SMZ3.Tracking.Configuration.ConfigFiles
                     Type = typeof(Regions.Zelda.SwampPalace),
                     Name = new("Swamp Palace"),
                     Hints = new("It's in a wet place."),
+                    MapName = "Dark World"
                 },
                 new RegionInfo()
                 {
                     Region = "Thieves' Town",
                     Type = typeof(Regions.Zelda.ThievesTown),
                     Name = new("Thieves' Town"),
+                    MapName = "Dark World"
                 },
                 new RegionInfo()
                 {
                     Region = "Tower of Hera",
                     Type = typeof(Regions.Zelda.TowerOfHera),
                     Name = new("Tower of Hera"),
+                    MapName = "Light World"
                 },
                 new RegionInfo()
                 {
@@ -276,6 +315,7 @@ namespace Randomizer.SMZ3.Tracking.Configuration.ConfigFiles
                     Type = typeof(Regions.Zelda.TurtleRock),
                     Name = new("Turtle Rock", new("Tortoise Rock", 0.1)),
                     Hints = new("You need a medallion to get in there."),
+                    MapName = "Dark World"
                 },
             };
         }

--- a/src/Randomizer.SMZ3.Tracking/Configuration/ConfigFiles/ResponseConfig.cs
+++ b/src/Randomizer.SMZ3.Tracking/Configuration/ConfigFiles/ResponseConfig.cs
@@ -115,6 +115,13 @@ namespace Randomizer.SMZ3.Tracking.Configuration.ConfigFiles
         public SchrodingersString? TrackedAlreadyTrackedItem { get; init; }
 
         /// <summary>
+        /// Gets the phrases to respond with when tracking an item that is at
+        /// its correct location according to the original game.
+        /// </summary>
+        public SchrodingersString TrackedVanillaItem { get; init; }
+            = new("");
+
+        /// <summary>
         /// Gets the phrases to respond with when setting the exact amount of an
         /// item, but that exact amount is already tracked.
         /// </summary>

--- a/src/Randomizer.SMZ3.Tracking/Configuration/Yaml/Sassy/requests.yml
+++ b/src/Randomizer.SMZ3.Tracking/Configuration/Yaml/Sassy/requests.yml
@@ -1580,6 +1580,139 @@
       We won't end
 
       I am shadow, I am the light
+  - Text: |-
+      We can dance if we want to
+      We can leave your friends behind
+      'Cause your friends don't dance and if they don't dance
+      Well, they're no friends of mine
+
+      Say, we can go where we want to
+      A place where they will never find
+      And we can act like we come from out of this world
+      Leave the real one far behind
+
+      And we can dance
+      (Dancé!)
+
+      We can go when we want to
+      The night is young and so am I
+      And we can dress real neat from our hats to our feet
+      And surprise 'em with the victory cry
+
+      Say, we can act if we want to
+      If we don't, nobody will
+      And you can act real rude and totally removed
+      And I can act like an imbecile
+
+      And say, we can dance, we can dance
+      Everything's out of control
+      We can dance, we can dance
+      They're doing it from pole to pole
+      We can dance, we can dance
+      Everybody look at your hands
+      We can dance, we can dance
+      Everybody's taking the chance
+      Safety dance
+      Oh well, the safety dance
+      Ah yes, the safety dance
+
+      We can dance if we want to
+      We've got all your life and mine
+      As long as we abuse it, never gonna lose it
+      Everything'll work out right
+
+      I say, we can dance if we want to
+      We can leave your friends behind
+      Because your friends don't dance and if they don't dance
+      Well, they're no friends of mine
+
+      I say, we can dance, we can dance
+      Everything's out of control
+      We can dance, we can dance
+      We're doing it from pole to pole
+      We can dance, we can dance
+      Everybody look at your hands
+      We can dance, we can dance
+      Everybody's taking the chance
+
+      Oh well, the safety dance
+      Ah yes, the safety dance
+      Oh well, the safety dance
+      Oh well, the safety dance
+      Oh yes, the safety dance
+      Oh, the safety dance, yeah
+      Well, it's the safety dance
+      It's the safety dance
+      Well, it's the safety dance
+      Oh, it's the safety dance
+      Oh, it's the safety dance
+      Oh, it's the safety dance
+  - Text: |-
+      Hey baby, wake up from your asleep
+      We have arrived onto the future
+      And the whole world is become
+
+      Elektronic, supersonic
+      Supersonic, elektronic
+
+      Hey baby, ride with me away
+      We doesn't have much time
+      My blue jeans is tight
+      So onto my love rocket climb
+      Inside tank of fuel is not fuel, but love
+      Above us, there is nothing above
+      But the stars, above
+      All systems gone!
+      Prepare for downcount!
+
+      Five, four, three, one!
+      Off blast!
+
+      Fly away in my space rocket
+      You no need put money in my pocket
+      The door is closed, I just lock it
+      I put my port plug in your socket
+
+      The sun in sky is bright like fire
+      You and me gets higher and higher
+      Cut off communication wire
+      Only thing can stop us is flat tire
+
+      Ha, ha, ha ha ha ha
+
+      Hey, love crusader
+      I want to be your space invader
+      For you I will descend the deepest moon crater
+      I is more stronger than Darth Vapor
+      Obey me I is your new dictator
+      For you is Venus, I am Mars
+      With you I is more richer than all the tsars
+      Make a wishes on a shooting stars
+      Then for you I will play on my cosmic guitars!
+      Ladies and gentlemen
+      Fasten your beltseats
+      We has commenced our descent
+      I trust you enjoy this flight
+      As much as you enjoy this accent
+
+      Now back on Earth it's time for downsplash
+      Into sea of eternal glory my spaceship crash
+      People have arrived for to cheer me from near and far
+      And as I float, I open door and shout
+      "I am world's biggest, washed-up superstar!"
+
+      (Supersonic elektronic)
+
+      As for sure as the sun rises in the west
+      Of all the singers and poets on Earth I am the bestest
+      Come, let me put ring of Jupiter on your finger
+      Then like a smell around you I will forever linger
+      Okay, is time for end, no more will I sang
+      Let me take you back in time
+      I want for you to experience big bang
+
+      Long live space race
+      Long live Molvania
 - Phrases:
   - tell me a joke
   - do you know any jokes?

--- a/src/Randomizer.SMZ3.Tracking/Configuration/Yaml/Sassy/responses.yml
+++ b/src/Randomizer.SMZ3.Tracking/Configuration/Yaml/Sassy/responses.yml
@@ -137,6 +137,9 @@ TrackedExactAmountDuplicate:
 TrackedMultipleItems:
 - Text: Tracked {2} in {1}.
 - Text: Added {2} from {1}.
+TrackedVanillaItem:
+- Text: Is this even randomized?
+  Weight: 0.25
 ClearedMultipleItems:
 - Text: Cleared {0} items in {1}.
 TrackedNothing:

--- a/src/Randomizer.SMZ3.Tracking/Configuration/Yaml/Templates/responses.yml
+++ b/src/Randomizer.SMZ3.Tracking/Configuration/Yaml/Templates/responses.yml
@@ -62,6 +62,9 @@ TrackedExactAmountDuplicate:
 # {2} is replaced with a list of the items tracked
 TrackedMultipleItems:
 
+# The list of possibilities when the player tracks an item from its vanilla location.
+TrackedVanillaItem:
+
 # The list of possibilities when the player clears all items from an area but did not track them
 # {0} is replaced with a number of the items tracked
 # {1} is replaced with the area name

--- a/src/Randomizer.SMZ3.Tracking/Tracker.cs
+++ b/src/Randomizer.SMZ3.Tracking/Tracker.cs
@@ -2431,6 +2431,12 @@ namespace Randomizer.SMZ3.Tracking
             }
             else
             {
+                if (item.InternalItemType == location.VanillaItem)
+                {
+                    Say(x => x.TrackedVanillaItem);
+                    return;
+                }
+
                 var locationInfo = WorldInfo.Location(location);
                 var isJunk = item.IsJunk(World.Config);
                 if (isJunk)


### PR DESCRIPTION
Adds a chance for Tracker to say "Is this even randomized?" when marking or tracking an item at its vanilla location.

I also added map names to the Region config. I don't know whether you forgot these or something else was missing on my end, but auto-tracking stopped updating the map. I fixed a crash as a result from this in my last PR, but now I found the root case (I guess).