### PR TITLE
Update Tracker.cs

### DIFF
--- a/src/Randomizer.SMZ3.Tracking/Tracker.cs
+++ b/src/Randomizer.SMZ3.Tracking/Tracker.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Speech.Recognition;
+using System.Runtime.InteropServices;
 using System.Speech.Synthesis;
 using System.Text;
 using System.Threading;
@@ -61,6 +62,9 @@ namespace Randomizer.SMZ3.Tracking
         private bool _alternateTracker;
         private HashSet<SchrodingersString> _saidLines = new();
         private bool _beatenGame;
+
+        [DllImport("winmm.dll")]
+        public static extern int waveInGetNumDevs();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Tracker"/> class.
@@ -379,6 +383,11 @@ namespace Randomizer.SMZ3.Tracking
 
             try
             {
+                if (waveInGetNumDevs() == 0)
+                {
+                    _logger.LogWarning("No microphone device found.");
+                    return false;
+                }
                 _recognizer.SetInputToDefaultAudioDevice();
                 MicrophoneInitialized = true;
                 return true;


### PR DESCRIPTION
Mod to check if any microphone devices exist before attempting to connect and then receiving exception. It uses an extern so if that isn't acceptable, it looks like the Exception will have to be.
Ref:
https://stackoverflow.com/questions/22734731/no-microphone-speechrecognitionengine-setinputtodefaultaudiodevice-problems