### PR TITLE
Undo Updates and Cas' Ice Palace Logic

### DIFF
--- a/setup/randomizer.app.iss
+++ b/setup/randomizer.app.iss
@@ -4,7 +4,7 @@
 #include "CodeDependencies.iss"
 
 #define MyAppName "SMZ3 Cas' Randomizer"
-#define MyAppVersion "7.0.1"
+#define MyAppVersion "7.0.2"
 #define MyAppPublisher "Vivelin"
 #define MyAppURL "https://github.com/Vivelin/SMZ3Randomizer"
 #define MyAppExeName "Randomizer.App.exe"

--- a/src/Randomizer.App/Randomizer.App.csproj
+++ b/src/Randomizer.App/Randomizer.App.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net5.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>chozo20.ico</ApplicationIcon>
-    <Version>7.0.1</Version>
+    <Version>7.0.2</Version>
     <Title>SMZ3 Cas' Randomizer</Title>
     <AssemblyTitle>SMZ3 Cas' Randomizer</AssemblyTitle>
     <Authors>Vivelin</Authors>

--- a/src/Randomizer.App/Windows/OptionsWindow.xaml
+++ b/src/Randomizer.App/Windows/OptionsWindow.xaml
@@ -186,29 +186,7 @@
 
               <controls:LabeledControl Text="Undo expiration time:"
                                        ToolTip="Specifies how many minutes you have to undo a tracker action to limit accidentally undoing actions.">
-                <Grid>
-                  <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="*" />
-                  </Grid.ColumnDefinitions>
-
-                  <TextBlock Grid.Column="0"
-                             Text="{Binding UndoExpirationTime, Mode=TwoWay, UpdateSourceTrigger=LostFocus}"
-                             Name="TextBlockUndoExpirationTime"
-                             Margin="0,3,7,3" />
-                  <Slider Grid.Column="1"
-                          Value="{Binding UndoExpirationTime, Mode=TwoWay}"
-                          Minimum="1"
-                          Maximum="30"
-                          SmallChange="1"
-                          LargeChange="5"
-                          TickFrequency="5"
-                          TickPlacement="BottomRight"
-                          Orientation="Horizontal"
-                          Name="SliderUndoExpirationTime"
-                          ValueChanged="UndoExpirationTimeChanged"
-                          HorizontalAlignment="Stretch" />
-                </Grid>
+                <TextBox Name="UndoExpirationTimeTextBox" Text="{Binding UndoExpirationTime, Mode=TwoWay}" LostFocus="UndoExpirationTimeTextBox_OnLostFocus" />
               </controls:LabeledControl>
 
               <controls:LabeledControl Text="Auto Tracker Scripts folder:">

--- a/src/Randomizer.App/Windows/OptionsWindow.xaml
+++ b/src/Randomizer.App/Windows/OptionsWindow.xaml
@@ -184,6 +184,33 @@
                 </Grid>
               </controls:LabeledControl>
 
+              <controls:LabeledControl Text="Undo expiration time:"
+                                       ToolTip="Specifies how many minutes you have to undo a tracker action to limit accidentally undoing actions.">
+                <Grid>
+                  <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                  </Grid.ColumnDefinitions>
+
+                  <TextBlock Grid.Column="0"
+                             Text="{Binding UndoExpirationTime, Mode=TwoWay, UpdateSourceTrigger=LostFocus}"
+                             Name="TextBlockUndoExpirationTime"
+                             Margin="0,3,7,3" />
+                  <Slider Grid.Column="1"
+                          Value="{Binding UndoExpirationTime, Mode=TwoWay}"
+                          Minimum="1"
+                          Maximum="30"
+                          SmallChange="1"
+                          LargeChange="5"
+                          TickFrequency="5"
+                          TickPlacement="BottomRight"
+                          Orientation="Horizontal"
+                          Name="SliderUndoExpirationTime"
+                          ValueChanged="UndoExpirationTimeChanged"
+                          HorizontalAlignment="Stretch" />
+                </Grid>
+              </controls:LabeledControl>
+
               <controls:LabeledControl Text="Auto Tracker Scripts folder:">
                 <controls:FileSystemInput Path="{Binding AutotrackerScriptsOutputPath, Mode=TwoWay}"
                                           IsFolderPicker="True"

--- a/src/Randomizer.App/Windows/OptionsWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/OptionsWindow.xaml.cs
@@ -231,5 +231,10 @@ namespace Randomizer.App
             TwitchLoginButton.Visibility = Visibility.Visible;
             TwitchLogoutButton.Visibility = Visibility.Collapsed;
         }
+
+        private void UndoExpirationTimeChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        {
+            TextBlockUndoExpirationTime.Text = Options?.UndoExpirationTime.ToString() ?? "";
+        }
     }
 }

--- a/src/Randomizer.App/Windows/OptionsWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/OptionsWindow.xaml.cs
@@ -14,6 +14,7 @@ using Randomizer.App.ViewModels;
 using Randomizer.SMZ3.ChatIntegration;
 using Randomizer.Data.Configuration;
 using Randomizer.Data.Options;
+using static System.Int32;
 
 namespace Randomizer.App
 {
@@ -232,9 +233,10 @@ namespace Randomizer.App
             TwitchLogoutButton.Visibility = Visibility.Collapsed;
         }
 
-        private void UndoExpirationTimeChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        private void UndoExpirationTimeTextBox_OnLostFocus(object sender, RoutedEventArgs e)
         {
-            TextBlockUndoExpirationTime.Text = Options?.UndoExpirationTime.ToString() ?? "";
+            _ = TryParse(new string(UndoExpirationTimeTextBox.Text.Where(char.IsDigit).ToArray()), out var number);
+            UndoExpirationTimeTextBox.Text = Math.Max(1, number).ToString();
         }
     }
 }

--- a/src/Randomizer.Data/Configuration/ConfigFiles/LocationConfig.cs
+++ b/src/Randomizer.Data/Configuration/ConfigFiles/LocationConfig.cs
@@ -880,7 +880,7 @@ namespace Randomizer.Data.Configuration.ConfigFiles
                 new LocationInfo()
                 {
                     LocationNumber = 335,
-                    Name = new("Pyramid of Power", "Pyramid"),
+                    Name = new("Pyramid of Power", "Pyramid", "Pyramid Ledge"),
                 },
                 new LocationInfo()
                 {

--- a/src/Randomizer.Data/Configuration/ConfigFiles/ResponseConfig.cs
+++ b/src/Randomizer.Data/Configuration/ConfigFiles/ResponseConfig.cs
@@ -574,6 +574,13 @@ namespace Randomizer.Data.Configuration.ConfigFiles
             = new SchrodingersString("There's nothing to undo.");
 
         /// <summary>
+        /// Gets the phrases to respond with when the latest undo action
+        /// has expired
+        /// </summary>
+        public SchrodingersString UndoExpired { get; init; }
+            = new ("There's nothing recent to undo.");
+
+        /// <summary>
         /// Gets the phrases to respond with when changing a Tracker setting.
         /// </summary>
         /// <remarks>

--- a/src/Randomizer.Data/Configuration/ConfigTypes/AutotrackerConfig.cs
+++ b/src/Randomizer.Data/Configuration/ConfigTypes/AutotrackerConfig.cs
@@ -15,6 +15,12 @@ namespace Randomizer.Data.Configuration.ConfigTypes
             = new("Auto tracker connected");
 
         /// <summary>
+        /// Gets the phrases to respond with when disconnected from the emulator.
+        /// </summary>
+        public SchrodingersString WhenDisconnected { get; init; }
+            = new("Auto tracker disconnected");
+
+        /// <summary>
         /// Gets the phrases to respond with when the game is started.
         /// </summary>
         public SchrodingersString GameStarted { get; init; }
@@ -171,6 +177,22 @@ namespace Randomizer.Data.Configuration.ConfigTypes
             [8] = new SchrodingersString("That could have been worse."),
             [16] = new SchrodingersString("That was pretty rough."),
             [22] = new SchrodingersString("How unfortunate."),
+        };
+
+        /// <summary>
+        /// Auto tracker detected switching to SMZ3
+        /// </summary>
+        public SchrodingersString SwitchedToSMZ3Rom { get; init; }
+            = new("Oh, I have to do work again?");
+
+        /// <summary>
+        /// Responses for changing to a game other than SMZ3. The key represents the hash of the
+        /// rom that is being switched to. For any hashes that aren't found, the responses for
+        /// SwitchedToOtherRom["Unknown"] is used.
+        /// </summary>
+        public Dictionary<string, SchrodingersString> SwitchedToOtherRom { get; init; } = new()
+        {
+            ["Unknown"] = new SchrodingersString("I can't help you with this game.")
         };
     }
 }

--- a/src/Randomizer.Data/Configuration/Yaml/Sassy/items.yml
+++ b/src/Randomizer.Data/Configuration/Yaml/Sassy/items.yml
@@ -7,15 +7,15 @@
       Weight: 0.1
     - Text: Tracked content. Be good or I'll take it away.
       Weight: 0.1
-    "2": 
+    "2":
     "10":
     - Text: Such a bountiful supply of content
     - Text: Please help! I cannot hold all this content
-    "11": 
+    "11":
     "15":
     - Text: I'm beginning to think you're lying about all this content.
     - Text: Is there really this much content?
-    "16": 
+    "16":
 - Item: Death
   WhenTracked:
     "1":
@@ -139,7 +139,7 @@
     - Text: I hope you enjoy your first bottle
     - Text: Was there a bee in this one?
     - Text: Potion storage increased by one step
-    "2": 
+    "2":
 - Item: Heart piece
   WhenTracked:
     "1":
@@ -158,17 +158,17 @@
     - Text: Another full heart, neat
     - Text: Increased survivablity by one step
     - Text: Maybe now you won't die.
-    "5": 
+    "5":
     "8":
     - Text: Wow another full heart
     - Text: Increased survivablity by one step
     - Text: Enough pieces for three full hearts. Wow
-    "9": 
+    "9":
     "12":
     - Text: I'm running out of jokes to make about you finding so many heart pieces
     - Text: Increased survivablity by one step
     - Text: Death is now a little harder to achieve.
-    "13": 
+    "13":
 - Item: Cane of Byrna
   Name:
   - Text: Cane of lag
@@ -234,7 +234,7 @@
     - Text: Throw more of these please
     - Text: I do enjoy seeing explosions
       Weight: 0.5
-    "3": 
+    "3":
 - Item: One Rupee
   WhenTracked:
     "1":
@@ -254,7 +254,7 @@
     "2":
     - Text: Blue pee? Maybe you should see a doctor.
     - Text: I hope your wallet is big enough
-    "3": 
+    "3":
 - Item: Twenty Rupees
   Name:
   - Text: Big 20
@@ -268,7 +268,7 @@
     "2":
     - Text: Only your second? I'm surprised.
     - Text: You now have 2 big twenties. Out of like five thousand.
-    "3": 
+    "3":
 - Item: Heart Container
   WhenTracked:
     "1":
@@ -277,7 +277,7 @@
     - Text: Thump thump
     "2":
     - Text: Get a few more and I can sleep early today
-    "3": 
+    "3":
 - Item: One Hundred Rupees
   Name:
   - Text: One Hundred Rupees
@@ -285,12 +285,12 @@
     "1":
     - Text: Don't spend it all in one place
     - Text: At least this is some decent money
-    "2": 
+    "2":
 - Item: Fifty Rupees
   WhenTracked:
     "1":
     - Text: Do you need bombs? Now you can afford them.
-    "2": 
+    "2":
 - Item: Single Arrow
   Name:
   - Text: Single Stick
@@ -299,7 +299,7 @@
     "1":
     - Text: This is now my favorite stick
     - Text: It's a single arrow, why are you having me track this?
-    "2": 
+    "2":
 - Item: Ten Arrows
   Name:
   - Text: Ten Sticks
@@ -308,7 +308,7 @@
     "1":
     - Text: Ten whole arrows, wow.
     - Text: This might be useful, if you didn't find sticks everywhere
-    "2": 
+    "2":
 - Item: Three Hundred Rupees
   WhenTracked:
     "1":
@@ -320,7 +320,7 @@
     "3":
     - Text: Did you seriously need three of these?
     - Text: Well aren't you rich now?
-    "4": 
+    "4":
 - Item: Pegasus Boots
   Name:
   - Text: Speedy boots
@@ -341,7 +341,7 @@
     - Text: Your mom signed the permission slip, now you can carry more bombs
     - Text: You are now authorized to know more things
     - Text: You can now carry more of an item you'll probably never run out of after the first 15 minutes.
-    "3": 
+    "3":
 - Item: +5 Arrow Capacity
   Name:
   - Text: +5 Stick Capacity
@@ -357,7 +357,7 @@
     "2":
     - Text: Your mom signed the permission slip, now you can carry more arrows
     - Text: You had to be told how to carry more sticks? Twice?
-    "3": 
+    "3":
 - Item: Sword
   Name:
   - Text: Pointy thing
@@ -367,11 +367,11 @@
     - Text: Tracked sword
     - Text: You can now poke things
     - Text: Don't forget to use the pointy end
-    "2": 
+    "2":
     "3":
     - Text: Toggled Bacon on
     - Text: Hmm... Bacon
-    "4": 
+    "4":
   Stages:
     "1":
     - Text: Fighter's Sword
@@ -393,7 +393,7 @@
     - Text: Congratulations on your new Fighter's Shield
     - Text: Do you really need this?
       Weight: 0.5
-    "2": 
+    "2":
     "3":
     - Text: Can you still see the sprite?
     - Text: Increased lag by one step
@@ -516,7 +516,7 @@
     - Text: Two whole tanks of energy. Wow.
     - Text: FYI You shouldn't drink these.
     - Text: Upgraded caffeine by one step
-    "3": 
+    "3":
     "14":
     - Text: You actually did it, you got all the E-Tanks in the game.
 - Item: Reserve Tank
@@ -532,7 +532,7 @@
     "2":
     - Text: <break time='3s'/> Oh I'm sorry. Was I supposed to care about Reserve Tanks?
     - Text: Oh. Neat. Wow. Reserve Tanks.
-    "3": 
+    "3":
 - Item: Missile
   Name:
   - Text: Explosive arrow
@@ -549,17 +549,17 @@
     - Text: Ten missles. Neat.
     - Text: The second missle pack is always special
     - Text: More Missiles
-    "3": 
+    "3":
     "4":
     - Text: You need some of these, right?
     - Text: Sometimes it feels like you only find missles in the game
-    "5": 
+    "5":
     "20":
     - Text: Okay, you have enough missiles now
-    "21": 
+    "21":
     "69":
     - Text: Nice
-    "70": 
+    "70":
 - Item: Super Missile
   Name:
   - Text: Soups
@@ -585,12 +585,12 @@
     - Text: Stockpiled more soup
     - Text: That is like a week's worth of soup
     - Text: Wow that's super
-    "3": 
+    "3":
     "10":
     - Text: Don't you have enough super missiles now?
     - Text: That's a lot of soup!
     - Text: Who needs the charge beam now?
-    "13": 
+    "13":
 - Item: Power Bomb
   Name:
   - Text: Explosive Hamburger
@@ -618,9 +618,9 @@
     - Text: Now you won't run out in the wrecked ship
     - Text: What are you going to destroy with these?
     - Text: Time to get things done in Metroid?
-    "3": 
+    "3":
     "4":
     - Text: Can you even eat that many burgs?
     - Text: You should have enough now, I think
-    "5": 
+    "5":
 

--- a/src/Randomizer.Data/Configuration/Yaml/Sassy/locations.yml
+++ b/src/Randomizer.Data/Configuration/Yaml/Sassy/locations.yml
@@ -86,3 +86,8 @@
 - LocationNumber: 292
   OutOfLogic:
   - ""
+# Pyramid of Power / Pyramid
+- LocationNumber: 335
+  Name:
+  - Text: "Pyramid of Sour"
+    Weight: 0.2

--- a/src/Randomizer.Data/Configuration/Yaml/Sassy/responses.yml
+++ b/src/Randomizer.Data/Configuration/Yaml/Sassy/responses.yml
@@ -328,6 +328,10 @@ NothingToUndo:
 - Text: There's nothing to undo.
 - Text: I haven't done anything.
 - Text: It's no use!
+UndoExpired:
+- Text: I'm afraid I can no longer undo that.
+- Text: You waited too long for me to undo that.
+- Text: You'll need to ask me sooner next time you want to undo something.
 TrackerSettingChanged:
 - Text: Changed {0} to {1}.
 BossDefeated:
@@ -909,7 +913,7 @@ Cheats:
     Weight: 0.05
   CheatFailed:
   - Text: Sorry, I can't perform that cheat for you at this time
-  CheatInvalidItem: 
+  CheatInvalidItem:
   - Text: If you want some of that, you'll need to make it yourself.
   - Text: Do you have any idea what you're even asking for?
   - Text: I'm sorry, I can't give you any of that.

--- a/src/Randomizer.Data/Configuration/Yaml/Templates/responses.yml
+++ b/src/Randomizer.Data/Configuration/Yaml/Templates/responses.yml
@@ -283,6 +283,9 @@ ActionUndone:
 # The list of possibilities when the player attempted to undo their last tracked action, but there's nothing to undo
 NothingToUndo:
 
+# The list of possibilities when the player attempted to undo their last tracked action, but the latest one has expired
+UndoExpired:
+
 # The list of possibilities when a tracker setting was changed
 # {0} is replaced with the setting name
 # {1} is replaced with the new value
@@ -596,7 +599,7 @@ Chat:
   # The list of possibilities when the GT big key guessing game is closed by a mod
   # {0} is replaced with the mod's name
   ModeratorClosedGuessingGame:
-  
+
   # The list of possibilities when the winner names are requested and we have at least one winner
   DeclareGuessingGameWinners:
 
@@ -624,7 +627,7 @@ Chat:
   # The phrases that Tracker will use after the GT big key guessing game winners were announced and she was among them.
   # {0} is replaced with the winning number.
   TrackerGuessWon:
-  
+
   # The phrases that Tracker will use when she is the only one who won the GT guessing game.
   # {0} is replaced with the winning number.
   TrackerGuessOnlyWinner:
@@ -648,7 +651,7 @@ Chat:
   # The list of possibilities when a poll was completed
   PollComplete:
 
-  # The list of possibilities when a poll was opened 
+  # The list of possibilities when a poll was opened
   PollOpened:
 
   # The list of possibilities when a poll response could not be determined to be open or completed
@@ -778,4 +781,4 @@ Cheats:
   CheatFailed:
 
   # The list of possibilities when an item is requested, but it is not a valid item
-  CheatInvalidItem: 
+  CheatInvalidItem:

--- a/src/Randomizer.Data/Configuration/Yaml/Templates/responses.yml
+++ b/src/Randomizer.Data/Configuration/Yaml/Templates/responses.yml
@@ -663,6 +663,9 @@ AutoTracker:
   # The list of possibilities when the auto tracker is connected to the game
   WhenConnected:
 
+  # The list of possibilities when the auto tracker is disconnected from the game
+  WhenDisconnected:
+
   # The list of possibilities when the auto tracker detects the player is in the game
   GameStarted:
 
@@ -734,6 +737,22 @@ AutoTracker:
     8:
     16:
     22:
+
+  # The list of possibilities when auto tracker detects switching to an SMZ3 rom from a previous rom
+  # Note: This functionality only works for BizHawk connected via Lua
+  SwitchedToSMZ3Rom:
+
+  # The list of possibilities when auto tracker detects switching to a non-SMZ3 rom
+  # You can include a series of different rom hashes and different possibilities for
+  # each one like the following. If a rom hash is not found, then it'll use the
+  # responses for Unknown.
+  # Note: This functionality only works for BizHawk connected via Lua
+  SwitchedToOtherRom:
+    Other:
+      - Text: Response1
+    Hash1:
+      - Text: Response1
+      - Text: Response2
 
 # This section is for map responses
 Map:

--- a/src/Randomizer.Data/Logic/LogicConfig.cs
+++ b/src/Randomizer.Data/Logic/LogicConfig.cs
@@ -35,6 +35,11 @@ namespace Randomizer.Data.Logic
         [Category("Logic")]
         public bool EasyEastCrateriaSkyItem { get; set; }
 
+        [DisplayName("Kholdstare Needs Somaria")]
+        [Description("You're expected to have the Cane of Somaria to get to Kholdstare to prevent from having to clear Ice Palace the vanilla way.")]
+        [Category("Logic")]
+        public bool KholdstareNeedsCaneOfSomaria { get; set; }
+
         [DisplayName("Fire Rod for Dark Rooms")]
         [Description("You're expected to be able to use the fire rod to light torches for navigating Hyrule Castle escape, Eastern Palace Armos Knights, and select rooms in Palace of Darkness.")]
         [Category("Tricks")]

--- a/src/Randomizer.Data/Options/GeneralOptions.cs
+++ b/src/Randomizer.Data/Options/GeneralOptions.cs
@@ -99,6 +99,8 @@ namespace Randomizer.Data.Options
 
         public bool AutoTrackerChangeMap { get; set; } = true;
 
+        public int UndoExpirationTime { get; set; } = 3;
+
         public string? TwitchUserName
         {
             get => _twitchUserName;
@@ -186,6 +188,7 @@ namespace Randomizer.Data.Options
             AutoTrackerChangeMap = AutoTrackerChangeMap,
             VoiceFrequency = (TrackerVoiceFrequency)VoiceFrequency,
             TrackerProfiles = SelectedProfiles,
+            UndoExpirationTime = UndoExpirationTime,
         };
 
         protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)

--- a/src/Randomizer.Data/Options/TrackerOptions.cs
+++ b/src/Randomizer.Data/Options/TrackerOptions.cs
@@ -91,6 +91,11 @@ namespace Randomizer.Data
         public TrackerVoiceFrequency VoiceFrequency { get; set; }
 
         /// <summary>
+        /// Amount of time in minutes to be able to undo an action
+        /// </summary>
+        public int UndoExpirationTime { get; set; } = 3;
+
+        /// <summary>
         /// The selected profiles for tracker responses
         /// </summary>
         public ICollection<string> TrackerProfiles { get; set; } = new List<string>() { "Sassy" };

--- a/src/Randomizer.Data/WorldData/Regions/Zelda/IcePalace.cs
+++ b/src/Randomizer.Data/WorldData/Regions/Zelda/IcePalace.cs
@@ -75,7 +75,7 @@ namespace Randomizer.Data.WorldData.Regions.Zelda
                 name: "Kholdstare",
                 vanillaItem: ItemType.HeartContainer,
                 access: items => items.BigKeyIP && items.Hammer && Logic.CanLiftLight(items) &&
-                    items.KeyIP >= (items.Somaria ? 1 : 2),
+                    items.KeyIP >= (items.Somaria ? 1 : 2) && (!Config.LogicConfig.KholdstareNeedsCaneOfSomaria || items.Somaria),
                 memoryAddress: 0xDE,
                 memoryFlag: 0xB);
 

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/AutoTracker.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/AutoTracker.cs
@@ -268,22 +268,22 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         }
 
         /// <summary>
-        /// Occurs when the tracker's auto tracker is enabled 
+        /// Occurs when the tracker's auto tracker is enabled
         /// </summary>
         public event EventHandler? AutoTrackerEnabled;
 
         /// <summary>
-        /// Occurs when the tracker's auto tracker is disabled 
+        /// Occurs when the tracker's auto tracker is disabled
         /// </summary>
         public event EventHandler? AutoTrackerDisabled;
 
         /// <summary>
-        /// Occurs when the tracker's auto tracker is connected 
+        /// Occurs when the tracker's auto tracker is connected
         /// </summary>
         public event EventHandler? AutoTrackerConnected;
 
         /// <summary>
-        /// Occurs when the tracker's auto tracker is disconnected 
+        /// Occurs when the tracker's auto tracker is disconnected
         /// </summary>
         public event EventHandler? AutoTrackerDisconnected;
 
@@ -646,7 +646,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
             {
                 if (data.CheckBinary8Bit(boss.Metadata?.MemoryAddress ?? 0, boss.Metadata?.MemoryFlag ?? 100))
                 {
-                    Tracker.MarkBossAsDefeated(boss);
+                    Tracker.MarkBossAsDefeated(boss, true, null, true);
                     _logger.LogInformation($"Auto tracked {boss.Name} as defeated");
                 }
             }
@@ -701,7 +701,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         protected void CheckBeatFinalBosses(EmulatorAction action)
         {
             if (_previousGame != CurrentGame || action.CurrentData == null || Tracker == null) return;
-            
+
             if (action.PreviousData?.ReadUInt8(0x2) == 0 && action.CurrentData.ReadUInt8(0x2) > 0)
             {
                 if (CurrentGame == Game.Zelda)
@@ -717,7 +717,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
                     var motherBrain = Tracker.World.AllBosses.First(x => x.Name == "Mother Brain");
                     if (motherBrain.State?.Defeated != true)
                     {
-                        Tracker.MarkBossAsDefeated(motherBrain, admittedGuilt: true, confidence: null, autoTracked: false);
+                        Tracker.MarkBossAsDefeated(motherBrain, admittedGuilt: true, confidence: null, autoTracked: true);
                     }
                 }
             }
@@ -737,7 +737,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
                     var motherBrain = Tracker.World.AllBosses.First(x => x.Name == "Mother Brain");
                     if (motherBrain.State?.Defeated != true)
                     {
-                        Tracker.MarkBossAsDefeated(motherBrain, admittedGuilt: true, confidence: null, autoTracked: false);
+                        Tracker.MarkBossAsDefeated(motherBrain, admittedGuilt: true, confidence: null, autoTracked: true);
                     }
                 }
             }

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/AutoTracker.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/AutoTracker.cs
@@ -508,7 +508,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
                     var castleTower = Tracker.World.CastleTower;
                     if (!castleTower.DungeonState.Cleared)
                     {
-                        Tracker.MarkDungeonAsCleared(castleTower, null);
+                        Tracker.MarkDungeonAsCleared(castleTower, null, autoTracked: true);
                         _logger.LogInformation($"Auto tracked {castleTower.DungeonMetadata.Name} as cleared");
                     }
                 }
@@ -621,7 +621,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
                     var currentValue = currentData.CheckUInt16(region.MemoryAddress * 2 ?? 0, region.MemoryFlag ?? 0);
                     if (!dungeon.DungeonState.Cleared && prevValue && currentValue)
                     {
-                        Tracker.MarkDungeonAsCleared(dungeon);
+                        Tracker.MarkDungeonAsCleared(dungeon, autoTracked: true);
                         _logger.LogInformation($"Auto tracked {dungeon.DungeonName} as cleared");
                     }
 

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/EmulatorDataReceivedEventArgs.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/EmulatorDataReceivedEventArgs.cs
@@ -10,10 +10,14 @@
         /// </summary>
         /// <param name="address"></param>
         /// <param name="data"></param>
-        public EmulatorDataReceivedEventArgs(int address, EmulatorMemoryData data)
+        /// <param name="romName"></param>
+        /// <param name="romHash"></param>
+        public EmulatorDataReceivedEventArgs(int address, EmulatorMemoryData data, string? romName = null, string? romHash = null)
         {
             Address = address;
             Data = data;
+            RomName = romName;
+            RomHash = romHash;
         }
 
         /// <summary>
@@ -25,5 +29,15 @@
         /// The data provided by the emulator
         /// </summary>
         public EmulatorMemoryData Data { get; }
+
+        /// <summary>
+        /// The filename of the current rom (BizHawk Lua connection only)
+        /// </summary>
+        public string? RomName { get; }
+
+        /// <summary>
+        /// The hash of the current rom (BizHawk Lua connection only)
+        /// </summary>
+        public string? RomHash { get; }
     }
 }

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/GameService.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/GameService.cs
@@ -17,7 +17,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
     /// auto tracker
     /// </summary>
     public class GameService : TrackerModule
-    { 
+    {
         private AutoTracker? _autoTracker => Tracker.AutoTracker;
         private readonly ILogger<GameService> _logger;
 
@@ -44,12 +44,12 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// <returns>False if it is currently unable to give an item to the player</returns>
         public bool TryGiveItem(Item item, int fromPlayerId = 0)
         {
-            if (_autoTracker == null || !_autoTracker.IsConnected)
+            if (_autoTracker == null || !_autoTracker.IsConnected || !_autoTracker.IsInSMZ3)
             {
                 return false;
             }
 
-            // First give the player the item by the requested 
+            // First give the player the item by the requested
             var bytes = new List<byte>();
             bytes.AddRange(Int16ToBytes(fromPlayerId + 1));
             bytes.AddRange(Int16ToBytes((int)item.Type));
@@ -92,7 +92,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// <returns>False if it is currently unable to give an item to the player</returns>
         public bool TryHealPlayer()
         {
-            if (_autoTracker == null || !_autoTracker.IsConnected)
+            if (_autoTracker == null || !_autoTracker.IsConnected || !_autoTracker.IsInSMZ3)
             {
                 return false;
             }
@@ -141,7 +141,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// <returns>False if it is currently unable to give magic to the player</returns>
         public bool TryFillMagic()
         {
-            if (_autoTracker == null || !_autoTracker.IsConnected || _autoTracker.CurrentGame != Game.Zelda)
+            if (_autoTracker == null || !_autoTracker.IsConnected || _autoTracker.CurrentGame != Game.Zelda || !_autoTracker.IsInSMZ3)
             {
                 return false;
             }
@@ -163,7 +163,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// <returns>False if it is currently unable to give bombs to the player</returns>
         public bool TryFillZeldaBombs()
         {
-            if (_autoTracker == null || !_autoTracker.IsConnected || _autoTracker.CurrentGame != Game.Zelda)
+            if (_autoTracker == null || !_autoTracker.IsConnected || _autoTracker.CurrentGame != Game.Zelda || !_autoTracker.IsInSMZ3)
             {
                 return false;
             }
@@ -185,7 +185,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// <returns>False if it is currently unable to give arrows to the player</returns>
         public bool TryFillArrows()
         {
-            if (_autoTracker == null || !_autoTracker.IsConnected || _autoTracker.CurrentGame != Game.Zelda)
+            if (_autoTracker == null || !_autoTracker.IsConnected || _autoTracker.CurrentGame != Game.Zelda || !_autoTracker.IsInSMZ3)
             {
                 return false;
             }
@@ -207,7 +207,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// <returns>False if it is currently unable to give rupees to the player</returns>
         public bool TryFillRupees()
         {
-            if (_autoTracker == null || !_autoTracker.IsConnected || _autoTracker.CurrentGame != Game.Zelda)
+            if (_autoTracker == null || !_autoTracker.IsConnected || _autoTracker.CurrentGame != Game.Zelda || !_autoTracker.IsInSMZ3)
             {
                 return false;
             }
@@ -229,7 +229,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// <returns>False if it is currently unable to give missiles to the player</returns>
         public bool TryFillMissiles()
         {
-            if (_autoTracker == null || !_autoTracker.IsConnected || _autoTracker.CurrentGame != Game.SM)
+            if (_autoTracker == null || !_autoTracker.IsConnected || _autoTracker.CurrentGame != Game.SM || !_autoTracker.IsInSMZ3)
             {
                 return false;
             }
@@ -252,7 +252,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// <returns>False if it is currently unable to give super missiles to the player</returns>
         public bool TryFillSuperMissiles()
         {
-            if (_autoTracker == null || !_autoTracker.IsConnected || _autoTracker.CurrentGame != Game.SM)
+            if (_autoTracker == null || !_autoTracker.IsConnected || _autoTracker.CurrentGame != Game.SM || !_autoTracker.IsInSMZ3)
             {
                 return false;
             }
@@ -275,7 +275,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// <returns>False if it is currently unable to give power bombs to the player</returns>
         public bool TryFillPowerBombs()
         {
-            if (_autoTracker == null || !_autoTracker.IsConnected || _autoTracker.CurrentGame != Game.SM)
+            if (_autoTracker == null || !_autoTracker.IsConnected || _autoTracker.CurrentGame != Game.SM || !_autoTracker.IsInSMZ3)
             {
                 return false;
             }
@@ -298,7 +298,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// <returns>True if successful</returns>
         public bool TryKillPlayer()
         {
-            if (_autoTracker == null || !_autoTracker.IsConnected)
+            if (_autoTracker == null || !_autoTracker.IsConnected || !_autoTracker.IsInSMZ3)
             {
                 return false;
             }

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/LuaMessage.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/LuaMessage.cs
@@ -7,6 +7,10 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
     /// </summary>
     public class LuaMessage
     {
+        public string? RomName { get; set; }
+
+        public string? RomHash { get; set; }
+
         /// <summary>
         /// The action to be done by the emulator (read/write/etc)
         /// </summary>

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/LuaScripts/bizhawk/autotracker.lua
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/LuaScripts/bizhawk/autotracker.lua
@@ -49,7 +49,7 @@ local function process_message(message)
     local values = data['WriteValues']
 
 	local bytes = nil
-	
+
 	if (action == 'read_block') then
 		bytes = emulator.read_bytes(address, length, domain)
     elseif (action == 'write_bytes') then
@@ -61,6 +61,8 @@ local function process_message(message)
 
     if (bytes ~= nil) then
 	    local result = {
+	        RomName = emulator.get_rom_name(),
+	        RomHash = emulator.get_rom_hash(),
 		    Action = action,
 		    Address = address,
 		    Length = length,
@@ -79,7 +81,7 @@ local function connect()
 	tcp = socket.tcp()
 	lastConnectionAttempt = os.time()
 	print('Attempting to connect')
-	
+
 	local ret, err = tcp:connect(HOST_ADDRESS, HOST_PORT)
 	if ret == 1 then
 		emulator.print('Connection established')

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/LuaScripts/bizhawk/emulator.lua
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/LuaScripts/bizhawk/emulator.lua
@@ -51,4 +51,12 @@ function emulator.write_uint16(address, value, domain)
 	memory.write_u16_le(translate_address(address, domain), value, domain)
 end
 
+function emulator.get_rom_name()
+    return gameinfo.getromname()
+end
+
+function emulator.get_rom_hash()
+    return gameinfo.getromhash()
+end
+
 return emulator;

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/LuaScripts/snes9xrr_32bit/autotracker.lua
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/LuaScripts/snes9xrr_32bit/autotracker.lua
@@ -49,7 +49,7 @@ local function process_message(message)
     local values = data['WriteValues']
 
 	local bytes = nil
-	
+
 	if (action == 'read_block') then
 		bytes = emulator.read_bytes(address, length, domain)
     elseif (action == 'write_bytes') then
@@ -61,6 +61,8 @@ local function process_message(message)
 
     if (bytes ~= nil) then
 	    local result = {
+	        RomName = emulator.get_rom_name(),
+	        RomHash = emulator.get_rom_hash(),
 		    Action = action,
 		    Address = address,
 		    Length = length,
@@ -79,7 +81,7 @@ local function connect()
 	tcp = socket.tcp()
 	lastConnectionAttempt = os.time()
 	print('Attempting to connect')
-	
+
 	local ret, err = tcp:connect(HOST_ADDRESS, HOST_PORT)
 	if ret == 1 then
 		emulator.print('Connection established')

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/LuaScripts/snes9xrr_32bit/emulator.lua
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/LuaScripts/snes9xrr_32bit/emulator.lua
@@ -35,4 +35,12 @@ function emulator.write_uint16(address, value, domain)
     memory.writeword(translate_address(address, domain), value, domain)
 end
 
+function emulator.get_rom_name()
+    return ""
+end
+
+function emulator.get_rom_hash()
+    return ""
+end
+
 return emulator;

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/LuaScripts/snex9xrr_64bit/autotracker.lua
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/LuaScripts/snex9xrr_64bit/autotracker.lua
@@ -49,7 +49,7 @@ local function process_message(message)
     local values = data['WriteValues']
 
 	local bytes = nil
-	
+
 	if (action == 'read_block') then
 		bytes = emulator.read_bytes(address, length, domain)
     elseif (action == 'write_bytes') then
@@ -61,6 +61,8 @@ local function process_message(message)
 
     if (bytes ~= nil) then
 	    local result = {
+	        RomName = emulator.get_rom_name(),
+	        RomHash = emulator.get_rom_hash(),
 		    Action = action,
 		    Address = address,
 		    Length = length,
@@ -79,7 +81,7 @@ local function connect()
 	tcp = socket.tcp()
 	lastConnectionAttempt = os.time()
 	print('Attempting to connect')
-	
+
 	local ret, err = tcp:connect(HOST_ADDRESS, HOST_PORT)
 	if ret == 1 then
 		emulator.print('Connection established')

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/LuaScripts/snex9xrr_64bit/emulator.lua
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/LuaScripts/snex9xrr_64bit/emulator.lua
@@ -35,4 +35,12 @@ function emulator.write_uint16(address, value, domain)
     memory.writeword(translate_address(address, domain), value, domain)
 end
 
+function emulator.get_rom_name()
+    return ""
+end
+
+function emulator.get_rom_hash()
+    return ""
+end
+
 return emulator;

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/MetroidStateChecks/MetroidDeath.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/MetroidStateChecks/MetroidDeath.cs
@@ -41,7 +41,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking.MetroidStateChecks
                 var death = Items.FirstOrDefault("Death");
                 if (death is not null)
                 {
-                    tracker.TrackItem(death);
+                    tracker.TrackItem(death, autoTracked: true);
                     return true;
                 }
             }

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/ZeldaDeath.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/ZeldaDeath.cs
@@ -48,7 +48,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking.ZeldaStateChecks
                 var death = Items.FirstOrDefault("Death");
                 if (death is not null)
                 {
-                    tracker.TrackItem(death);
+                    tracker.TrackItem(death, autoTracked: true);
                     return true;
                 }
             }

--- a/src/Randomizer.SMZ3.Tracking/Tracker.cs
+++ b/src/Randomizer.SMZ3.Tracking/Tracker.cs
@@ -551,7 +551,8 @@ namespace Randomizer.SMZ3.Tracking
         /// possible rewards.
         /// </param>
         /// <param name="confidence">The speech recognition confidence.</param>
-        public void SetDungeonReward(IDungeon dungeon, RewardType? reward = null, float? confidence = null)
+        /// <param name="autoTracked">If this was called by the auto tracker</param>
+        public void SetDungeonReward(IDungeon dungeon, RewardType? reward = null, float? confidence = null, bool autoTracked = false)
         {
             var originalReward = dungeon.DungeonState.MarkedReward;
             if (reward == null)
@@ -569,7 +570,8 @@ namespace Randomizer.SMZ3.Tracking
             }
 
             OnDungeonUpdated(new TrackerEventArgs(confidence));
-            AddUndo(() => dungeon.DungeonState.MarkedReward = originalReward);
+
+            if (!autoTracked) AddUndo(() => dungeon.DungeonState.MarkedReward = originalReward);
         }
 
         /// <summary>

--- a/src/Randomizer.SMZ3.Tracking/Tracker.cs
+++ b/src/Randomizer.SMZ3.Tracking/Tracker.cs
@@ -54,7 +54,7 @@ namespace Randomizer.SMZ3.Tracking
         private readonly ILogger<Tracker> _logger;
         private readonly TrackerOptionsAccessor _trackerOptions;
         private readonly Dictionary<string, Timer> _idleTimers;
-        private readonly Stack<Action> _undoHistory = new();
+        private readonly Stack<(Action Action, DateTime UndoTime)> _undoHistory = new();
         private readonly RandomizerContext _dbContext;
         private readonly ICommunicator _communicator;
         private readonly ITrackerStateService _stateService;
@@ -441,9 +441,17 @@ namespace Randomizer.SMZ3.Tracking
         {
             if (_undoHistory.TryPop(out var undoLast))
             {
-                Say(Responses.ActionUndone);
-                undoLast();
-                OnActionUndone(new TrackerEventArgs(confidence));
+                if ((DateTime.Now - undoLast.UndoTime).TotalMinutes <= (_trackerOptions?.Options?.UndoExpirationTime ?? 3))
+                {
+                    Say(Responses.ActionUndone);
+                    undoLast.Action();
+                    OnActionUndone(new TrackerEventArgs(confidence));
+                }
+                else
+                {
+                    Say(Responses.UndoExpired);
+                    _undoHistory.Push(undoLast);
+                }
             }
             else
             {
@@ -656,7 +664,7 @@ namespace Randomizer.SMZ3.Tracking
                 _logger.LogError(e, "Error enabling voice recognition");
                 loadError = true;
             }
-            
+
             Say(_alternateTracker ? Responses.StartingTrackingAlternate : Responses.StartedTracking);
             RestartIdleTimers();
             return !loadError;
@@ -1253,11 +1261,11 @@ namespace Randomizer.SMZ3.Tracking
 
                             _previousMissingItems = allMissingItems;
                         }
-                        
+
                     }
                 }
             }
-            
+
             var addedEvent = History.AddEvent(
                 HistoryEventType.TrackedItem,
                 item.Metadata.IsProgression(World.Config),
@@ -1278,7 +1286,7 @@ namespace Randomizer.SMZ3.Tracking
                     addedEvent.IsUndone = true;
                 });
             }
-            
+
             GiveLocationHint(accessibleBefore);
             RestartIdleTimers();
 
@@ -1349,7 +1357,7 @@ namespace Randomizer.SMZ3.Tracking
             {
                 dungeon = GetDungeonFromItem(item, dungeon)!;
                 if (TrackDungeonTreasure(dungeon, confidence))
-                    undoTrackTreasure = _undoHistory.Pop();
+                    undoTrackTreasure = _undoHistory.Pop().Action;
             }
 
             IsDirty = true;
@@ -1370,7 +1378,7 @@ namespace Randomizer.SMZ3.Tracking
 
                 AddUndo(() =>
                 {
-                    undoTrack();
+                    undoTrack.Action();
                     undoTrackTreasure?.Invoke();
                     location.State.Cleared = false;
                     ItemService.ResetProgression();
@@ -1380,7 +1388,7 @@ namespace Randomizer.SMZ3.Tracking
             {
                 AddUndo(() =>
                 {
-                    undoTrack();
+                    undoTrack.Action();
                     undoTrackTreasure?.Invoke();
                     ItemService.ResetProgression();
                 });
@@ -1423,8 +1431,8 @@ namespace Randomizer.SMZ3.Tracking
                 var undoTrack = _undoHistory.Pop();
                 AddUndo(() =>
                 {
-                    undoClear();
-                    undoTrack();
+                    undoClear.Action();
+                    undoTrack.Action();
                     ItemService.ResetProgression();
                 });
             }
@@ -1745,7 +1753,7 @@ namespace Randomizer.SMZ3.Tracking
 
                 if (!autoTracked)
                 {
-                    undoStopPegWorldMode = _undoHistory.Pop();
+                    undoStopPegWorldMode = _undoHistory.Pop().Action;
                 }
             }
 
@@ -1912,7 +1920,7 @@ namespace Randomizer.SMZ3.Tracking
                     if (item != null && item.State.TrackingState > 0)
                     {
                         UntrackItem(item);
-                        undoUntrack = _undoHistory.Pop();
+                        undoUntrack = _undoHistory.Pop().Action;
                     }
 
                     if (!rewardLocation.Item.IsDungeonItem)
@@ -2198,7 +2206,7 @@ namespace Randomizer.SMZ3.Tracking
         /// <param name="undo">
         /// The action to invoke to undo the last operation.
         /// </param>
-        protected internal virtual void AddUndo(Action undo) => _undoHistory.Push(undo);
+        protected internal virtual void AddUndo(Action undo) => _undoHistory.Push((undo, DateTime.Now));
 
         /// <summary>
         /// Cleans up resources used by this class.
@@ -2333,7 +2341,7 @@ namespace Randomizer.SMZ3.Tracking
             if (dungeon != null && (IsTreasure(item) || World.Config.ZeldaKeysanity))
             {
                 if (TrackDungeonTreasure(dungeon, confidence))
-                    return _undoHistory.Pop();
+                    return _undoHistory.Pop().Action;
             }
 
             IsDirty = true;
@@ -2354,7 +2362,7 @@ namespace Randomizer.SMZ3.Tracking
             if (dungeon != null && (IsTreasure(location.Item) || World.Config.ZeldaKeysanity))
             {
                 if (TrackDungeonTreasure(dungeon, confidence, 1, autoTracked, stateResponse))
-                    return _undoHistory.Pop();
+                    return _undoHistory.Pop().Action;
             }
 
             IsDirty = true;

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/CheatsModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/CheatsModule.cs
@@ -94,7 +94,7 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
                 Tracker.Say(x => x.Cheats.PromptEnableCheats);
                 return false;
             }
-            else if (Tracker.AutoTracker == null || !Tracker.AutoTracker.IsConnected)
+            else if (Tracker.AutoTracker == null || !Tracker.AutoTracker.IsConnected || !Tracker.AutoTracker.IsInSMZ3)
             {
                 Tracker.Say(x => x.Cheats.PromptEnableAutoTracker);
                 return false;

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/UndoModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/UndoModule.cs
@@ -31,7 +31,7 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
         {
             return new GrammarBuilder()
                 .Append("Hey tracker,")
-                .OneOf("undo", "undo that", "control Z", "that's not what I said");
+                .OneOf("undo that", "control Z", "that's not what I said", "take backsies");
         }
     }
 }

--- a/tests/Randomizer.SMZ3.Tests/LogicTests/LogicConfigTests.cs
+++ b/tests/Randomizer.SMZ3.Tests/LogicTests/LogicConfigTests.cs
@@ -362,5 +362,53 @@ namespace Randomizer.SMZ3.Tests.LogicTests
             missingItems.Should().BeEmpty();
             tempWorld.EastCrateria.SkyMissile.IsAvailable(progression).Should().BeTrue();
         }
+
+        [Fact]
+        public void TestKholdstareNeedsCaneOfSomaria()
+        {
+            var config = new Config();
+
+            var items = new List<ItemType>()
+            {
+                ItemType.MoonPearl,
+                ItemType.Firerod,
+                ItemType.Hookshot,
+                ItemType.ProgressiveGlove,
+                ItemType.ProgressiveGlove,
+                ItemType.ProgressiveSword,
+                ItemType.Flippers,
+                ItemType.BigKeyIP,
+                ItemType.Hammer,
+                ItemType.KeyIP,
+            };
+
+            config.LogicConfig.KholdstareNeedsCaneOfSomaria = false;
+            var tempWorld = new World(config, "", 0, "");
+            var progression = new Progression(items, Array.Empty<RewardType>(), Array.Empty<BossType>());
+            var missingItems = Logic.GetMissingRequiredItems(tempWorld.IcePalace.KholdstareReward, progression, out _);
+            missingItems.Should().HaveCount(2)
+                .And.ContainEquivalentOf(new[] { ItemType.KeyIP })
+                .And.ContainEquivalentOf(new[] { ItemType.Somaria });
+
+            progression = new Progression(items.Append(ItemType.KeyIP), Array.Empty<RewardType>(), Array.Empty<BossType>());
+            missingItems = Logic.GetMissingRequiredItems(tempWorld.IcePalace.KholdstareReward, progression, out _);
+            missingItems.Should().BeEmpty();
+
+            config.LogicConfig.KholdstareNeedsCaneOfSomaria = true;
+            tempWorld = new World(config, "", 0, "");
+            progression = new Progression(items, Array.Empty<RewardType>(), Array.Empty<BossType>());
+            missingItems = Logic.GetMissingRequiredItems(tempWorld.IcePalace.KholdstareReward, progression, out _);
+            missingItems.Should().HaveCount(1)
+                .And.ContainEquivalentOf(new[] { ItemType.Somaria });
+
+            progression = new Progression(items.Append(ItemType.KeyIP), Array.Empty<RewardType>(), Array.Empty<BossType>());
+            missingItems = Logic.GetMissingRequiredItems(tempWorld.IcePalace.KholdstareReward, progression, out _);
+            missingItems.Should().HaveCount(1)
+                .And.ContainEquivalentOf(new[] { ItemType.Somaria });
+
+            progression = new Progression(items.Append(ItemType.Somaria), Array.Empty<RewardType>(), Array.Empty<BossType>());
+            missingItems = Logic.GetMissingRequiredItems(tempWorld.IcePalace.KholdstareReward, progression, out _);
+            missingItems.Should().BeEmpty();
+        }
     }
 }


### PR DESCRIPTION
- Undo actions can now only be undone for a certain period of time
- Fixed where autotracked bosses and deaths could be undone
- Added logic option for requiring Cane of Somaria for Ice Palace