### PR TITLE
GT Item and Treasure Count Fixes

### DIFF
--- a/setup/randomizer.app.iss
+++ b/setup/randomizer.app.iss
@@ -4,7 +4,7 @@
 #include "CodeDependencies.iss"
 
 #define MyAppName "SMZ3 Cas' Randomizer"
-#define MyAppVersion "6.0.0-rc.1"
+#define MyAppVersion "6.0.0-rc.2"
 #define MyAppPublisher "Vivelin"
 #define MyAppURL "https://github.com/Vivelin/SMZ3Randomizer"
 #define MyAppExeName "Randomizer.App.exe"

--- a/src/Randomizer.App/Randomizer.App.csproj
+++ b/src/Randomizer.App/Randomizer.App.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net5.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>chozo20.ico</ApplicationIcon>
-    <Version>6.0.0-rc.1</Version>
+    <Version>6.0.0-rc.2</Version>
     <Title>SMZ3 Cas' Randomizer</Title>
     <AssemblyTitle>SMZ3 Cas' Randomizer</AssemblyTitle>
     <Authors>Vivelin</Authors>

--- a/src/Randomizer.App/Windows/OptionsWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/OptionsWindow.xaml.cs
@@ -81,7 +81,7 @@ namespace Randomizer.App
         }
 
         public ICollection<string> EnabledProfiles =>
-            Options?.SelectedProfiles.ToList();
+            Options?.SelectedProfiles.Where(x => !string.IsNullOrEmpty(x)).ToList();
 
         public ICollection<string> DisabledProfiles =>
             AvailableProfiles?.Where(x => Options?.SelectedProfiles?.Contains(x) == false)?.ToList();
@@ -128,9 +128,14 @@ namespace Randomizer.App
 
         private void EnableProfile_Click(object sender, RoutedEventArgs e)
         {
-            Options.SelectedProfiles.Add(DisabledProfilesListBox.SelectedItem as string);
-            PropertyChanged?.Invoke(this, new(nameof(EnabledProfiles)));
-            PropertyChanged?.Invoke(this, new(nameof(DisabledProfiles)));
+            var newProfile = DisabledProfilesListBox.SelectedItem as string;
+            if (!string.IsNullOrEmpty(newProfile))
+            {
+                Options.SelectedProfiles.Add(newProfile);
+                Options.SelectedProfiles.Remove(null);
+                PropertyChanged?.Invoke(this, new(nameof(EnabledProfiles)));
+                PropertyChanged?.Invoke(this, new(nameof(DisabledProfiles)));
+            }
         }
 
         private void DisableProfile_Click(object sender, RoutedEventArgs e)

--- a/src/Randomizer.SMZ3.Tracking/Configuration/TrackerConfigProvider.cs
+++ b/src/Randomizer.SMZ3.Tracking/Configuration/TrackerConfigProvider.cs
@@ -176,7 +176,7 @@ namespace Randomizer.SMZ3.Tracking.Configuration
             return Directory
                 .GetDirectories(_basePath)
                 .Select(x => (new DirectoryInfo(x)).Name)
-                .Where(x => x != "Templates")
+                .Where(x => x != "Templates" && !string.IsNullOrEmpty(x))
                 .ToList();
         }
 

--- a/src/Randomizer.SMZ3.Tracking/Configuration/TrackerConfigProvider.cs
+++ b/src/Randomizer.SMZ3.Tracking/Configuration/TrackerConfigProvider.cs
@@ -176,7 +176,7 @@ namespace Randomizer.SMZ3.Tracking.Configuration
             return Directory
                 .GetDirectories(_basePath)
                 .Select(x => (new DirectoryInfo(x)).Name)
-                .Where(x => x != "Templates" && !string.IsNullOrEmpty(x))
+                .Where(x => x != "Templates")
                 .ToList();
         }
 

--- a/src/Randomizer.SMZ3.Tracking/Configuration/TrackerConfigProvider.cs
+++ b/src/Randomizer.SMZ3.Tracking/Configuration/TrackerConfigProvider.cs
@@ -208,11 +208,14 @@ namespace Randomizer.SMZ3.Tracking.Configuration
             
             foreach (var profile in profiles)
             {
-                var otherConfig = LoadYamlFile<T>(fileName, profile);
-                if (otherConfig == null) continue;
-                var otherMergeableConfig = (IMergeable<T2>)otherConfig;
-                if (otherConfig == null) throw new InvalidOperationException($"The class '{typeof(T).Name}' does not implement IMergeable.");
-                mergeableConfig.MergeFrom(otherMergeableConfig);
+                if (!string.IsNullOrEmpty(profile))
+                {
+                    var otherConfig = LoadYamlFile<T>(fileName, profile);
+                    if (otherConfig == null) continue;
+                    var otherMergeableConfig = (IMergeable<T2>)otherConfig;
+                    if (otherConfig == null) throw new InvalidOperationException($"The class '{typeof(T).Name}' does not implement IMergeable.");
+                    mergeableConfig.MergeFrom(otherMergeableConfig);
+                }
             }
 
             return config;

--- a/src/Randomizer.SMZ3.Tracking/Services/UIService.cs
+++ b/src/Randomizer.SMZ3.Tracking/Services/UIService.cs
@@ -38,6 +38,7 @@ namespace Randomizer.SMZ3.Tracking.Services
             _configProvider = configProvider;
 
             var iconPaths = _options.Options.TrackerProfiles
+                .Where(x => !string.IsNullOrEmpty(x))
                 .Select(x => Path.Combine(_configProvider.ConfigDirectory, x)).Reverse().ToList();
             iconPaths.Add(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
             IconPaths = iconPaths;

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/TrackerModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/TrackerModule.cs
@@ -59,6 +59,7 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
         /// with the specified tracker.
         /// </summary>
         /// <param name="tracker">The tracker instance to use.</param>
+        /// <param name="itemService">Service to get item information</param>
         /// <param name="logger">Used to log information.</param>
         protected TrackerModule(Tracker tracker, IItemService itemService, ILogger logger)
         {

--- a/src/Randomizer.SMZ3/Generation/PlandoConfig.cs
+++ b/src/Randomizer.SMZ3/Generation/PlandoConfig.cs
@@ -52,6 +52,11 @@ namespace Randomizer.SMZ3.Generation
         public KeysanityMode KeysanityMode { get; set; }
 
         /// <summary>
+        /// Gets or sets the logic options that apply to the plando.
+        /// </summary>
+        public LogicConfig Logic { get; set; }
+
+        /// <summary>
         /// Gets or sets a dictionary that contains the names of locations and
         /// the types of items they should be filled with.
         /// </summary>
@@ -68,10 +73,5 @@ namespace Randomizer.SMZ3.Generation
         /// medallions they require.
         /// </summary>
         public Dictionary<string, ItemType> Medallions { get; set; }
-
-        /// <summary>
-        /// Gets or sets the logic options that apply to the plando.
-        /// </summary>
-        public LogicConfig Logic { get; set; }
     }
 }


### PR DESCRIPTION
So the seed I rolled to test out the GT item counting literally only had keys, the map, and compass before the big key. This was kind of nagging me a bit, so I decided to check it out, and sure enough tracker was still going into the whole "You got another X item. Y treasures left." before which I think gets in the way of counting. This fixes that.

While doing that, I also found the spot that was causing the issue where Tracker wouldn't announce that there are no remaining items left when using the auto tracking, so I'm fixing that as well.