### PR TITLE
Fix tracker counting mushroom/magic powder as junk

### DIFF
--- a/src/Randomizer.SMZ3.Tracking/Tracker.cs
+++ b/src/Randomizer.SMZ3.Tracking/Tracker.cs
@@ -2220,12 +2220,19 @@ namespace Randomizer.SMZ3.Tracking
                 {
                     World.LightWorldDeathMountainWest.EtherTablet,
                     World.LightWorldSouth.BombosTablet
-                }
+                },
+                [ItemType.Bottle] = new[] { World.LightWorldNorthWest.SickKid },
+                [ItemType.BottleWithBee] = new[] { World.LightWorldNorthWest.SickKid },
+                [ItemType.BottleWithFairy] = new[] { World.LightWorldNorthWest.SickKid },
+                [ItemType.BottleWithBluePotion] = new[] { World.LightWorldNorthWest.SickKid },
+                [ItemType.BottleWithGoldBee] = new[] { World.LightWorldNorthWest.SickKid },
+                [ItemType.BottleWithGreenPotion] = new[] { World.LightWorldNorthWest.SickKid },
+                [ItemType.BottleWithRedPotion] = new[] { World.LightWorldNorthWest.SickKid },
             };
 
             if (leads.TryGetValue(item.Type, out var leadsToLocation))
             {
-                foreach (var location in leadsToLocation)
+                foreach (var location in leadsToLocation.Where(x => !x.State.Cleared))
                 {
                     var reward = location.Item;
                     if (reward.Type != ItemType.Nothing)

--- a/src/Randomizer.SMZ3.Tracking/Tracker.cs
+++ b/src/Randomizer.SMZ3.Tracking/Tracker.cs
@@ -2230,9 +2230,9 @@ namespace Randomizer.SMZ3.Tracking
                 [ItemType.BottleWithRedPotion] = new[] { World.LightWorldNorthWest.SickKid },
             };
 
-            if (leads.TryGetValue(item.Type, out var leadsToLocation))
+            if (leads.TryGetValue(item.Type, out var leadsToLocation) && !ItemService.IsTracked(item.Type))
             {
-                foreach (var location in leadsToLocation.Where(x => !x.State.Cleared))
+                foreach (var location in leadsToLocation)
                 {
                     var reward = location.Item;
                     if (reward.Type != ItemType.Nothing)

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/SpoilerModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/SpoilerModule.cs
@@ -432,19 +432,11 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
                         ? Tracker.CorrectPronunciation(location.World.Config.SamusName)
                         : Tracker.CorrectPronunciation(location.World.Config.LinkName);
 
-                    if (location.Item.Metadata.IsJunk(location.Item.World.Config))
-                    {
-                        return GiveLocationHint(x => x.LocationHasJunkItem, location, characterName);
-                    }
-
-                    // Todo: Add check for if it's progression
-
-                    if (location.Item.Metadata.IsGood(location.Item.World.Config))
+                    if (Tracker.IsWorth(location.Item))
                     {
                         return GiveLocationHint(x => x.LocationHasUsefulItem, location, characterName);
                     }
-
-                    return GiveLocationHint(x => x.NoApplicableHints, location);
+                    return GiveLocationHint(x => x.LocationHasJunkItem, location, characterName);
 
                 // Try to give a hint from the config
                 case 1:

--- a/src/Randomizer.Shared/Enums/ItemType.cs
+++ b/src/Randomizer.Shared/Enums/ItemType.cs
@@ -341,7 +341,7 @@ namespace Randomizer.Shared
         HeartContainer = 0x3E,
 
         [Description("Sanctuary Heart Container")]
-        [ItemCategory(ItemCategory.Zelda, ItemCategory.Scam)]
+        [ItemCategory(ItemCategory.Zelda, ItemCategory.Scam, ItemCategory.Junk)]
         HeartContainerRefill = 0x3F,
 
         [Description("Three Bombs")]


### PR DESCRIPTION
Apparently tracker wasn't doing the IsWorth check for stuff like mushrooms for location hints. Also added bottles -> sick kid, but added where it won't say it's worth it if you already have a bottle.

Fixes #288 