### PR TITLE
Multiworld Generation

### DIFF
--- a/src/Randomizer.App/RomGenerator.cs
+++ b/src/Randomizer.App/RomGenerator.cs
@@ -444,6 +444,25 @@ namespace Randomizer.App
             }
 
             log.AppendLine();
+            log.AppendLine(Underline("Hints", '='));
+            log.AppendLine();
+
+            foreach (var (world, hints) in seed.Hints)
+            {
+                if (world.Config.MultiWorld)
+                {
+                    log.AppendLine(Underline("Player: " + world.Player));
+                    log.AppendLine();
+                }
+
+                foreach (var hint in hints)
+                {
+                    log.AppendLine(hint);
+                }
+                log.AppendLine();
+            }
+
+            log.AppendLine();
             log.AppendLine(Underline("Spheres", '='));
             log.AppendLine();
 

--- a/src/Randomizer.App/RomGenerator.cs
+++ b/src/Randomizer.App/RomGenerator.cs
@@ -368,7 +368,7 @@ namespace Randomizer.App
                 GeneratorVersion = Smz3Randomizer.Version.Major
             };
             _dbContext.GeneratedRoms.Add(rom);
-            await _stateService.CreateStateAsync(seed.Worlds[0].World, rom);
+            await _stateService.CreateStateAsync(seed.Worlds.Select(x => x.World), rom);
             return rom;
         }
 

--- a/src/Randomizer.App/RomGenerator.cs
+++ b/src/Randomizer.App/RomGenerator.cs
@@ -16,6 +16,7 @@ using Randomizer.App.Patches;
 using Randomizer.App.ViewModels;
 using Randomizer.Data.Options;
 using Randomizer.Data.Services;
+using Randomizer.Data.WorldData;
 using Randomizer.Data.WorldData.Regions;
 using Randomizer.Shared;
 using Randomizer.Shared.Models;
@@ -70,7 +71,7 @@ namespace Randomizer.App
                 try
                 {
                     seed = GenerateSeed(options);
-                    if (!_randomizer.ValidateSeedSettings(seed, seed.Playthrough.Config))
+                    if (!_randomizer.ValidateSeedSettings(seed))
                     {
                         latestError = "";
                         validated = false;
@@ -393,23 +394,46 @@ namespace Randomizer.App
             log.AppendLine(Underline($"SMZ3 Cas’ spoiler log", '='));
             log.AppendLine($"Generated on {DateTime.Now:F}");
             log.AppendLine($"Seed: {options.SeedOptions.Seed} (actual: {seed.Seed})");
-            log.AppendLine($"Settings String: {seed.Playthrough.Config.SettingsString}");
-            log.AppendLine($"Early Items: {string.Join(',', seed.Playthrough.Config.EarlyItems.Select(x => x.ToString()).ToArray())}");
 
-            var locationPrefs = new List<string>();
-            foreach (var (locationId, value) in seed.Playthrough.Config.LocationItems)
+            if (options.SeedOptions.Race)
             {
-                var itemPref = value < Enum.GetValues(typeof(ItemPool)).Length ? ((ItemPool)value).ToString() : ((ItemType)value).ToString();
-                locationPrefs.Add($"{seed.Worlds[0].World.Locations.First(x => x.Id == locationId).Name} - {itemPref}");
+                log.AppendLine("[Race]");
             }
-            log.AppendLine($"Location Preferences: {string.Join(',', locationPrefs.ToArray())}");
 
-            var type = options.LogicConfig.GetType();
-            var logicOptions = string.Join(',', type.GetProperties().Select(x => $"{x.Name}: {x.GetValue(seed.Playthrough.Config.LogicConfig)}"));
-            log.AppendLine($"Logic Options: {logicOptions}");
+            log.AppendLine();
+            log.AppendLine(Underline("Settings", '='));
+            log.AppendLine();
 
-            log.AppendLine((options.SeedOptions.Keysanity ? "[Keysanity] " : "")
-                         + (options.SeedOptions.Race ? "[Race] " : ""));
+            foreach (var world in seed.Worlds.Select(x => x.World))
+            {
+                if (world.Config.MultiWorld)
+                {
+                    log.AppendLine(Underline("Player: " + world.Player));
+                    log.AppendLine();
+                }
+
+                log.AppendLine($"Settings String: {world.Config.SettingsString}");
+                log.AppendLine($"Early Items: {string.Join(',', world.Config.EarlyItems.Select(x => x.ToString()).ToArray())}");
+
+                var locationPrefs = new List<string>();
+                foreach (var (locationId, value) in world.Config.LocationItems)
+                {
+                    var itemPref = value < Enum.GetValues(typeof(ItemPool)).Length ? ((ItemPool)value).ToString() : ((ItemType)value).ToString();
+                    locationPrefs.Add($"{world.Locations.First(x => x.Id == locationId).Name} - {itemPref}");
+                }
+                log.AppendLine($"Location Preferences: {string.Join(',', locationPrefs.ToArray())}");
+
+                var type = options.LogicConfig.GetType();
+                var logicOptions = string.Join(',', type.GetProperties().Select(x => $"{x.Name}: {x.GetValue(world.Config.LogicConfig)}"));
+                log.AppendLine($"Logic Options: {logicOptions}");
+
+                if (world.Config.Keysanity)
+                {
+                    log.AppendLine("Keysanity: " + world.Config.KeysanityMode.ToString());
+                }
+                log.AppendLine();
+            }
+
             if (File.Exists(options.PatchOptions.Msu1Path))
                 log.AppendLine($"MSU-1 pack: {Path.GetFileNameWithoutExtension(options.PatchOptions.Msu1Path)}");
             log.AppendLine();
@@ -418,6 +442,10 @@ namespace Randomizer.App
             {
                 return log.ToString();
             }
+
+            log.AppendLine();
+            log.AppendLine(Underline("Spheres", '='));
+            log.AppendLine();
 
             var spheres = seed.Playthrough.GetPlaythroughText();
             for (var i = 0; i < spheres.Count; i++)
@@ -432,31 +460,64 @@ namespace Randomizer.App
                 log.AppendLine();
             }
 
-            log.AppendLine(Underline("Rewards"));
             log.AppendLine();
-            foreach (var region in seed.Worlds[0].World.Regions)
+            log.AppendLine(Underline("Dungeons", '='));
+            log.AppendLine();
+
+            foreach (var world in seed.Worlds.Select(x => x.World))
             {
-                if (region is IHasReward rewardRegion)
-                    log.AppendLine($"{region.Name}: {rewardRegion.RewardType}");
+                if (world.Config.MultiWorld)
+                {
+                    log.AppendLine(Underline("Player " + world.Player + " Rewards"));
+                }
+                else
+                {
+                    log.AppendLine(Underline("Rewards"));
+                }
+                log.AppendLine();
+
+                foreach (var region in world.Regions)
+                {
+                    if (region is IHasReward rewardRegion)
+                        log.AppendLine($"{region.Name}: {rewardRegion.RewardType}");
+                }
+                log.AppendLine();
+
+                if (world.Config.MultiWorld)
+                {
+                    log.AppendLine(Underline("Player " + world.Player + " Medallions"));
+                }
+                else
+                {
+                    log.AppendLine(Underline("Medallions"));
+                }
+                log.AppendLine();
+
+                foreach (var region in world.Regions)
+                {
+                    if (region is INeedsMedallion medallionReegion)
+                        log.AppendLine($"{region.Name}: {medallionReegion.Medallion}");
+                }
+                log.AppendLine();
             }
+
+            log.AppendLine();
+            log.AppendLine(Underline("All Items", '='));
             log.AppendLine();
 
-            log.AppendLine(Underline("Medallions"));
-            log.AppendLine();
-            foreach (var region in seed.Worlds[0].World.Regions)
+            foreach (var world in seed.Worlds.Select(x => x.World))
             {
-                if (region is INeedsMedallion medallionReegion)
-                    log.AppendLine($"{region.Name}: {medallionReegion.Medallion}");
-            }
-            log.AppendLine();
+                if (world.Config.MultiWorld)
+                {
+                    log.AppendLine(Underline("Player: " + world.Player));
+                    log.AppendLine();
+                }
 
-            log.AppendLine(Underline("All items"));
-            log.AppendLine();
-
-            var world = seed.Worlds.Single();
-            foreach (var location in world.World.Locations)
-            {
-                log.AppendLine($"{location}: {location.Item}");
+                foreach (var location in world.Locations)
+                {
+                    log.AppendLine($"{location}: {location.Item}");
+                }
+                log.AppendLine();
             }
 
             return log.ToString();

--- a/src/Randomizer.Data/Options/Config.cs
+++ b/src/Randomizer.Data/Options/Config.cs
@@ -190,6 +190,9 @@ namespace Randomizer.Data.Options
         public bool SingleWorld => GameMode == GameMode.Normal;
         public bool MultiWorld => GameMode == GameMode.Multiworld;
         public bool Keysanity => KeysanityMode != KeysanityMode.None;
+        public int Id { get; set; }
+        public string PlayerName { get; set; }
+        public string PlayerGuid { get; set; }
         public string Seed { get; set; }
         public string SettingsString { get; set; }
         public bool CopySeedAndRaceSettings { get; set; }

--- a/src/Randomizer.Data/Services/IMetadataService.cs
+++ b/src/Randomizer.Data/Services/IMetadataService.cs
@@ -229,6 +229,7 @@ namespace Randomizer.Data.Services
         /// Applies various metadata to the world, such as LocationData and ItemData
         /// </summary>
         /// <param name="world">The world to apply metadata to</param>
-        public void LoadWorldMetadata(World world);
+        /// <param name="createNewStates">If new states should be created for items not already in the world</param>
+        public void LoadWorldMetadata(World world, bool createNewStates);
     }
 }

--- a/src/Randomizer.Data/Services/ITrackerStateService.cs
+++ b/src/Randomizer.Data/Services/ITrackerStateService.cs
@@ -10,10 +10,10 @@ namespace Randomizer.Data.Services
 {
     public interface ITrackerStateService
     {
-        public Task CreateStateAsync(World world, GeneratedRom generatedRom);
+        public Task CreateStateAsync(IEnumerable<World> world, GeneratedRom generatedRom);
 
-        public Task SaveStateAsync(World world, GeneratedRom generatedRom, double secondsElapsed);
+        public Task SaveStateAsync(IEnumerable<World> worlds, GeneratedRom generatedRom, double secondsElapsed);
 
-        public TrackerState? LoadState(World world, GeneratedRom generatedRom);
+        public TrackerState? LoadState(IEnumerable<World> worlds, GeneratedRom generatedRom);
     }
 }

--- a/src/Randomizer.Data/Services/MetadataService.cs
+++ b/src/Randomizer.Data/Services/MetadataService.cs
@@ -281,7 +281,8 @@ namespace Randomizer.Data.Services
         /// Applies various metadata to the world, such as LocationData and ItemData
         /// </summary>
         /// <param name="world">The world to apply metadata to</param>
-        public void LoadWorldMetadata(World world)
+        /// <param name="createNewStates">If new states should be created for items not already in the world</param>
+        public void LoadWorldMetadata(World world, bool createNewStates)
         {
             world.Locations.ToList().ForEach(loc => loc.Metadata = Location(loc.Id));
             world.Dungeons.ToList().ForEach(d => d.DungeonMetadata = Dungeon(d));
@@ -293,7 +294,7 @@ namespace Randomizer.Data.Services
             {
                 if (worldItems.Any())
                     worldItems.ToList().ForEach(x => x.Metadata = metadata);
-                else
+                else if (createNewStates)
                 {
                     _logger.LogInformation($"No data found {metadata.Item}");
                     var item = new Item(metadata.InternalItemType, world, metadata.Item)
@@ -302,7 +303,8 @@ namespace Randomizer.Data.Services
                         {
                             ItemName = metadata.Item,
                             Type = metadata.InternalItemType,
-                            TrackerState = world.State
+                            TrackerState = world.State,
+                            WorldId = world.Id
                         },
                         Metadata = metadata
                     };
@@ -315,7 +317,7 @@ namespace Randomizer.Data.Services
             {
                 if (worldBoss != null)
                     worldBoss.Metadata = metadata;
-                else
+                else if (createNewStates)
                 {
                     _logger.LogInformation($"No data found {metadata.Boss}");
                     var boss = new Boss(metadata.Type, world, metadata.Boss)
@@ -324,7 +326,8 @@ namespace Randomizer.Data.Services
                         {
                             BossName = metadata.Boss,
                             Type = metadata.Type,
-                            TrackerState = world.State
+                            TrackerState = world.State,
+                            WorldId = world.Id
                         },
                         Metadata = metadata
                     };

--- a/src/Randomizer.Data/Services/TrackerStateService.cs
+++ b/src/Randomizer.Data/Services/TrackerStateService.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using Randomizer.Data.WorldData;
 using Randomizer.Data.WorldData.Regions;
 using Randomizer.Data.WorldData.Regions.Zelda;
+using Randomizer.Shared;
 using Randomizer.Shared.Models;
 
 namespace Randomizer.Data.Services
@@ -22,20 +23,36 @@ namespace Randomizer.Data.Services
             _logger = logger;
         }
 
-        public async Task CreateStateAsync(World world, GeneratedRom generatedRom)
+        public async Task CreateStateAsync(IEnumerable<World> worlds, GeneratedRom generatedRom)
         {
-            var locationStates = world
-                .Locations
+            var locationStates = worlds
+                .SelectMany(x => x.Locations)
                 .Select(x => new TrackerLocationState
                 {
                     LocationId = x.Id,
-                    Item = x.Item?.Type,
-                    Cleared = false
+                    Item = x.Item.Type,
+                    Cleared = false,
+                    WorldId = x.World.Id,
+                    ItemWorldId = x.Item.World.Id
                 })
                 .ToList();
 
-            var dungeonStates = world
-                .Dungeons
+            var addedItems = new List<(World, ItemType)>();
+            var itemStates = new List<TrackerItemState>();
+            foreach (var item in worlds.SelectMany(x => x.AllItems))
+            {
+                if (addedItems.Contains((item.World, item.Type))) continue;
+                itemStates.Add(new TrackerItemState
+                {
+                    ItemName = item.Name,
+                    Type = item.Type,
+                    WorldId = item.World.Id
+                });
+                addedItems.Add((item.World, item.Type));
+            }
+
+            var dungeonStates = worlds
+                .SelectMany(x => x.Dungeons)
                 .Select(x => new TrackerDungeonState
                 {
                     Name = x.GetType().Name,
@@ -43,24 +60,42 @@ namespace Randomizer.Data.Services
                     Reward = x is IHasReward rewardRegion ? rewardRegion.RewardType : null,
                     RequiredMedallion = x is INeedsMedallion medallionRegion ? medallionRegion.Medallion : null,
                     MarkedReward = x is CastleTower ? Shared.RewardType.Agahnim : null,
+                    WorldId = ((Region)x).World.Id
+                })
+                .ToList();
+
+            var bossStates = worlds
+                .SelectMany(x => x.AllBosses)
+                .Select(boss => new TrackerBossState()
+                {
+                    BossName = boss.Name,
+                    Type = boss.Type,
+                    WorldId = boss.World.Id,
                 })
                 .ToList();
 
             var state = new TrackerState()
             {
                 LocationStates = locationStates,
+                ItemStates = itemStates,
                 DungeonStates = dungeonStates,
+                BossStates = bossStates,
+                LocalWorldId = worlds.First(x => x.IsLocalWorld).Id,
                 StartDateTime = DateTimeOffset.Now,
                 UpdatedDateTime = DateTimeOffset.Now
             };
 
+            foreach (var world in worlds)
+            {
+                world.State = state;
+            }
+
             generatedRom.TrackerState = state;
-            world.State = state;
             await _randomizerContext.SaveChangesAsync();
 
         }
 
-        public TrackerState? LoadState(World world, GeneratedRom generatedRom)
+        public TrackerState? LoadState(IEnumerable<World> worlds, GeneratedRom generatedRom)
         {
             var trackerState = generatedRom.TrackerState;
 
@@ -69,22 +104,22 @@ namespace Randomizer.Data.Services
                 return null;
             }
 
-            world.State = trackerState;
+            foreach (var world in worlds)
+            {
+                world.State = trackerState;
+            }
 
-            LoadLocationStates(world, trackerState);
-            LoadItemStates(world, trackerState);
-            LoadDungeonStates(world, trackerState);
-            LoadBossStates(world, trackerState);
+            LoadLocationStates(worlds, trackerState);
+            LoadItemStates(worlds, trackerState);
+            LoadDungeonStates(worlds, trackerState);
+            LoadBossStates(worlds, trackerState);
             LoadHistory(trackerState);
-
-            var locationCount = world.Locations.Count();
-            var emptyStateLocations = world.Locations.Where(x => x.State == null).ToList();
 
             return trackerState;
         }
 
 
-        public async Task SaveStateAsync(World world, GeneratedRom generatedRom, double secondsElapsed)
+        public async Task SaveStateAsync(IEnumerable<World> worlds, GeneratedRom generatedRom, double secondsElapsed)
         {
             var trackerState = generatedRom.TrackerState;
 
@@ -93,11 +128,14 @@ namespace Randomizer.Data.Services
                 return;
             }
 
-            world.State = trackerState;
+            foreach (var world in worlds)
+            {
+                world.State = trackerState;
+            }
 
-            SaveLocationStates(world, trackerState);
-            SaveItemStates(world, trackerState);
-            SaveBossStates(world, trackerState);
+            SaveLocationStates(worlds, trackerState);
+            SaveItemStates(worlds, trackerState);
+            SaveBossStates(worlds, trackerState);
 
             trackerState.UpdatedDateTime = DateTimeOffset.Now;
             trackerState.SecondsElapsed = secondsElapsed;
@@ -106,52 +144,58 @@ namespace Randomizer.Data.Services
             await _randomizerContext.SaveChangesAsync();
         }
 
-        private void LoadLocationStates(World world, TrackerState trackerState)
+        private void LoadLocationStates(IEnumerable<World> worlds, TrackerState trackerState)
         {
             _randomizerContext.Entry(trackerState).Collection(x => x.LocationStates).Load();
 
             foreach (var locationState in trackerState.LocationStates)
             {
-                var location = world.Locations.First(x => x.Id == locationState.LocationId);
+                var location = worlds
+                    .First(x => x.Id == locationState.WorldId)
+                    .Locations
+                    .First(x => x.Id == locationState.LocationId);
                 location.State = locationState;
-                location.Item = locationState.Item != null ? new Item(locationState.Item.Value, world) : null;
+                location.Item = new Item(locationState.Item, worlds.First(x => x.Id == locationState.ItemWorldId));
             }
         }
 
-        private void SaveLocationStates(World world, TrackerState trackerState)
+        private void SaveLocationStates(IEnumerable<World> worlds, TrackerState trackerState)
         {
-            var totalLocations = world.Locations.Count();
-            var clearedLocations = world.Locations.Where(x => x.State.Cleared).Count();
+            var totalLocations = worlds.SelectMany(x => x.Locations).Count();
+            var clearedLocations = worlds.SelectMany(x => x.Locations).Where(x => x.State.Cleared).Count();
             var percCleared = (int)Math.Floor((double)clearedLocations / totalLocations * 100);
             trackerState.PercentageCleared = percCleared;
         }
 
-        private void LoadItemStates(World world, TrackerState trackerState)
+        private void LoadItemStates(IEnumerable<World> worlds, TrackerState trackerState)
         {
             _randomizerContext.Entry(trackerState).Collection(x => x.ItemStates).Load();
 
             // Load previously saved items
-            foreach (var (state, worldItems) in trackerState.ItemStates.Select(x => (state: x, items: world.AllItems.Where(w => w.Is(x.Type ?? Shared.ItemType.Nothing, x.ItemName)))))
+            foreach (var world in worlds)
             {
-                if (worldItems.Any())
+                foreach (var (state, worldItems) in trackerState.ItemStates.Select(x => (state: x, items: world.AllItems.Where(w => w.Is(x.Type ?? Shared.ItemType.Nothing, x.ItemName)))))
                 {
-                    worldItems.ToList().ForEach(x => x.State = state);
-                }
-                else
-                {
-                    _logger.LogInformation($"{state.ItemName} not found in world");
-                    var item = new Item(state.Type ?? Shared.ItemType.Nothing, world, state.ItemName)
+                    if (worldItems.Any())
                     {
-                        State = state
-                    };
-                    world.TrackerItems.Add(item);
+                        worldItems.ToList().ForEach(x => x.State = state);
+                    }
+                    else
+                    {
+                        _logger.LogInformation($"{state.ItemName} not found in world");
+                        var item = new Item(state.Type ?? Shared.ItemType.Nothing, world, state.ItemName)
+                        {
+                            State = state
+                        };
+                        world.TrackerItems.Add(item);
+                    }
                 }
             }
 
             // Create item states for items 
-            foreach (var item in world.AllItems.Where(x => x.State == null))
+            foreach (var item in worlds.SelectMany(x => x.AllItems).Where(x => x.State == null))
             {
-                var otherItem = world.AllItems
+                var otherItem = item.World.AllItems
                     .FirstOrDefault(x => x != item && x.State != null && x.Name == item.Name);
 
                 if (otherItem != null)
@@ -165,6 +209,7 @@ namespace Randomizer.Data.Services
                         TrackerState = trackerState,
                         ItemName = item.Name,
                         Type = item.Type,
+                        WorldId = item.World.Id
                     };
                     item.State = state;
                     trackerState.ItemStates.Add(state);
@@ -172,22 +217,24 @@ namespace Randomizer.Data.Services
             }
         }
 
-        private void SaveItemStates(World world, TrackerState trackerState)
+        private void SaveItemStates(IEnumerable<World> worlds, TrackerState trackerState)
         {
             // Add any new item states
-            var itemStates = world.AllItems
+            var itemStates = worlds
+                .SelectMany(x => x.AllItems)
                 .Select(x => x.State).Distinct()
                 .Where(x => !trackerState.ItemStates.Contains(x))
                 .ToList();
             itemStates.ForEach(x => trackerState.ItemStates.Add(x));
         }
 
-        private void LoadDungeonStates(World world, TrackerState trackerState)
+        private void LoadDungeonStates(IEnumerable<World> worlds, TrackerState trackerState)
         {
             _randomizerContext.Entry(trackerState).Collection(x => x.DungeonStates).Load();
 
             foreach (var dungeonState in trackerState.DungeonStates)
             {
+                var world = worlds.First(x => x.Id == dungeonState.WorldId);
                 var dungeon = world.Dungeons.First(x => x.GetType().Name == dungeonState.Name);
                 dungeon.DungeonState = dungeonState;
 
@@ -201,46 +248,51 @@ namespace Randomizer.Data.Services
             }
         }
 
-        private void LoadBossStates(World world, TrackerState trackerState)
+        private void LoadBossStates(IEnumerable<World> worlds, TrackerState trackerState)
         {
             _randomizerContext.Entry(trackerState).Collection(x => x.BossStates).Load();
 
             // Load previously saved bosses
-            foreach (var (state, worldBoss) in trackerState.BossStates.Select(x => (state: x, worldBoss: world.AllBosses.FirstOrDefault(w => w.Is(x.Type, x.BossName)))))
+            foreach (var world in worlds)
             {
-                if (worldBoss != null)
+                foreach (var (state, worldBoss) in trackerState.BossStates.Select(x => (state: x, worldBoss: world.AllBosses.FirstOrDefault(w => w.Is(x.Type, x.BossName)))))
                 {
-                    worldBoss.State = state;
-                }
-                else
-                {
-                    _logger.LogInformation($"{state.BossName} not found in world");
-                    var boss = new Boss(state.Type, world, state.BossName)
+                    if (worldBoss != null)
                     {
-                        State = state
-                    };
-                    world.TrackerBosses.Add(boss);
+                        worldBoss.State = state;
+                    }
+                    else
+                    {
+                        _logger.LogInformation($"{state.BossName} not found in world");
+                        var boss = new Boss(state.Type, world, state.BossName)
+                        {
+                            State = state
+                        };
+                        world.TrackerBosses.Add(boss);
+                    }
                 }
             }
 
             // Create boss states for bosses not already set
-            foreach (var boss in world.AllBosses.Where(x => x.State == null))
+            foreach (var boss in worlds.SelectMany(x => x.AllBosses).Where(x => x.State == null))
             {
                 var state = new TrackerBossState()
                 {
                     TrackerState = trackerState,
                     BossName = boss.Name,
                     Type = boss.Type,
+                    WorldId = boss.World.Id,
                 };
                 boss.State = state;
                 trackerState.BossStates.Add(state);
             }
         }
 
-        private void SaveBossStates(World world, TrackerState trackerState)
+        private void SaveBossStates(IEnumerable<World> worlds, TrackerState trackerState)
         {
             // Add any new item states
-            var bossStates = world.AllBosses
+            var bossStates = worlds
+                .SelectMany(x => x.AllBosses)
                 .Select(x => x.State).Distinct()
                 .Where(x => !trackerState.BossStates.Contains(x))
                 .ToList();

--- a/src/Randomizer.Data/WorldData/World.cs
+++ b/src/Randomizer.Data/WorldData/World.cs
@@ -24,12 +24,13 @@ namespace Randomizer.Data.WorldData
 {
     public class World
     {
-        public World(Config config, string player, int id, string guid)
+        public World(Config config, string player, int id, string guid, bool isLocalWorld = true)
         {
             Config = config;
             Player = player;
             Id = id;
             Guid = guid;
+            IsLocalWorld = isLocalWorld;
 
             Logic = new Logic.Logic(this);
 
@@ -96,6 +97,7 @@ namespace Randomizer.Data.WorldData
         public string Player { get; }
         public string Guid { get; }
         public int Id { get; }
+        public bool IsLocalWorld { get; set; }
         public IEnumerable<Region> Regions { get; }
         public IEnumerable<Room> Rooms { get; }
         public IEnumerable<Location> Locations { get; }

--- a/src/Randomizer.SMZ3.Tracking/Tracker.cs
+++ b/src/Randomizer.SMZ3.Tracking/Tracker.cs
@@ -411,8 +411,12 @@ namespace Randomizer.SMZ3.Tracking
         {
             IsDirty = false;
             Rom = rom;
-            var trackerState = _stateService.LoadState(_worldAccessor.World, rom);
-            Metadata.LoadWorldMetadata(_worldAccessor.World);
+            var trackerState = _stateService.LoadState(_worldAccessor.Worlds, rom);
+            foreach (var world in _worldAccessor.Worlds)
+            {
+                Metadata.LoadWorldMetadata(world, world.IsLocalWorld);
+            }
+            
             if (trackerState != null)
             {
                 _timerService.SetSavedTime(TimeSpan.FromSeconds(trackerState.SecondsElapsed));
@@ -430,7 +434,7 @@ namespace Randomizer.SMZ3.Tracking
         public async Task SaveAsync(GeneratedRom rom)
         {
             IsDirty = false;
-            await _stateService.SaveStateAsync(_worldAccessor.World, rom, _timerService.SecondsElapsed);
+            await _stateService.SaveStateAsync(_worldAccessor.Worlds, rom, _timerService.SecondsElapsed);
         }
 
         /// <summary>

--- a/src/Randomizer.SMZ3/Contracts/IGameHintService.cs
+++ b/src/Randomizer.SMZ3/Contracts/IGameHintService.cs
@@ -18,9 +18,8 @@ namespace Randomizer.SMZ3.Contracts
         /// <param name="hintPlayerWorld">The player that will be receiving the hints</param>
         /// <param name="allWorlds">All worlds that are a part of the seed</param>
         /// <param name="playthrough">The initial playthrough with all of the spheres</param>
-        /// <param name="hintCount">The number of hints to generate</param>
         /// <param name="seed">Seed number for shuffling and randomization</param>
         /// <returns>A collection of strings to use for the in game hints</returns>
-        IEnumerable<string> GetInGameHints(World world, ICollection<World> allWorlds, Playthrough playthrough, int hintCount, int seed);
+        IEnumerable<string> GetInGameHints(World hintPlayerWorld, ICollection<World> allWorlds, Playthrough playthrough, int seed);
     }
 }

--- a/src/Randomizer.SMZ3/Contracts/ISeededRandomizer.cs
+++ b/src/Randomizer.SMZ3/Contracts/ISeededRandomizer.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System.Collections.Generic;
+using System.Threading;
 using Randomizer.Data.Options;
 using Randomizer.SMZ3.Generation;
 
@@ -8,6 +9,8 @@ namespace Randomizer.SMZ3.Contracts
     {
         SeedData GenerateSeed(Config config, string seed, CancellationToken cancellationToken = default);
 
-        bool ValidateSeedSettings(SeedData seedData, Config config);
+        SeedData GenerateSeed(List<Config> configs, string seed = "", CancellationToken cancellationToken = default);
+
+        bool ValidateSeedSettings(SeedData seedData);
     }
 }

--- a/src/Randomizer.SMZ3/FileData/Patcher.cs
+++ b/src/Randomizer.SMZ3/FileData/Patcher.cs
@@ -17,6 +17,7 @@ using static Randomizer.SMZ3.FileData.DropPrize;
 using Randomizer.Data.Options;
 using Randomizer.Data.Configuration.ConfigFiles;
 using Randomizer.Data.Services;
+using Randomizer.SMZ3.Generation;
 
 namespace Randomizer.SMZ3.FileData
 {
@@ -737,7 +738,16 @@ namespace Randomizer.SMZ3.FileData
             _patches.Add((Snes(0x308400), Dialog.Simple(triforceRoom)));
             _stringTable.SetTriforceRoomText(triforceRoom);
 
-            _stringTable.SetHints(hints.Select(x => Dialog.GetGameSafeString(x)));
+            if (hints.Any())
+            {
+                hints = hints.Take(config.UniqueHintCount);
+                while (hints.Count() < GameHintService.HintLocations.Count)
+                {
+                    hints = hints.Concat(hints.Take(Math.Min(GameHintService.HintLocations.Count() - hints.Count(), hints.Count())));
+                }
+                _stringTable.SetHints(hints.Shuffle(_rnd).Select(x => Dialog.GetGameSafeString(x)));
+            }
+            
         }
 
         private void WriteStringTable()

--- a/src/Randomizer.SMZ3/Generation/GameHintService.cs
+++ b/src/Randomizer.SMZ3/Generation/GameHintService.cs
@@ -146,7 +146,7 @@ namespace Randomizer.SMZ3.Generation
             {
                 var dungeonRegion = dungeon as Region;
                 var usefulNess = CheckIfLocationsAreImportant(allWorlds, importantLocations, dungeonRegion.Locations);
-                var dungeonName = _metadataService.Dungeon(dungeon).Name.ToString();
+                var dungeonName = GetDungeonName(hintPlayerWorld, dungeon, dungeonRegion);
 
                 if (usefulNess == LocationUsefulness.Mandatory)
                 {
@@ -301,6 +301,12 @@ namespace Randomizer.SMZ3.Generation
             }
         }
 
+        private string GetDungeonName(World hintPlayerWorld, IDungeon dungeon, Region region)
+        {
+            var dungeonName = _metadataService.Dungeon(dungeon).Name.ToString();
+            return $"{dungeonName}{GetMultiworldSuffix(hintPlayerWorld, region.World)}";
+        }
+
         private string GetLocationName(World hintPlayerWorld, Location location)
         {
             var name = $"{_metadataService.Region(location.Region).Name} - {_metadataService.Location(location.Id).Name}";
@@ -323,7 +329,7 @@ namespace Randomizer.SMZ3.Generation
             {
                 return hintPlayerWorld == item.World
                     ? " belonging to you"
-                    : " belonging to another player"; // Will need to update to player name when multiworld is working
+                    : $" belonging to {item.World.Player}";
             }
         }
 
@@ -337,7 +343,7 @@ namespace Randomizer.SMZ3.Generation
             {
                 return hintPlayerWorld == locationWorld
                     ? " in your world"
-                    : " in another player's world"; // Will need to update to player name when multiworld is working
+                    : $" in {locationWorld.Player}'s world";
             }
         }
 

--- a/src/Randomizer.SMZ3/Generation/SeedData.cs
+++ b/src/Randomizer.SMZ3/Generation/SeedData.cs
@@ -10,6 +10,7 @@ namespace Randomizer.SMZ3.Generation
         public string Game { get; set; }
         public string Mode { get; set; }
         public List<(World World, Dictionary<int, byte[]> Patches)> Worlds { get; set; }
+        public List<(World World, List<string>)> Hints { get; set; }
 
         public Playthrough Playthrough { get; set; }
     }

--- a/src/Randomizer.SMZ3/Generation/Smz3Plandomizer.cs
+++ b/src/Randomizer.SMZ3/Generation/Smz3Plandomizer.cs
@@ -74,7 +74,7 @@ namespace Randomizer.SMZ3.Generation
                 Worlds = new List<(World World, Dictionary<int, byte[]> Patches)>()
             };
 
-            var hints = _hintService.GetInGameHints(worlds[0], worlds, playthrough, config.UniqueHintCount, 0);
+            var hints = _hintService.GetInGameHints(worlds[0], worlds, playthrough, 0);
 
             foreach (var world in worlds)
             {

--- a/src/Randomizer.SMZ3/Generation/Smz3Plandomizer.cs
+++ b/src/Randomizer.SMZ3/Generation/Smz3Plandomizer.cs
@@ -39,7 +39,7 @@ namespace Randomizer.SMZ3.Generation
         {
             var worlds = new List<World>
             {
-                new World(config, "Player", 0, Guid.NewGuid().ToString("N"))
+                new World(config, "Player", 0, Guid.NewGuid().ToString("N"), true)
             };
 
             var filler = _fillerFactory.Create(config.PlandoConfig);

--- a/src/Randomizer.SMZ3/Generation/Smz3Randomizer.cs
+++ b/src/Randomizer.SMZ3/Generation/Smz3Randomizer.cs
@@ -102,10 +102,19 @@ namespace Randomizer.SMZ3.Generation
                     newConfig.Id = i + 1;
                     newConfig.PlayerName = "test" + newConfig.Id;
                     newConfig.PlayerGuid = Guid.NewGuid().ToString("N");
+
+                    if (i == 0)
+                    {
+                        newConfig.KeysanityMode = KeysanityMode.Both;
+                    }
+
+                    newConfig.LogicConfig.PreventFivePowerBombSeed = false;
+                    newConfig.LogicConfig.PreventScrewAttackSoftLock = false;
+                    newConfig.EarlyItems.Add(ItemType.ScrewAttack);
+
                     configs.Add(newConfig);
                 }
-            }
-            */
+            }*/
 
             var worlds = new List<World>();
             if (primaryConfig.SingleWorld)

--- a/src/Randomizer.SMZ3/Generation/Smz3Randomizer.cs
+++ b/src/Randomizer.SMZ3/Generation/Smz3Randomizer.cs
@@ -86,17 +86,26 @@ namespace Randomizer.SMZ3.Generation
 
             _logger.LogDebug($"Seed: {seedNumber} | Race: {primaryConfig.Race} | Keysanity: {primaryConfig.KeysanityMode} | Item placement: {primaryConfig.ItemPlacementRule} | World count : {configs.Count()}");
 
-            //primaryConfig.GameMode = GameMode.Multiworld;
+            /*primaryConfig.GameMode = GameMode.Multiworld;
+
+            // Testing code. TODO: Remove
+            if (primaryConfig.MultiWorld)
+            {
+                for (var i = 0; i < 4; i++)
+                {
+                    configs.Add(primaryConfig);
+                }
+            }*/
+
             var worlds = new List<World>();
             if (primaryConfig.SingleWorld)
                 worlds.Add(new World(primaryConfig, "Player", 0, Guid.NewGuid().ToString("N")));
             else
             {
-                var playerId = 0;
-                foreach (var config in configs)
+                for (var playerId = 0; playerId < configs.Count; playerId++)
                 {
                     var player = "test" + playerId;
-                    worlds.Add(new World(config, player, playerId, Guid.NewGuid().ToString("N")));
+                    worlds.Add(new World(configs[playerId], player, playerId, Guid.NewGuid().ToString("N")));
                 }
                 //var players = options.ContainsKey("players") ? int.Parse(options["players"]) : 1;
                 //for (var p = 0; p < players; p++)
@@ -122,7 +131,8 @@ namespace Randomizer.SMZ3.Generation
                 Game = Name,
                 Mode = primaryConfig.GameMode.ToLowerString(),
                 Playthrough = primaryConfig.Race ? new Playthrough(primaryConfig, Enumerable.Empty<Playthrough.Sphere>()) : playthrough,
-                Worlds = new List<(World World, Dictionary<int, byte[]> Patches)>()
+                Worlds = new List<(World World, Dictionary<int, byte[]> Patches)>(),
+                Hints = new()
             };
 
             if (primaryConfig.GenerateSeedOnly)
@@ -136,7 +146,8 @@ namespace Randomizer.SMZ3.Generation
             foreach (var world in worlds)
             {
                 var patchRnd = new Random(patchSeed);
-                var hints = _hintService.GetInGameHints(world, worlds, playthrough, primaryConfig.UniqueHintCount, rng.Next());
+                var hints = _hintService.GetInGameHints(world, worlds, playthrough, rng.Next());
+                seedData.Hints.Add((world, hints.ToList()));
                 var patch = new Patcher(world, worlds, seedData.Guid, primaryConfig.Race ? 0 : seedNumber, patchRnd, _metadataService, _gameLines);
                 seedData.Worlds.Add((world, patch.CreatePatch(world.Config, hints)));
             }

--- a/src/Randomizer.SMZ3/Generation/Smz3Randomizer.cs
+++ b/src/Randomizer.SMZ3/Generation/Smz3Randomizer.cs
@@ -68,25 +68,36 @@ namespace Randomizer.SMZ3.Generation
         }
 
         public SeedData GenerateSeed(Config config, CancellationToken cancellationToken = default)
-            => GenerateSeed(config, "", cancellationToken);
+            => GenerateSeed(new List<Config> { config }, "", cancellationToken);
 
         public SeedData GenerateSeed(Config config, string seed, CancellationToken cancellationToken = default)
+            => GenerateSeed(new List<Config>() { config }, seed, cancellationToken);
+
+        public SeedData GenerateSeed(List<Config> configs, string seed, CancellationToken cancellationToken = default)
         {
+            var primaryConfig = configs.First();
+
             var seedNumber = ParseSeed(ref seed);
             var rng = new Random(seedNumber);
-            config.Seed = seedNumber.ToString();
-            if (config.Race)
+            primaryConfig.Seed = seedNumber.ToString();
+            if (primaryConfig.Race)
                 rng = new Random(rng.Next());
-            config.SettingsString = Config.ToConfigString(config, true);
+            primaryConfig.SettingsString = Config.ToConfigString(primaryConfig, true);
 
-            _logger.LogDebug($"Seed: {seedNumber} | Race: {config.Race} | Keysanity: {config.KeysanityMode} | Item placement: {config.ItemPlacementRule}");
+            _logger.LogDebug($"Seed: {seedNumber} | Race: {primaryConfig.Race} | Keysanity: {primaryConfig.KeysanityMode} | Item placement: {primaryConfig.ItemPlacementRule} | World count : {configs.Count()}");
 
+            //primaryConfig.GameMode = GameMode.Multiworld;
             var worlds = new List<World>();
-            if (config.SingleWorld)
-                worlds.Add(new World(config, "Player", 0, Guid.NewGuid().ToString("N")));
+            if (primaryConfig.SingleWorld)
+                worlds.Add(new World(primaryConfig, "Player", 0, Guid.NewGuid().ToString("N")));
             else
             {
-                throw new NotSupportedException("Multiworld seeds are currently not supported.");
+                var playerId = 0;
+                foreach (var config in configs)
+                {
+                    var player = "test" + playerId;
+                    worlds.Add(new World(config, player, playerId, Guid.NewGuid().ToString("N")));
+                }
                 //var players = options.ContainsKey("players") ? int.Parse(options["players"]) : 1;
                 //for (var p = 0; p < players; p++)
                 //{
@@ -101,34 +112,33 @@ namespace Randomizer.SMZ3.Generation
             }
 
             Filler.SetRandom(rng);
-            Filler.Fill(worlds, config, cancellationToken);
+            Filler.Fill(worlds, primaryConfig, cancellationToken);
 
-            var playthrough = Playthrough.Generate(worlds, config);
+            var playthrough = Playthrough.Generate(worlds, primaryConfig);
             var seedData = new SeedData
             {
                 Guid = Guid.NewGuid().ToString("N"),
                 Seed = seed,
                 Game = Name,
-                Mode = config.GameMode.ToLowerString(),
-                Playthrough = config.Race ? new Playthrough(config, Enumerable.Empty<Playthrough.Sphere>()) : playthrough,
+                Mode = primaryConfig.GameMode.ToLowerString(),
+                Playthrough = primaryConfig.Race ? new Playthrough(primaryConfig, Enumerable.Empty<Playthrough.Sphere>()) : playthrough,
                 Worlds = new List<(World World, Dictionary<int, byte[]> Patches)>()
             };
 
-            if (config.GenerateSeedOnly)
+            if (primaryConfig.GenerateSeedOnly)
             {
                 seedData.Worlds = worlds.Select(x => (x, (Dictionary<int, byte[]>)null)).ToList();
                 return seedData;
             }
-
-            var hints = _hintService.GetInGameHints(worlds[0], worlds, playthrough, config.UniqueHintCount, rng.Next());
 
             /* Make sure RNG is the same when applying patches to the ROM to have consistent RNG for seed identifer etc */
             var patchSeed = rng.Next();
             foreach (var world in worlds)
             {
                 var patchRnd = new Random(patchSeed);
-                var patch = new Patcher(world, worlds, seedData.Guid, config.Race ? 0 : seedNumber, patchRnd, _metadataService, _gameLines);
-                seedData.Worlds.Add((world, patch.CreatePatch(config, hints)));
+                var hints = _hintService.GetInGameHints(world, worlds, playthrough, primaryConfig.UniqueHintCount, rng.Next());
+                var patch = new Patcher(world, worlds, seedData.Guid, primaryConfig.Race ? 0 : seedNumber, patchRnd, _metadataService, _gameLines);
+                seedData.Worlds.Add((world, patch.CreatePatch(world.Config, hints)));
             }
 
             Debug.WriteLine("Generated seed on randomizer instance " + GetHashCode());
@@ -142,13 +152,13 @@ namespace Randomizer.SMZ3.Generation
         /// Ensures that a generated seed matches the requested preferences
         /// </summary>
         /// <param name="seedData">The seed data that contains the generated spheres to guarantee early items</param>
-        /// <param name="config">The confirm with the seed generation settings</param>
         /// <returns>True if the seed matches all config settings, false otherwise</returns>
-        public bool ValidateSeedSettings(SeedData seedData, Config config)
+        public bool ValidateSeedSettings(SeedData seedData)
         {
             // Go through and make sure specified locations are populated correctly
             foreach (var world in seedData.Worlds.Select(x => x.World))
             {
+                var config = world.Config;
                 var configLocations = config.LocationItems;
 
                 foreach ((var locationId, var value) in configLocations)
@@ -173,16 +183,16 @@ namespace Randomizer.SMZ3.Generation
                         }
                     }
                 }
-            }
 
-            // Through and make sure the early items are populated in early spheres
-            foreach (var itemType in config.EarlyItems)
-            {
-                var sphereIndex = seedData.Playthrough.Spheres.IndexOf(x => x.Items.Any(y => y.Progression && y.Type == itemType));
-                if (sphereIndex > 2)
+                // Through and make sure the early items are populated in early spheres
+                foreach (var itemType in config.EarlyItems)
                 {
-                    _logger.LogInformation($"Item {itemType} did not show up early as expected. Sphere: {sphereIndex}");
-                    return false;
+                    var sphereIndex = seedData.Playthrough.Spheres.IndexOf(x => x.Items.Any(y => y.Progression && y.Type == itemType));
+                    if (sphereIndex > 2)
+                    {
+                        _logger.LogInformation($"Item {itemType} did not show up early as expected. Sphere: {sphereIndex}");
+                        return false;
+                    }
                 }
             }
 

--- a/src/Randomizer.SMZ3/Generation/Smz3Randomizer.cs
+++ b/src/Randomizer.SMZ3/Generation/Smz3Randomizer.cs
@@ -86,38 +86,36 @@ namespace Randomizer.SMZ3.Generation
 
             _logger.LogDebug($"Seed: {seedNumber} | Race: {primaryConfig.Race} | Keysanity: {primaryConfig.KeysanityMode} | Item placement: {primaryConfig.ItemPlacementRule} | World count : {configs.Count()}");
 
-            /*primaryConfig.GameMode = GameMode.Multiworld;
-
-            // Testing code. TODO: Remove
+            // Testing code. Tests should fail if this code is present.
+            // This code will be remove once multiworld is properly implemented.
+            /*
+            primaryConfig.GameMode = GameMode.Multiworld;
             if (primaryConfig.MultiWorld)
             {
+                primaryConfig.Id = 0;
+                primaryConfig.PlayerName = "test0";
+                primaryConfig.PlayerGuid = Guid.NewGuid().ToString("N");
+                var configString = Config.ToConfigString(primaryConfig, false);
                 for (var i = 0; i < 4; i++)
                 {
-                    configs.Add(primaryConfig);
+                    var newConfig = Config.FromConfigString(configString);
+                    newConfig.Id = i + 1;
+                    newConfig.PlayerName = "test" + newConfig.Id;
+                    newConfig.PlayerGuid = Guid.NewGuid().ToString("N");
+                    configs.Add(newConfig);
                 }
-            }*/
+            }
+            */
 
             var worlds = new List<World>();
             if (primaryConfig.SingleWorld)
-                worlds.Add(new World(primaryConfig, "Player", 0, Guid.NewGuid().ToString("N")));
+                worlds.Add(new World(primaryConfig, "Player", 0, Guid.NewGuid().ToString("N"), true));
             else
             {
-                for (var playerId = 0; playerId < configs.Count; playerId++)
+                foreach (var config in configs)
                 {
-                    var player = "test" + playerId;
-                    worlds.Add(new World(configs[playerId], player, playerId, Guid.NewGuid().ToString("N")));
+                    worlds.Add(new World(config, config.PlayerName, config.Id, config.PlayerGuid, config.Id == 0));
                 }
-                //var players = options.ContainsKey("players") ? int.Parse(options["players"]) : 1;
-                //for (var p = 0; p < players; p++)
-                //{
-                //    var found = options.TryGetValue($"player-{p}", out var player);
-                //    if (!found)
-                //        throw new ArgumentException($"No name provided for player {p + 1}");
-                //    if (!legalCharacters.IsMatch(player))
-                //        throw new ArgumentException($"No alphanumeric characters found in name for player {p + 1}");
-                //    player = CleanPlayerName(player);
-                //    worlds.Add(new World(config, player, p, Guid.NewGuid().ToString("N")));
-                //}
             }
 
             Filler.SetRandom(rng);
@@ -153,7 +151,7 @@ namespace Randomizer.SMZ3.Generation
             }
 
             Debug.WriteLine("Generated seed on randomizer instance " + GetHashCode());
-            _worldAccessor.World = worlds[0];
+            _worldAccessor.World = worlds.First(x => x.IsLocalWorld);
             _worldAccessor.Worlds = worlds;
             LastGeneratedSeed = seedData;
             return seedData;

--- a/src/Randomizer.Shared/Migrations/20221016050403_Multiworld.Designer.cs
+++ b/src/Randomizer.Shared/Migrations/20221016050403_Multiworld.Designer.cs
@@ -2,15 +2,17 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Randomizer.Shared.Models;
 
 namespace Randomizer.Shared.Migrations
 {
     [DbContext(typeof(RandomizerContext))]
-    partial class RandomizerContextModelSnapshot : ModelSnapshot
+    [Migration("20221016050403_Multiworld")]
+    partial class Multiworld
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Randomizer.Shared/Migrations/20221016050403_Multiworld.cs
+++ b/src/Randomizer.Shared/Migrations/20221016050403_Multiworld.cs
@@ -1,0 +1,108 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Randomizer.Shared.Migrations
+{
+    public partial class Multiworld : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "LocalWorldId",
+                table: "TrackerStates",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AlterColumn<byte>(
+                name: "Item",
+                table: "TrackerLocationStates",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: (byte)0,
+                oldClrType: typeof(byte),
+                oldType: "INTEGER",
+                oldNullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "Ignored",
+                table: "TrackerLocationStates",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<int>(
+                name: "ItemWorldId",
+                table: "TrackerLocationStates",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "WorldId",
+                table: "TrackerLocationStates",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "WorldId",
+                table: "TrackerItemStates",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "WorldId",
+                table: "TrackerDungeonStates",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "WorldId",
+                table: "TrackerBossStates",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LocalWorldId",
+                table: "TrackerStates");
+
+            migrationBuilder.DropColumn(
+                name: "Ignored",
+                table: "TrackerLocationStates");
+
+            migrationBuilder.DropColumn(
+                name: "ItemWorldId",
+                table: "TrackerLocationStates");
+
+            migrationBuilder.DropColumn(
+                name: "WorldId",
+                table: "TrackerLocationStates");
+
+            migrationBuilder.DropColumn(
+                name: "WorldId",
+                table: "TrackerItemStates");
+
+            migrationBuilder.DropColumn(
+                name: "WorldId",
+                table: "TrackerDungeonStates");
+
+            migrationBuilder.DropColumn(
+                name: "WorldId",
+                table: "TrackerBossStates");
+
+            migrationBuilder.AlterColumn<byte>(
+                name: "Item",
+                table: "TrackerLocationStates",
+                type: "INTEGER",
+                nullable: true,
+                oldClrType: typeof(byte),
+                oldType: "INTEGER");
+        }
+    }
+}

--- a/src/Randomizer.Shared/Models/TrackerBossState.cs
+++ b/src/Randomizer.Shared/Models/TrackerBossState.cs
@@ -13,6 +13,7 @@ namespace Randomizer.Shared.Models
         public string BossName { get; set; }
         public bool Defeated { get; set; }
         public BossType Type { get; set; }
+        public int WorldId { get; set; }
     }
 
 }

--- a/src/Randomizer.Shared/Models/TrackerDungeonState.cs
+++ b/src/Randomizer.Shared/Models/TrackerDungeonState.cs
@@ -16,6 +16,7 @@ namespace Randomizer.Shared.Models {
         public RewardType? MarkedReward { get; set; }
         public ItemType? MarkedMedallion { get; set; }
         public bool HasManuallyClearedTreasure { get; set; }
+        public int WorldId { get; set; }
         public bool HasReward => Reward != null && Reward != RewardType.None;
         public bool HasMarkedReward => MarkedReward != null && MarkedReward != RewardType.None;
         public bool RequiresMedallion => RequiredMedallion != null && RequiredMedallion.Value.IsInCategory(ItemCategory.Medallion);

--- a/src/Randomizer.Shared/Models/TrackerItemState.cs
+++ b/src/Randomizer.Shared/Models/TrackerItemState.cs
@@ -12,6 +12,7 @@ namespace Randomizer.Shared.Models
         public ItemType? Type { get; set; }
         public string ItemName { get; set; }
         public int TrackingState { get; set; }
+        public int WorldId { get; set; }
     }
 
 }

--- a/src/Randomizer.Shared/Models/TrackerLocationState.cs
+++ b/src/Randomizer.Shared/Models/TrackerLocationState.cs
@@ -10,9 +10,12 @@ namespace Randomizer.Shared.Models
         public long Id { get; set; }
         public TrackerState TrackerState { get; set; }
         public int LocationId { get; set; }
-        public ItemType? Item { get; set; }
+        public ItemType Item { get; set; }
         public ItemType? MarkedItem { get; set; }
         public bool Cleared { get; set; }
+        public bool Ignored { get; set; }
+        public int WorldId { get; set; }
+        public int ItemWorldId { get; set; }
         public bool HasMarkedItem => MarkedItem != null && MarkedItem != ItemType.Nothing;
     }
 

--- a/src/Randomizer.Shared/Models/TrackerState.cs
+++ b/src/Randomizer.Shared/Models/TrackerState.cs
@@ -16,6 +16,7 @@ namespace Randomizer.Shared.Models
         public DateTimeOffset UpdatedDateTime { get; set; }
         public double SecondsElapsed { get; set; }
         public int PercentageCleared { get; set; }
+        public int LocalWorldId { get; set; }
         public ICollection<TrackerItemState> ItemStates { get; set; }
         public ICollection<TrackerLocationState> LocationStates { get; set; }
         public ICollection<TrackerRegionState> RegionStates { get; set; }


### PR DESCRIPTION
Closes #230 

Here's a summary of the main changes in the PR

- The spoiler log was updated to print off info for all worlds. I also updated it to include hints.
- The standard filler now looks at the individual world configs for settings like item placement.
- The SMZ3Randomizer now supports taking in multiple configs and generating the worlds based on those configs.
- Updates to in game hint generation to work with multiple worlds.
- Updated the database to house multiple worlds, and all data is saved to the db 

My general thought is going forward tracker will load all of the world from the db. Currently when you start the tracker, it actually generates a world and then overrides everything. I'll probably create a "TrackerFiller" or something to use instead of the Standard or Plando fillers to load from the db. For the multiworld, each player will be given the world details upon generation that will be saved to the db and loaded from.