### PR TITLE
Updates from Digi's Stream and Async Race

### DIFF
--- a/setup/randomizer.app.iss
+++ b/setup/randomizer.app.iss
@@ -4,7 +4,7 @@
 #include "CodeDependencies.iss"
 
 #define MyAppName "SMZ3 Cas' Randomizer"
-#define MyAppVersion "6.0.0-rc.4"
+#define MyAppVersion "6.0.0-rc.5"
 #define MyAppPublisher "Vivelin"
 #define MyAppURL "https://github.com/Vivelin/SMZ3Randomizer"
 #define MyAppExeName "Randomizer.App.exe"

--- a/src/Randomizer.App/Randomizer.App.csproj
+++ b/src/Randomizer.App/Randomizer.App.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net5.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>chozo20.ico</ApplicationIcon>
-    <Version>6.0.0-rc.4</Version>
+    <Version>6.0.0-rc.5</Version>
     <Title>SMZ3 Cas' Randomizer</Title>
     <AssemblyTitle>SMZ3 Cas' Randomizer</AssemblyTitle>
     <Authors>Vivelin</Authors>

--- a/src/Randomizer.App/ViewModels/RandomizerOptions.cs
+++ b/src/Randomizer.App/ViewModels/RandomizerOptions.cs
@@ -142,8 +142,6 @@ namespace Randomizer.App.ViewModels
             {
                 var oldConfig = Config.FromConfigString(SeedOptions.ConfigString);
 
-                var keysanity = SeedOptions.KeysanityMode;
-                var itemPlacement = SeedOptions.ItemPlacementRule;
                 var race = SeedOptions.Race;
                 var disableSpoilerLog = SeedOptions.DisableSpoilerLog;
                 var disableTrackerHints = SeedOptions.DisableTrackerHints;
@@ -153,8 +151,6 @@ namespace Randomizer.App.ViewModels
 
                 if (SeedOptions.CopySeedAndRaceSettings)
                 {
-                    keysanity = oldConfig.KeysanityMode;
-                    itemPlacement = oldConfig.ItemPlacementRule;
                     race = oldConfig.Race;
                     disableSpoilerLog = oldConfig.DisableSpoilerLog;
                     disableTrackerHints = oldConfig.DisableTrackerHints;
@@ -163,12 +159,11 @@ namespace Randomizer.App.ViewModels
                     seed = oldConfig.Seed;
                 }
 
-
                 return new Config()
                 {
                     GameMode = GameMode.Normal,
-                    KeysanityMode = keysanity,
-                    ItemPlacementRule = itemPlacement,
+                    KeysanityMode = oldConfig.KeysanityMode,
+                    ItemPlacementRule = oldConfig.ItemPlacementRule,
                     Race = race,
                     DisableSpoilerLog = disableSpoilerLog,
                     DisableTrackerHints = disableTrackerHints,

--- a/src/Randomizer.App/ViewModels/TrackerMapLocationViewModel.cs
+++ b/src/Randomizer.App/ViewModels/TrackerMapLocationViewModel.cs
@@ -71,7 +71,7 @@ namespace Randomizer.App.ViewModels
                 if (Syncer.SpecialLocationLogic(Locations.First()))
                 {
                     var progression = Region is HyruleCastle || Region.World.Config.KeysanityForRegion(Region) ? syncer.Progression : syncer.ProgressionWithKeys;
-                    var statuses = Locations.Select(x => x.GetStatus(progression));
+                    var statuses = Locations.Select(x => x.GetStatus(progression, Syncer.TrackerLogic.TrackerLocationLogic));
 
                     ClearableLocationsCount = statuses.Count(x => x == Shared.Enums.LocationStatus.Available);
                     RelevantLocationsCount = statuses.Count(x => x == Shared.Enums.LocationStatus.Relevant);

--- a/src/Randomizer.App/ViewModels/TrackerMapLocationViewModel.cs
+++ b/src/Randomizer.App/ViewModels/TrackerMapLocationViewModel.cs
@@ -193,9 +193,14 @@ namespace Randomizer.App.ViewModels
                     {
                         image = "boss.png";
                     }
-                    else if (Dungeon != null && !Dungeon.Cleared && region.CanComplete(Syncer.ProgressionForRegion(Region)))
+                    else if (Dungeon != null && !Dungeon.Cleared)
                     {
-                        image = Dungeon.Reward.GetDescription().ToLowerInvariant() + ".png";
+                        var regionLocations = (IHasLocations)Region;
+                        if (region.CanComplete(Syncer.Tracker.GetProgression(false))
+                            || regionLocations.Locations.All(x => x.IsAvailable(Syncer.ProgressionForRegion(Region))))
+                        {
+                            image = Dungeon.Reward.GetDescription().ToLowerInvariant() + ".png";
+                        }
                     }
                 }
                 else if (Type == MapLocationType.Item)

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/LuaConnector.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/LuaConnector.cs
@@ -178,7 +178,10 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
                 }
                 catch (SocketException se)
                 {
-                    _logger.LogError(se, "Error in accepting socket");
+                    if (_isEnabled)
+                    {
+                        _logger.LogError(se, "Error in accepting socket");
+                    }
                 }
             }
         }

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/LuaConnector.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/LuaConnector.cs
@@ -115,7 +115,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         {
             _isConnected = false;
             _isEnabled = false;
-            if (_tcpListener != null && _socket != null && _socket.Connected)
+            if (_tcpListener != null)
             {
                 _tcpListener.Stop();
             }

--- a/src/Randomizer.SMZ3.Tracking/Configuration/ConfigFiles/LocationConfig.cs
+++ b/src/Randomizer.SMZ3.Tracking/Configuration/ConfigFiles/LocationConfig.cs
@@ -37,7 +37,7 @@ namespace Randomizer.SMZ3.Tracking.Configuration.ConfigFiles
                 new LocationInfo()
                 {
                     LocationNumber = 1,
-                    Name = new("Flooded Cavern - under water", "West Ocean - under water", "that room before Wrecked Ship that's underwater", new("Missile (outside Wrecked Ship bottom)", 0)),
+                    Name = new("Flooded Cavern (under water)", "West Ocean (under water)", "that room before Wrecked Ship that's underwater", new("Missile (outside Wrecked Ship bottom)", 0)),
                     X = 1128,
                     Y = 244,
                 },
@@ -131,7 +131,7 @@ namespace Randomizer.SMZ3.Tracking.Configuration.ConfigFiles
                 new LocationInfo()
                 {
                     LocationNumber = 15,
-                    Name = new("Mockball Room - Fail item", "that spot you get to when failing the mock ball in Green Brinstar", new("Missile (green Brinstar below super missile)", 0)),
+                    Name = new("Mockball Room (Fail item)", "that spot you get to when failing the mock ball in Green Brinstar", new("Missile (green Brinstar below super missile)", 0)),
                     X = 296,
                     Y = 212,
                 },
@@ -176,7 +176,7 @@ namespace Randomizer.SMZ3.Tracking.Configuration.ConfigFiles
                 new LocationInfo()
                 {
                     LocationNumber = 23,
-                    Name = new("Pink Shaft - Chozo", "the room underneath Pink Brinstar", new("Charge Beam", 0)),
+                    Name = new("Pink Shaft (Chozo)", "the room underneath Pink Brinstar", new("Charge Beam", 0)),
                     X = 488,
                     Y = 436,
                 },
@@ -291,7 +291,7 @@ namespace Randomizer.SMZ3.Tracking.Configuration.ConfigFiles
                 new LocationInfo()
                 {
                     LocationNumber = 41,
-                    Name = new("Alpha Power Bomb Room - Behind the wall", "Missile (red Brinstar spike room)", "the room behind the wall in the Chozo room in Red Brinstar"),
+                    Name = new("Alpha Power Bomb Room (Behind the wall)", "Missile (red Brinstar spike room)", "the room behind the wall in the Chozo room in Red Brinstar"),
                     X = 1032,
                     Y = 436,
                 },
@@ -326,7 +326,7 @@ namespace Randomizer.SMZ3.Tracking.Configuration.ConfigFiles
                 new LocationInfo()
                 {
                     LocationNumber = 49,
-                    Name = new("Lava Room - Submerged in wall", "Cathedral", "the room in Upper Norfair with the item in the lava", new("Missile (lava room)", 0)),
+                    Name = new("Lava Room (Submerged in wall)", "Cathedral", "the room in Upper Norfair with the item in the lava", new("Missile (lava room)", 0)),
                     X = 568,
                     Y = 212,
                 },
@@ -368,14 +368,14 @@ namespace Randomizer.SMZ3.Tracking.Configuration.ConfigFiles
                 new LocationInfo()
                 {
                     LocationNumber = 55,
-                    Name = new("Hi-Jump Lobby - Back", "the spot on your way out of the room in the Upper Norfair where you have to wait a long time for an enemy before you can leave again", new("Missile (Hi-Jump Boots)", 0)),
+                    Name = new("Hi-Jump Lobby (Back)", "the spot on your way out of the room in the Upper Norfair where you have to wait a long time for an enemy before you can leave again", new("Missile (Hi-Jump Boots)", 0)),
                     X = 312,
                     Y = 244,
                 },
                 new LocationInfo()
                 {
                     LocationNumber = 56,
-                    Name = new("Hi-Jump Lobby - Entrance", "the room in the Upper Norfair where you have to wait a long time for an enemy before you can leave again", new("Energy Tank (Hi-Jump Boots)", 0)),
+                    Name = new("Hi-Jump Lobby (Entrance)", "the room in the Upper Norfair where you have to wait a long time for an enemy before you can leave again", new("Energy Tank (Hi-Jump Boots)", 0)),
                     X = 344,
                     Y = 244,
                 },
@@ -434,7 +434,7 @@ namespace Randomizer.SMZ3.Tracking.Configuration.ConfigFiles
                 new LocationInfo()
                 {
                     LocationNumber = 65,
-                    Name = new("Speed Booster Hall - Ceiling", "the spot in the ceiling on the right side of Bubble Mountain", new("Missile (Speed Booster)", 0)),
+                    Name = new("Speed Booster Hall (Ceiling)", "the spot in the ceiling on the right side of Bubble Mountain", new("Missile (Speed Booster)", 0)),
                     X = 1208,
                     Y = 148,
                 },
@@ -462,14 +462,14 @@ namespace Randomizer.SMZ3.Tracking.Configuration.ConfigFiles
                 new LocationInfo()
                 {
                     LocationNumber = 70,
-                    Name = new("Gold Torizo - Drop down", "the spot before you drop down to fight Gold Torizo", new("Missile (Gold Torizo)", 0)),
+                    Name = new("Gold Torizo (Drop down)", "the spot before you drop down to fight Gold Torizo", new("Missile (Gold Torizo)", 0)),
                     X = 632,
                     Y = 564,
                 },
                 new LocationInfo()
                 {
                     LocationNumber = 71,
-                    Name = new("Golden Torizo - Ceiling", "the spot where Gold Torizo hides before the fight", new("Super Missile (Gold Torizo)", 0)),
+                    Name = new("Golden Torizo (Ceiling)", "the spot where Gold Torizo hides before the fight", new("Super Missile (Gold Torizo)", 0)),
                     X = 664,
                     Y = 564,
                 },
@@ -533,28 +533,28 @@ namespace Randomizer.SMZ3.Tracking.Configuration.ConfigFiles
                 new LocationInfo()
                 {
                     LocationNumber = 128,
-                    Name = new("Main Shaft - Side room", "the room behind the bombeable wall on the left side of Wrecked Ship", new("Missile (Wrecked Ship middle)", 0)),
+                    Name = new("Main Shaft (Side room)", "the room behind the bombeable wall on the left side of Wrecked Ship", new("Missile (Wrecked Ship middle)", 0)),
                     X = 408,
                     Y = 340,
                 },
                 new LocationInfo()
                 {
                     LocationNumber = 129,
-                    Name = new("Post Chozo Concert - Speed Booster Item", "Bowling Alley - Speed Booster Item", "the spot that requires the Speed Booster in Wrecked Ship", new("Reserve Tank, Wrecked Ship", 0), new("Wrecked Ship, Reserve Tank", 0)),
+                    Name = new("Post Chozo Concert (Speed Booster Item)", "Bowling Alley (Speed Booster Item)", "the spot that requires the Speed Booster in Wrecked Ship", new("Reserve Tank, Wrecked Ship", 0), new("Wrecked Ship, Reserve Tank", 0)),
                     X = 504,
                     Y = 180,
                 },
                 new LocationInfo()
                 {
                     LocationNumber = 130,
-                    Name = new("Post Chozo Concert - Breakable Chozo", "the breakable Chozo in Wrecked Ship", new("Missile (Gravity Suit)", 0)),
+                    Name = new("Post Chozo Concert (Breakable Chozo)", "the breakable Chozo in Wrecked Ship", new("Missile (Gravity Suit)", 0)),
                     X = 440,
                     Y = 244,
                 },
                 new LocationInfo()
                 {
                     LocationNumber = 131,
-                    Name = new("Attic - Assembly Line", "the room with the conveyors and robots", new("Missile (Wrecked Ship top)", 0)),
+                    Name = new("Attic (Assembly Line)", "the room with the conveyors and robots", new("Missile (Wrecked Ship top)", 0)),
                     X = 696,
                     Y = 148,
                 },
@@ -582,21 +582,21 @@ namespace Randomizer.SMZ3.Tracking.Configuration.ConfigFiles
                 new LocationInfo()
                 {
                     LocationNumber = 135,
-                    Name = new("Post Chozo Concert - Gravity Suit Chamber", "the room after the Chozo concert", new("Gravity Suit", 0)),
+                    Name = new("Post Chozo Concert (Gravity Suit Chamber)", "the room after the Chozo concert", new("Gravity Suit", 0)),
                     X = 344,
                     Y = 244,
                 },
                 new LocationInfo()
                 {
                     LocationNumber = 136,
-                    Name = new("Main Street - Ceiling (Shinespark)", "Main Street Missiles", "the spot in the ceiling in Maridia that requires Shinespark", new("Missile (green Maridia shinespark)", 0)),
+                    Name = new("Main Street (Ceiling Shinespark)", "Main Street Missiles", "the spot in the ceiling in Maridia that requires Shinespark", new("Missile (green Maridia shinespark)", 0)),
                     X = 232,
                     Y = 468,
                 },
                 new LocationInfo()
                 {
                     LocationNumber = 137,
-                    Name = new("Main Street - Crab Supers", "the tiny room where you watch crabs walking into the wall", new("Super Missile (green Maridia)", 0)),
+                    Name = new("Main Street (Crab Supers)", "the tiny room where you watch crabs walking into the wall", new("Super Missile (green Maridia)", 0)),
                     X = 264,
                     Y = 436,
                 },
@@ -610,7 +610,7 @@ namespace Randomizer.SMZ3.Tracking.Configuration.ConfigFiles
                 new LocationInfo()
                 {
                     LocationNumber = 139,
-                    Name = new("Mama Turtle Room - Wall item", "the spot in the wall in the turtle room", new("Missile (green Maridia tatori)", 0)),
+                    Name = new("Mama Turtle Room (Wall item)", "the spot in the wall in the turtle room", new("Missile (green Maridia tatori)", 0)),
                     X = 520,
                     Y = 500,
                 },
@@ -665,14 +665,14 @@ namespace Randomizer.SMZ3.Tracking.Configuration.ConfigFiles
                 new LocationInfo()
                 {
                     LocationNumber = 148,
-                    Name = new("Aqueduct - Left item", new("Missile (pink Maridia)", 0)),
+                    Name = new("Aqueduct (Left item)", new("Missile (pink Maridia)", 0)),
                     X = 680,
                     Y = 372,
                 },
                 new LocationInfo()
                 {
                     LocationNumber = 149,
-                    Name = new("Aqueduct - Right item", new("Super Missile (pink Maridia)", 0)),
+                    Name = new("Aqueduct (Right item)", new("Super Missile (pink Maridia)", 0)),
                     X = 712,
                     Y = 372,
                 },
@@ -749,37 +749,37 @@ namespace Randomizer.SMZ3.Tracking.Configuration.ConfigFiles
                 new LocationInfo()
                 {
                     LocationNumber = 262,
-                    Name = new("Paradox Cave Upper - Left"),
+                    Name = new("Paradox Cave Upper (Left)"),
                 },
                 new LocationInfo()
                 {
                     LocationNumber = 263,
-                    Name = new("Paradox Cave Upper - Right"),
+                    Name = new("Paradox Cave Upper (Right)"),
                 },
                 new LocationInfo()
                 {
                     LocationNumber = 264,
-                    Name = new("Paradox Cave Lower - Far Left"),
+                    Name = new("Paradox Cave Lower (Far Left)"),
                 },
                 new LocationInfo()
                 {
                     LocationNumber = 265,
-                    Name = new("Paradox Cave Lower - Left"),
+                    Name = new("Paradox Cave Lower (Left)"),
                 },
                 new LocationInfo()
                 {
                     LocationNumber = 266,
-                    Name = new("Paradox Cave Lower - Middle"),
+                    Name = new("Paradox Cave Lower (Middle)"),
                 },
                 new LocationInfo()
                 {
                     LocationNumber = 267,
-                    Name = new("Paradox Cave Lower - Right"),
+                    Name = new("Paradox Cave Lower (Right)"),
                 },
                 new LocationInfo()
                 {
                     LocationNumber = 268,
-                    Name = new("Paradox Cave Lower - Far Right"),
+                    Name = new("Paradox Cave Lower (Far Right)"),
                 },
                 new LocationInfo()
                 {
@@ -1035,32 +1035,32 @@ namespace Randomizer.SMZ3.Tracking.Configuration.ConfigFiles
                 new LocationInfo()
                 {
                     LocationNumber = 321,
-                    Name = new("Hookshot Cave - Top Right"),
+                    Name = new("Hookshot Cave (Top Right)"),
                 },
                 new LocationInfo()
                 {
                     LocationNumber = 322,
-                    Name = new("Hookshot Cave - Top Left"),
+                    Name = new("Hookshot Cave (Top Left)"),
                 },
                 new LocationInfo()
                 {
                     LocationNumber = 323,
-                    Name = new("Hookshot Cave - Bottom Left"),
+                    Name = new("Hookshot Cave (Bottom Left)"),
                 },
                 new LocationInfo()
                 {
                     LocationNumber = 324,
-                    Name = new("Hookshot Cave - Bottom Right"),
+                    Name = new("Hookshot Cave (Bottom Right)"),
                 },
                 new LocationInfo()
                 {
                     LocationNumber = 325,
-                    Name = new("Superbunny Cave - Top"),
+                    Name = new("Superbunny Cave (Top)"),
                 },
                 new LocationInfo()
                 {
                     LocationNumber = 326,
-                    Name = new("Superbunny Cave - Bottom"),
+                    Name = new("Superbunny Cave (Bottom)"),
                 },
                 new LocationInfo()
                 {
@@ -1178,12 +1178,12 @@ namespace Randomizer.SMZ3.Tracking.Configuration.ConfigFiles
                 new LocationInfo()
                 {
                     LocationNumber = 345,
-                    Name = new("Mire Shed - Left"),
+                    Name = new("Mire Shed (Left)"),
                 },
                 new LocationInfo()
                 {
                     LocationNumber = 346,
-                    Name = new("Mire Shed - Right"),
+                    Name = new("Mire Shed (Right)"),
                 },
                 new LocationInfo()
                 {
@@ -1193,17 +1193,17 @@ namespace Randomizer.SMZ3.Tracking.Configuration.ConfigFiles
                 new LocationInfo()
                 {
                     LocationNumber = 348,
-                    Name = new("Secret Room - Left", "Back of Escape - Left", new("Sewers Secret Room - Left", 0)),
+                    Name = new("Secret Room (Left)", "Back of Escape (Left)", new("Sewers Secret Room (Left)", 0)),
                 },
                 new LocationInfo()
                 {
                     LocationNumber = 349,
-                    Name = new("Secret Room - Middle", "Back of Escape - Middle", new("Sewers Secret Room - Middle", 0)),
+                    Name = new("Secret Room (Middle)", "Back of Escape (Middle)", new("Sewers Secret Room (Middle)", 0)),
                 },
                 new LocationInfo()
                 {
                     LocationNumber = 350,
-                    Name = new("Secret Room - Right", "Back of Escape - Right", new("Sewers Secret Room - Right", 0)),
+                    Name = new("Secret Room (Right)", "Back of Escape (Right)", new("Sewers Secret Room (Right)", 0)),
                 },
                 new LocationInfo()
                 {
@@ -1243,7 +1243,7 @@ namespace Randomizer.SMZ3.Tracking.Configuration.ConfigFiles
                 new LocationInfo()
                 {
                     LocationNumber = 358,
-                    Name = new("Castle Tower - Dark Maze"),
+                    Name = new("Castle Tower (Dark Maze)"),
                 },
                 new LocationInfo()
                 {
@@ -1356,12 +1356,12 @@ namespace Randomizer.SMZ3.Tracking.Configuration.ConfigFiles
                 new LocationInfo()
                 {
                     LocationNumber = 380,
-                    Name = new("The Arena - Bridge", new("Palace of Darkness The Arena - Bridge", 0)),
+                    Name = new("The Arena (Bridge)", new("Palace of Darkness The Arena (Bridge)", 0)),
                 },
                 new LocationInfo()
                 {
                     LocationNumber = 381,
-                    Name = new("The Arena - Ledge", new("Palace of Darkness The Arena - Ledge", 0)),
+                    Name = new("The Arena (Ledge)", new("Palace of Darkness The Arena (Ledge)", 0)),
                 },
                 new LocationInfo()
                 {

--- a/src/Randomizer.SMZ3.Tracking/Configuration/ConfigTypes/BasicVoiceRequest.cs
+++ b/src/Randomizer.SMZ3.Tracking/Configuration/ConfigTypes/BasicVoiceRequest.cs
@@ -25,7 +25,7 @@ namespace Randomizer.SMZ3.Tracking.Configuration.ConfigTypes
         }
 
         [MergeKey]
-        public string Key => Phrases[0];
+        public string Key => Phrases[0].ToLower();
 
         /// <summary>
         /// Gets a collection of phrases that should be recognized.

--- a/src/Randomizer.SMZ3.Tracking/TrackerLogic.cs
+++ b/src/Randomizer.SMZ3.Tracking/TrackerLogic.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Randomizer.Shared;
+using Randomizer.Shared.Enums;
+using Randomizer.SMZ3.Regions;
+
+namespace Randomizer.SMZ3.Tracking
+{
+    /// <summary>
+    /// Temporary class for housing special logic for locations
+    /// </summary>
+    public class TrackerLogic
+    {
+        private readonly Tracker _tracker;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="tracker"></param>
+        public TrackerLogic(Tracker tracker)
+        {
+            _tracker = tracker;
+            TrackerLocationLogic = new()
+            {
+                // Mimic Cave
+                { 265, (items) => CheckDungeonMedallion(items, _tracker.World.TurtleRock) },
+                // Sahasrahla
+                { 300, (items) => CountReward(items, RewardType.PendantGreen) == 1 },
+                // Pyramid Fairy
+                { 336, (items) => CountReward(items, RewardType.CrystalRed) == 2 },
+                { 337, (items) => CountReward(items, RewardType.CrystalRed) == 2 },
+                // Misery Mire
+                { 425, (items) => CheckDungeonMedallion(items, _tracker.World.MiseryMire) },
+                { 426, (items) => CheckDungeonMedallion(items, _tracker.World.MiseryMire) },
+                { 427, (items) => CheckDungeonMedallion(items, _tracker.World.MiseryMire) },
+                { 428, (items) => CheckDungeonMedallion(items, _tracker.World.MiseryMire) },
+                { 429, (items) => CheckDungeonMedallion(items, _tracker.World.MiseryMire) },
+                { 430, (items) => CheckDungeonMedallion(items, _tracker.World.MiseryMire) },
+                { 431, (items) => CheckDungeonMedallion(items, _tracker.World.MiseryMire) },
+                { 432, (items) => CheckDungeonMedallion(items, _tracker.World.MiseryMire) },
+                // Turtle Rock
+                { 433, (items) => CheckDungeonMedallion(items, _tracker.World.TurtleRock) },
+                { 434, (items) => CheckDungeonMedallion(items, _tracker.World.TurtleRock) },
+                { 435, (items) => CheckDungeonMedallion(items, _tracker.World.TurtleRock) },
+                { 436, (items) => CheckDungeonMedallion(items, _tracker.World.TurtleRock) },
+                { 437, (items) => CheckDungeonMedallion(items, _tracker.World.TurtleRock) },
+                { 438, (items) => CheckDungeonMedallion(items, _tracker.World.TurtleRock) },
+                { 439, (items) => CheckDungeonMedallion(items, _tracker.World.TurtleRock) },
+                { 440, (items) => CheckDungeonMedallion(items, _tracker.World.TurtleRock) },
+                { 441, (items) => CheckDungeonMedallion(items, _tracker.World.TurtleRock) },
+                { 442, (items) => CheckDungeonMedallion(items, _tracker.World.TurtleRock) },
+                { 443, (items) => CheckDungeonMedallion(items, _tracker.World.TurtleRock) },
+                { 444, (items) => CheckDungeonMedallion(items, _tracker.World.TurtleRock) },
+            };
+        }
+
+        /// <summary>
+        /// Retrieves a dictionary of requirements for specific locations
+        /// </summary>
+        public Dictionary<int, Requirement> TrackerLocationLogic { get; private set; }
+
+        /// <summary>
+        /// Retrieves the requirements for the location, or an always true requirement
+        /// if it is not found
+        /// </summary>
+        /// <param name="location"></param>
+        /// <returns></returns>
+        public Requirement FindOrDefault(Location location)
+        {
+            if (TrackerLocationLogic?.ContainsKey(location.Id) == true)
+            {
+                return TrackerLocationLogic[location.Id];
+            }
+            return (items) => true;
+        }
+
+        private bool CheckDungeonMedallion(Progression items, Region dungeon)
+        {
+            if (dungeon is not INeedsMedallion) return true;
+            var dungeonInfo = _tracker.WorldInfo.Dungeons.First(x => x.GetRegion(_tracker.World) == dungeon);
+            return (dungeonInfo.Requirement == Medallion.Bombos && items.Bombos) ||
+                (dungeonInfo.Requirement == Medallion.Ether && items.Ether) ||
+                (dungeonInfo.Requirement == Medallion.Quake && items.Quake) ||
+                (items.Bombos && items.Ether && items.Quake);
+        }
+
+        private int CountReward(Progression items, RewardType reward)
+        {
+            var dungeons = _tracker.World.Regions
+                .Where(x => x is IHasReward rewardRegion && rewardRegion.Reward == reward && rewardRegion.CanComplete(items) && CheckDungeonMedallion(items, x));
+
+            return _tracker.WorldInfo.Dungeons
+                .Where(x => dungeons.Contains(x.GetRegion(_tracker.World)))
+                .Count(x => x.Reward.ToRewardType() == reward);
+        }
+    }
+}

--- a/src/Randomizer.SMZ3/Location.cs
+++ b/src/Randomizer.SMZ3/Location.cs
@@ -228,11 +228,12 @@ namespace Randomizer.SMZ3
         /// </summary>
         /// <param name="items">The available items</param>
         /// <returns>The LocationStatus enum of the location</returns>
-        public LocationStatus GetStatus(Progression items)
+        public LocationStatus GetStatus(Progression items, Dictionary<int, Requirement> trackerLogic)
         {
+            var logic = trackerLogic.ContainsKey(Id) ? trackerLogic[Id] : (items) => true;
             if (Cleared) return LocationStatus.Cleared;
-            else if (IsAvailable(items)) return LocationStatus.Available;
-            else if (IsRelevant(items)) return LocationStatus.Relevant;
+            else if (IsAvailable(items) && logic(items)) return LocationStatus.Available;
+            else if (IsRelevant(items) && logic(items)) return LocationStatus.Relevant;
             else return LocationStatus.OutOfLogic;
         }
 

--- a/src/Randomizer.SMZ3/Location.cs
+++ b/src/Randomizer.SMZ3/Location.cs
@@ -221,7 +221,7 @@ namespace Randomizer.SMZ3
         /// <param name="items">The available items.</param>
         /// <see langword="true"/> if the location is available with <paramref
         /// name="items"/>; otherwise, <see langword="false"/>.
-        public bool IsRevelant(Progression items) => Region.CanEnter(items, false) && _relevanceRequirement(items);
+        public bool IsRelevant(Progression items) => Region.CanEnter(items, false) && _relevanceRequirement(items);
 
         /// <summary>
         /// Returns the status of a location based on the given items
@@ -232,7 +232,7 @@ namespace Randomizer.SMZ3
         {
             if (Cleared) return LocationStatus.Cleared;
             else if (IsAvailable(items)) return LocationStatus.Available;
-            else if (IsRevelant(items)) return LocationStatus.Relevant;
+            else if (IsRelevant(items)) return LocationStatus.Relevant;
             else return LocationStatus.OutOfLogic;
         }
 

--- a/src/Randomizer.SMZ3/Logic.cs
+++ b/src/Randomizer.SMZ3/Logic.cs
@@ -147,7 +147,7 @@ namespace Randomizer.SMZ3
         {
             if (World.Config.LogicConfig.LeftSandPitRequiresSpringBall)
             {
-                return items.SpringBall && items.HiJump;
+                return items.SpringBall;
             }
 
             return CanWallJump(WallJumpDifficulty.Medium)

--- a/src/Randomizer.SMZ3/Regions/SuperMetroid/Maridia/InnerMaridia.cs
+++ b/src/Randomizer.SMZ3/Regions/SuperMetroid/Maridia/InnerMaridia.cs
@@ -10,7 +10,8 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Maridia
                 name: "Missile (yellow Maridia false wall)",
                 alsoKnownAs: new[] { "Pseudo Plasma Spark Room" },
                 vanillaItem: ItemType.Missile,
-                access: items => items.CardMaridiaL1 && Logic.CanPassBombPassages(items) && CanPassPipeCrossroads(items),
+                access: items => items.CardMaridiaL1 && Logic.CanPassBombPassages(items) && CanPassPipeCrossroads(items) && CanReachAqueduct(items, Logic, true),
+                relevanceRequirement: items => items.CardMaridiaL1 && Logic.CanPassBombPassages(items) && CanPassPipeCrossroads(items) && CanReachAqueduct(items, Logic, false),
                 memoryAddress: 0x11,
                 memoryFlag: 0x40);
             PlasmaBeamRoom = new Location(this, 143, 0x8FC559, LocationType.Chozo,
@@ -125,15 +126,14 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Maridia
 
         public override bool CanEnter(Progression items, bool requireRewards)
             => items.Gravity && (
-                    (World.UpperNorfairWest.CanEnter(items, true) && items.Super && Logic.CanUsePowerBombs(items) &&
-                        (Logic.CanFly(items) || items.SpeedBooster || items.Grapple)) ||
+                    (World.UpperNorfairWest.CanEnter(items, true) && items.Super && Logic.CanUsePowerBombs(items) && CanPassMountDeath(items, Logic)) ||
                     Logic.CanAccessMaridiaPortal(items, requireRewards));
 
         public bool CanComplete(Progression items)
             => CanEnter(items, true) && CanDefeatDraygon(items, true);
 
         private static bool CanReachAqueduct(Progression items, ILogic logic, bool requireRewards)
-            => (items.CardMaridiaL1 && (logic.CanFly(items) || items.SpeedBooster || items.Grapple))
+            => (items.CardMaridiaL1 && CanPassMountDeath(items, logic))
                          || (items.CardMaridiaL2 && logic.CanAccessMaridiaPortal(items, requireRewards));
 
         private bool CanAccessPreciousRoom(Progression items, bool requireRewards)
@@ -165,6 +165,12 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Maridia
         private bool CanReachRightSandPit(Progression items, bool requireReweards)
             => CanReachAqueduct(items, Logic, requireReweards) && items.Super && (Logic.CanWallJump(WallJumpDifficulty.Easy) || items.HiJump || items.SpaceJump);
 
+        // Large room on the west side of Maridia where you are intended to grapple over
+        private static bool CanPassMountDeath(Progression items, ILogic logic)
+        {
+            return logic.CanFly(items) || items.SpeedBooster || items.Grapple || (items.HiJump && logic.CanWallJump(WallJumpDifficulty.Hard));
+        }
+
         public class WateringHoleRoom : Room
         {
             public WateringHoleRoom(InnerMaridia region)
@@ -174,7 +180,8 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Maridia
                     name: "Left",
                     alsoKnownAs: new[] { "Super Missile (yellow Maridia)", "Watering Hole - Left", },
                     vanillaItem: ItemType.Super,
-                    access: items => items.CardMaridiaL1 && Logic.CanPassBombPassages(items) && region.CanPassPipeCrossroads(items),
+                    access: items => items.CardMaridiaL1 && Logic.CanPassBombPassages(items) && region.CanPassPipeCrossroads(items) && CanReachAqueduct(items, Logic, true),
+                    relevanceRequirement: items => items.CardMaridiaL1 && Logic.CanPassBombPassages(items) && region.CanPassPipeCrossroads(items) && CanReachAqueduct(items, Logic, false),
                     memoryAddress: 0x11,
                     memoryFlag: 0x10);
 
@@ -182,7 +189,8 @@ namespace Randomizer.SMZ3.Regions.SuperMetroid.Maridia
                     name: "Right",
                     alsoKnownAs: new[] { "Missile (yellow Maridia super missile)", "Watering Hole - right" },
                     vanillaItem: ItemType.Missile,
-                    access: items => items.CardMaridiaL1 && Logic.CanPassBombPassages(items) && region.CanPassPipeCrossroads(items),
+                    access: items => items.CardMaridiaL1 && Logic.CanPassBombPassages(items) && region.CanPassPipeCrossroads(items) && CanReachAqueduct(items, Logic, true),
+                    relevanceRequirement: items => items.CardMaridiaL1 && Logic.CanPassBombPassages(items) && region.CanPassPipeCrossroads(items) && CanReachAqueduct(items, Logic, false),
                     memoryAddress: 0x11,
                     memoryFlag: 0x20);
             }

--- a/src/Randomizer.Shared/Models/LogicConfig.cs
+++ b/src/Randomizer.Shared/Models/LogicConfig.cs
@@ -15,7 +15,7 @@ namespace Randomizer.Shared
         public bool PreventFivePowerBombSeed { get; set; }
 
         [DisplayName("Left Sand Pit Needs Spring Ball")]
-        [Description("You're expected to have the spring ball and hi-jump boots to navigate the left sand pit in Maridia.")]
+        [Description("You're expected to have the spring ball to navigate the left sand pit in Maridia.")]
         [Category("Logic")]
         public bool LeftSandPitRequiresSpringBall { get; set; }
 

--- a/tests/Randomizer.SMZ3.Tests/LogicTests/LogicConfigTests.cs
+++ b/tests/Randomizer.SMZ3.Tests/LogicTests/LogicConfigTests.cs
@@ -272,8 +272,8 @@ namespace Randomizer.SMZ3.Tests.LogicTests
             var tempWorld = new World(config, "", 0, "");
             var progression = new Progression(new[] { ItemType.CardMaridiaL1, ItemType.Morph, ItemType.Super, ItemType.PowerBomb, ItemType.Gravity, ItemType.SpaceJump }, new List<RewardType>());
             var missingItems = Logic.GetMissingRequiredItems(tempWorld.InnerMaridia.LeftSandPit.Left, progression);
-            missingItems.Should().HaveCount(2)
-                .And.ContainEquivalentOf(new[] { ItemType.SpringBall, ItemType.HiJump });
+            missingItems.Should().HaveCount(1)
+                .And.ContainEquivalentOf(new[] { ItemType.SpringBall });
             tempWorld.InnerMaridia.LeftSandPit.Left.IsAvailable(progression).Should().BeFalse();
             tempWorld.InnerMaridia.LeftSandPit.Right.IsAvailable(progression).Should().BeFalse();
 


### PR DESCRIPTION
Wasn't intending to make as many updates as this, but was watching Digi play and a few things came up that this PR resolves, along a couple items that came up with the async seed.

- Game mode/item placement was not being copied in with settings strings
- BasicVoiceRequests weren't merging properly if cases were different
- With the walljump patch, hi jump is no longer needed for the left sand pit, so I removed it
- Dungeon bosses were showing up as accessible even if you didn't have the means to get to them
- The watering hole and that hidden room to the top left of Maridia were in logic in medium wall jump without space jump, speed booster, or grapple which should be needed to pass the large room
- Backed out PR 213 as it prevented you from closing and reopening tracker, but I'm no longer printing the exception as it's not really an issue
- Removed " - " from location names as apparently "a-b" does not require you to say dash, but "a - b" does

Probably will wait until Monday to publish a build to give folks a few more days to play the async seed as this has logic changes.