### PR TITLE
Fixes issues with items being tracked on reset

### DIFF
--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/AutoTrackerMetroidState.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/AutoTrackerMetroidState.cs
@@ -98,6 +98,13 @@
         }
 
         /// <summary>
+        /// Checks to make sure that the state is valid and fully loaded. There's a period upon first booting up that
+        /// all of these are 0s, but some of the memory in the location data can be screwy.
+        /// </summary>
+        public bool IsValid => CurrentRoom != 0 || CurrentRegion != 0 || CurrentRoomInRegion != 0 || Energy != 0 ||
+                               SamusX != 0 || SamusY != 0;
+
+        /// <summary>
         /// Prints debug data for the state
         /// </summary>
         /// <returns></returns>

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/EmulatorAction.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/EmulatorAction.cs
@@ -90,6 +90,15 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// </summary>
         public ICollection<Location>? Locations { get; set; }
 
+        /// <summary>
+        /// Clears both the previous and current data sets
+        /// </summary>
+        public void ClearData()
+        {
+            PreviousData = null;
+            CurrentData = null;
+        }
+
     }
 
 }


### PR DESCRIPTION
There have been a few issues where if auto tracker is connected before the game fully loads, it'll track the SM bosses and locations. This change looks for a valid game state before tracking. It also resets everything on disconnects.