### PR TITLE
Update LuaConnector.cs

### DIFF
--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/LuaConnector.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/LuaConnector.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
@@ -115,7 +115,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         {
             _isConnected = false;
             _isEnabled = false;
-            if (_tcpListener != null)
+            if (_tcpListener != null && _socket != null && _socket.Connected)
             {
                 _tcpListener.Stop();
             }


### PR DESCRIPTION
Mod to conditional in the event that Lua was not connected to: I was getting "A blocking operation was interrupted by a call to WSACancelBlockingCall." in my logs if I closed tracker without connecting via Lua script dialog.