### PR TITLE
Adding Moat Speed Booster Trick

### DIFF
--- a/src/Randomizer.Data/Logic/ILogic.cs
+++ b/src/Randomizer.Data/Logic/ILogic.cs
@@ -58,6 +58,8 @@ namespace Randomizer.Data.Logic
 
         public bool CanParlorSpeedBoost(Progression items);
 
+        public bool CanMoatSpeedBoost(Progression items);
+
         public bool CanMoveAtHighSpeeds(Progression items);
 
         public bool CanPassSwordOnlyDarkRooms(Progression items);

--- a/src/Randomizer.Data/Logic/Logic.cs
+++ b/src/Randomizer.Data/Logic/Logic.cs
@@ -134,6 +134,11 @@ namespace Randomizer.Data.Logic
             return items.SpeedBooster && World.Config.LogicConfig.ParlorSpeedBooster;
         }
 
+        public bool CanMoatSpeedBoost(Progression items)
+        {
+            return items.SpeedBooster && World.Config.LogicConfig.MoatSpeedBooster;
+        }
+
         public bool CanMoveAtHighSpeeds(Progression items)
         {
             return items.SpeedBooster || (items.Morph && World.Config.LogicConfig.MockBall);

--- a/src/Randomizer.Data/Logic/LogicConfig.cs
+++ b/src/Randomizer.Data/Logic/LogicConfig.cs
@@ -65,6 +65,11 @@ namespace Randomizer.Data.Logic
         [Category("Tricks")]
         public bool ParlorSpeedBooster { get; set; }
 
+        [DisplayName("Moat Speed Booster Fly By")]
+        [Description("You're expected to be able to use the speed booster to shine spark over the moat in order to get to the Wrecked Ship.")]
+        [Category("Tricks")]
+        public bool MoatSpeedBooster { get; set; }
+
         [DisplayName("Mockball")]
         [Description("You're expected to be able to use to mockball to avoid having the speed booster at the entrance to Green Brinstar and Upper Norfair West.")]
         [Category("Tricks")]

--- a/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Crateria/EastCrateria.cs
+++ b/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Crateria/EastCrateria.cs
@@ -62,7 +62,7 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Crateria
 
         private bool CanAccessFloodedCavernUnderWater(Progression items, bool requireRewards)
             => items.Morph && (
-                items.SpeedBooster
+                Logic.CanMoatSpeedBoost(items)
                 || items.Grapple
                 || items.SpaceJump
                 || (items.Gravity && (Logic.CanIbj(items) || items.HiJump))

--- a/src/Randomizer.Data/WorldData/Regions/SuperMetroid/WreckedShip.cs
+++ b/src/Randomizer.Data/WorldData/Regions/SuperMetroid/WreckedShip.cs
@@ -113,7 +113,7 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid
             return items.Super && (
                         /* Over the Moat */
                         ((Config.MetroidKeysanity ? items.CardCrateriaL2 : Logic.CanUsePowerBombs(items)) && (
-                            items.SpeedBooster || items.Grapple || items.SpaceJump ||
+                            Logic.CanMoatSpeedBoost(items) || items.Grapple || items.SpaceJump ||
                             (items.Gravity && (Logic.CanIbj(items) || (items.HiJump && Logic.CanWallJump(WallJumpDifficulty.Easy))))
                             || Logic.CanWallJump(WallJumpDifficulty.Insane)
                         )) ||


### PR DESCRIPTION
This does actually change default behavior with new seeds, but because this feels pretty similar to the Parlor Speed Boost that was added a long time ago both in terms of execution difficulty and type, I thought it would be appropriate in the tricks section.