### PR TITLE
Move every Metroid Location into a Room

### DIFF
--- a/src/Randomizer.App/Windows/GenerateRomWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/GenerateRomWindow.xaml.cs
@@ -459,7 +459,7 @@ namespace Randomizer.App.Windows
 
             stats.Increment("Successfully generated");
 
-            if (IsScam(world.World.InnerMaridia.ShaktoolItem.Item.Type))
+            if (IsScam(world.World.InnerMaridia.SpringBall.ShaktoolItem.Item.Type))
                 stats.Increment("Shaktool betrays you");
 
             if (IsScam(world.World.LightWorldNorthEast.ZorasDomain.Zora.Item.Type))
@@ -471,7 +471,7 @@ namespace Randomizer.App.Windows
             if (IsScam(world.World.DarkWorldNorthWest.PegWorld.Item.Type))
                 stats.Increment("\"I want to go on something more thrilling than Peg World.\"");
 
-            if (world.World.BlueBrinstar.MorphBall.Item.Type == ItemType.Morph)
+            if (world.World.BlueBrinstar.BlueBrinstarMorphBall.MorphBall.Item.Type == ItemType.Morph)
                 stats.Increment("The Morph Ball is in its original location");
 
             if (world.World.GanonsTower.MoldormChest.Item.Type.IsInCategory(ItemCategory.Metroid))

--- a/src/Randomizer.Data/Services/IMetadataService.cs
+++ b/src/Randomizer.Data/Services/IMetadataService.cs
@@ -169,7 +169,7 @@ namespace Randomizer.Data.Services
         /// <returns>
         /// A new <see cref="RoomInfo"/> for the specified room.
         /// </returns>
-        public RoomInfo Room(Type type);
+        public RoomInfo? Room(Type type);
 
         /// <summary>
         /// Returns extra information for the specified room.
@@ -178,7 +178,7 @@ namespace Randomizer.Data.Services
         /// <returns>
         /// A new <see cref="RoomInfo"/> for the specified room.
         /// </returns>
-        public RoomInfo Room(Room room);
+        public RoomInfo? Room(Room room);
 
         /// <summary>
         /// Returns extra information for the specified room.

--- a/src/Randomizer.Data/Services/IMetadataService.cs
+++ b/src/Randomizer.Data/Services/IMetadataService.cs
@@ -189,7 +189,7 @@ namespace Randomizer.Data.Services
         /// <returns>
         /// A new <see cref="RoomInfo"/> for the specified room.
         /// </returns>
-        public RoomInfo Room<TRoom>() where TRoom : Room;
+        public RoomInfo? Room<TRoom>() where TRoom : Room;
 
         /// <summary>
         /// Returns extra information for the specified location.

--- a/src/Randomizer.Data/Services/MetadataService.cs
+++ b/src/Randomizer.Data/Services/MetadataService.cs
@@ -201,8 +201,8 @@ namespace Randomizer.Data.Services
         /// <returns>
         /// A new <see cref="RoomInfo"/> for the specified room.
         /// </returns>
-        public RoomInfo Room(Type type)
-            => Rooms.Single(x => x.Type == type);
+        public RoomInfo? Room(Type type)
+            => Rooms.SingleOrDefault(x => x.Type == type);
 
         /// <summary>
         /// Returns extra information for the specified room.
@@ -211,7 +211,7 @@ namespace Randomizer.Data.Services
         /// <returns>
         /// A new <see cref="RoomInfo"/> for the specified room.
         /// </returns>
-        public RoomInfo Room(Room room)
+        public RoomInfo? Room(Room room)
             => Room(room.GetType());
 
         /// <summary>

--- a/src/Randomizer.Data/Services/MetadataService.cs
+++ b/src/Randomizer.Data/Services/MetadataService.cs
@@ -223,7 +223,7 @@ namespace Randomizer.Data.Services
         /// <returns>
         /// A new <see cref="RoomInfo"/> for the specified room.
         /// </returns>
-        public RoomInfo Room<TRoom>() where TRoom : Room
+        public RoomInfo? Room<TRoom>() where TRoom : Room
             => Room(typeof(TRoom));
 
         /// <summary>

--- a/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Brinstar/BlueBrinstar.cs
+++ b/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Brinstar/BlueBrinstar.cs
@@ -10,54 +10,11 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
     {
         public BlueBrinstar(World world, Config config, IMetadataService? metadata, TrackerState? trackerState) : base(world, config, metadata, trackerState)
         {
-            MorphBall = new Location(this, 26, 0x8F86EC, LocationType.Visible,
-                name: "Morphing Ball",
-                vanillaItem: ItemType.Morph,
-                memoryAddress: 0x3,
-                memoryFlag: 0x4,
-                metadata: metadata,
-                trackerState: trackerState);
-
-            PowerBomb = new Location(this, 27, 0x8F874C, LocationType.Visible,
-                name: "Power Bomb (blue Brinstar)",
-                vanillaItem: ItemType.PowerBomb,
-                access: items => Logic.CanUsePowerBombs(items),
-                memoryAddress: 0x3,
-                memoryFlag: 0x8,
-                metadata: metadata,
-                trackerState: trackerState);
-
-            MiddleMissile = new Location(this, 28, 0x8F8798, LocationType.Visible,
-                name: "Missile (blue Brinstar middle)",
-                vanillaItem: ItemType.Missile,
-                access: items => items.CardBrinstarL1 && items.Morph,
-                memoryAddress: 0x3,
-                memoryFlag: 0x10,
-                metadata: metadata,
-                trackerState: trackerState);
-
-            Ceiling = new Location(this, 29, 0x8F879E, LocationType.Hidden,
-                name: "Energy Tank, Brinstar Ceiling",
-                vanillaItem: ItemType.ETank,
-                access: items => items.CardBrinstarL1 && (Logic.CanFly(items) || items.HiJump || items.SpeedBooster || items.Ice),
-                memoryAddress: 0x3,
-                memoryFlag: 0x20,
-                metadata: metadata,
-                trackerState: trackerState);
-
-            BottomMissile = new Location(this, 34, 0x8F8802, LocationType.Chozo,
-                name: "Missile (blue Brinstar bottom)",
-                vanillaItem: ItemType.Missile,
-                access: items => items.Morph,
-                memoryAddress: 0x4,
-                memoryFlag: 0x4,
-                metadata: metadata,
-                trackerState: trackerState);
-
+            BlueBrinstarMorphBall = new BlueBrinstarMorphBallRoom(this, metadata, trackerState);
+            BlueBrinstarFirstMissile = new BlueBrinstarFirstMissileRoom(this, metadata, trackerState);
+            BlueBrinstarEnergyTank = new BlueBrinstarEnergyTankRoom(this, metadata, trackerState);
             BlueBrinstarTop = new BlueBrinstarTopRoom(this, metadata, trackerState);
-
             MemoryRegionId = 1;
-
             Metadata = metadata?.Region(GetType()) ?? new RegionInfo("Blue Brinstar");
         }
 
@@ -65,17 +22,88 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
 
         public override string Area => "Brinstar";
 
-        public Location MorphBall { get; }
+        public BlueBrinstarMorphBallRoom BlueBrinstarMorphBall { get; }
 
-        public Location PowerBomb { get; }
+        public BlueBrinstarFirstMissileRoom BlueBrinstarFirstMissile { get; }
 
-        public Location MiddleMissile { get; }
-
-        public Location Ceiling { get; }
-
-        public Location BottomMissile { get; }
+        public BlueBrinstarEnergyTankRoom BlueBrinstarEnergyTank { get; }
 
         public BlueBrinstarTopRoom BlueBrinstarTop { get; }
+
+        public class BlueBrinstarMorphBallRoom : Room
+        {
+            public BlueBrinstarMorphBallRoom(BlueBrinstar region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Blue Brinstar Morph Ball Room", metadata, "Morph Ball Room")
+            {
+                MorphBall = new Location(this, 26, 0x8F86EC, LocationType.Visible,
+                    name: "Morphing Ball",
+                    vanillaItem: ItemType.Morph,
+                    memoryAddress: 0x3,
+                    memoryFlag: 0x4,
+                    metadata: metadata,
+                    trackerState: trackerState);
+
+                PowerBomb = new Location(this, 27, 0x8F874C, LocationType.Visible,
+                    name: "Power Bomb (blue Brinstar)",
+                    vanillaItem: ItemType.PowerBomb,
+                    access: items => Logic.CanUsePowerBombs(items),
+                    memoryAddress: 0x3,
+                    memoryFlag: 0x8,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location MorphBall { get; }
+
+            public Location PowerBomb { get; }
+        }
+
+        public class BlueBrinstarFirstMissileRoom : Room
+        {
+            public BlueBrinstarFirstMissileRoom(BlueBrinstar region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Blue Brinstar First Missile Room", metadata)
+            {
+                MiddleMissile = new Location(this, 28, 0x8F8798, LocationType.Visible,
+                    name: "Missile (blue Brinstar middle)",
+                    vanillaItem: ItemType.Missile,
+                    access: items => items.CardBrinstarL1 && items.Morph,
+                    memoryAddress: 0x3,
+                    memoryFlag: 0x10,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location MiddleMissile { get; }
+        }
+
+        public class BlueBrinstarEnergyTankRoom : Room
+        {
+            public BlueBrinstarEnergyTankRoom(BlueBrinstar region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Blue Brinstar Energy Tank Room", metadata)
+            {
+                Ceiling = new Location(this, 29, 0x8F879E, LocationType.Hidden,
+                    name: "Energy Tank, Brinstar Ceiling",
+                    vanillaItem: ItemType.ETank,
+                    access: items => items.CardBrinstarL1 && (Logic.CanFly(items) || items.HiJump || items.SpeedBooster || items.Ice),
+                    memoryAddress: 0x3,
+                    memoryFlag: 0x20,
+                    metadata: metadata,
+                    trackerState: trackerState);
+
+                BottomMissile = new Location(this, 34, 0x8F8802, LocationType.Chozo,
+                    name: "Missile (blue Brinstar bottom)",
+                    vanillaItem: ItemType.Missile,
+                    access: items => items.Morph,
+                    memoryAddress: 0x4,
+                    memoryFlag: 0x4,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location Ceiling { get; }
+
+            public Location BottomMissile { get; }
+        }
 
         public class BlueBrinstarTopRoom : Room
         {

--- a/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Brinstar/GreenBrinstar.cs
+++ b/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Brinstar/GreenBrinstar.cs
@@ -11,61 +11,12 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
         public GreenBrinstar(World world, Config config, IMetadataService? metadata, TrackerState? trackerState) : base(world, config, metadata, trackerState)
         {
             Weight = -6;
-
-            PowerBomb = new Location(this, 13, 0x8F84AC, LocationType.Chozo,
-                name: "Power Bomb (green Brinstar bottom)",
-                access: items => items.CardBrinstarL2 && Logic.CanUsePowerBombs(items)
-                              && (Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items)),
-                memoryAddress: 0x1,
-                memoryFlag: 0x20,
-                metadata: metadata,
-                trackerState: trackerState);
-            MissileBelowSuperMissile = new Location(this, 15, 0x8F8518, LocationType.Visible,
-                name: "Missile (green Brinstar below super missile)",
-                vanillaItem: ItemType.Missile,
-                access: items => Logic.CanPassBombPassages(items) && Logic.CanOpenRedDoors(items),
-                memoryAddress: 0x1,
-                memoryFlag: 0x80,
-                metadata: metadata,
-                trackerState: trackerState);
-            TopSuperMissile = new Location(this, 16, 0x8F851E, LocationType.Visible,
-                name: "Super Missile (green Brinstar top)",
-                vanillaItem: ItemType.Super,
-                access: items => Logic.CanOpenRedDoors(items) && Logic.CanMoveAtHighSpeeds(items),
-                memoryAddress: 0x2,
-                memoryFlag: 0x1,
-                metadata: metadata,
-                trackerState: trackerState);
-            ReserveTank = new Location(this, 17, 0x8F852C, LocationType.Chozo,
-                name: "Reserve Tank, Brinstar",
-                vanillaItem: ItemType.ReserveTank,
-                access: items => Logic.CanOpenRedDoors(items) && Logic.CanMoveAtHighSpeeds(items),
-                memoryAddress: 0x2,
-                memoryFlag: 0x2,
-                metadata: metadata,
-                trackerState: trackerState);
-            ETank = new Location(this, 30, 0x8F87C2, LocationType.Visible,
-                name: "Energy Tank, Etecoons",
-                vanillaItem: ItemType.ETank,
-                access: items => items.CardBrinstarL2 && Logic.CanUsePowerBombs(items)
-                              && (Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items)),
-                memoryAddress: 0x3,
-                memoryFlag: 0x40,
-                metadata: metadata,
-                trackerState: trackerState);
-            BottomSuperMissile = new Location(this, 31, 0x8F87D0, LocationType.Visible,
-                name: "Super Missile (green Brinstar bottom)",
-                vanillaItem: ItemType.Super,
-                access: items => items.CardBrinstarL2 && Logic.CanUsePowerBombs(items) && items.Super
-                              && (Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items)),
-                memoryAddress: 0x3,
-                memoryFlag: 0x80,
-                metadata: metadata,
-                trackerState: trackerState);
+            GreenBrinstarMainShaft = new GreenBrinstarMainShaftRoom(this, metadata, trackerState);
+            EtecoonEnergyTank = new EtecoonEnergyTankRoom(this, metadata, trackerState);
+            EtecoonSuper = new EtecoonSuperRoom(this, metadata, trackerState);
+            MockballHall = new MockballHallRoom(this, metadata, trackerState);
             MockballHallHidden = new MockballHallHiddenRoom(this, metadata, trackerState);
-
             MemoryRegionId = 1;
-
             Metadata = metadata?.Region(GetType()) ?? new RegionInfo("Green Brinstar");
         }
 
@@ -73,17 +24,13 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
 
         public override string Area => "Brinstar";
 
-        public Location PowerBomb { get; }
+        public GreenBrinstarMainShaftRoom GreenBrinstarMainShaft { get; }
 
-        public Location MissileBelowSuperMissile { get; }
+        public EtecoonEnergyTankRoom EtecoonEnergyTank { get; }
 
-        public Location TopSuperMissile { get; }
+        public EtecoonSuperRoom EtecoonSuper { get; }
 
-        public Location ReserveTank { get; }
-
-        public Location ETank { get; }
-
-        public Location BottomSuperMissile { get; }
+        public MockballHallRoom MockballHall { get; }
 
         public MockballHallHiddenRoom MockballHallHidden { get; }
 
@@ -92,15 +39,109 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
             return Logic.CanDestroyBombWalls(items) || Logic.CanParlorSpeedBoost(items);
         }
 
+        public class GreenBrinstarMainShaftRoom : Room
+        {
+            public GreenBrinstarMainShaftRoom(GreenBrinstar region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Green Brinstar Main Shaft", metadata)
+            {
+                PowerBomb = new Location(this, 13, 0x8F84AC, LocationType.Chozo,
+                    name: "Power Bomb (green Brinstar bottom)",
+                    access: items => items.CardBrinstarL2 && Logic.CanUsePowerBombs(items)
+                                  && (Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items)),
+                    memoryAddress: 0x1,
+                    memoryFlag: 0x20,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location PowerBomb { get; }
+        }
+
+        public class EtecoonEnergyTankRoom : Room
+        {
+            public EtecoonEnergyTankRoom(GreenBrinstar region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Etecoon Energy Tank Room", metadata)
+            {
+                ETank = new Location(this, 30, 0x8F87C2, LocationType.Visible,
+                    name: "Energy Tank, Etecoons",
+                    vanillaItem: ItemType.ETank,
+                    access: items => items.CardBrinstarL2 && Logic.CanUsePowerBombs(items)
+                                  && (Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items)),
+                    memoryAddress: 0x3,
+                    memoryFlag: 0x40,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location ETank { get; }
+        }
+
+        public class EtecoonSuperRoom : Room
+        {
+            public EtecoonSuperRoom(GreenBrinstar region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Etecon Super Room", metadata)
+            {
+                BottomSuperMissile = new Location(this, 31, 0x8F87D0, LocationType.Visible,
+                    name: "Super Missile (green Brinstar bottom)",
+                    vanillaItem: ItemType.Super,
+                    access: items => items.CardBrinstarL2 && Logic.CanUsePowerBombs(items) && items.Super
+                                  && (Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items)),
+                    memoryAddress: 0x3,
+                    memoryFlag: 0x80,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location BottomSuperMissile { get; }
+        }
+
+        public class MockballHallRoom : Room
+        {
+            public MockballHallRoom(GreenBrinstar region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Mockball Hall", metadata, "Early Supers Room")
+            {
+                MissileBelowSuperMissile = new Location(this, 15, 0x8F8518, LocationType.Visible,
+                    name: "Missile (green Brinstar below super missile)",
+                    vanillaItem: ItemType.Missile,
+                    access: items => Logic.CanPassBombPassages(items) && Logic.CanOpenRedDoors(items),
+                    memoryAddress: 0x1,
+                    memoryFlag: 0x80,
+                    metadata: metadata,
+                    trackerState: trackerState);
+
+                TopSuperMissile = new Location(this, 16, 0x8F851E, LocationType.Visible,
+                    name: "Super Missile (green Brinstar top)",
+                    vanillaItem: ItemType.Super,
+                    access: items => Logic.CanOpenRedDoors(items) && Logic.CanMoveAtHighSpeeds(items),
+                    memoryAddress: 0x2,
+                    memoryFlag: 0x1,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location MissileBelowSuperMissile { get; }
+
+            public Location TopSuperMissile { get; }
+        }
+
         public class MockballHallHiddenRoom : Room
         {
             public MockballHallHiddenRoom(GreenBrinstar region, IMetadataService? metadata, TrackerState? trackerState)
-                : base(region, "Mockball Hall Hidden Room", metadata)
+                : base(region, "Mockball Hall Hidden Room", metadata, "Brinstar Reserve Tank Room")
             {
+                ReserveTank = new Location(this, 17, 0x8F852C, LocationType.Chozo,
+                    name: "Reserve Tank, Brinstar",
+                    vanillaItem: ItemType.ReserveTank,
+                    access: CanEnter,
+                    memoryAddress: 0x2,
+                    memoryFlag: 0x2,
+                    metadata: metadata,
+                    trackerState: trackerState);
+
                 HiddenItem = new Location(this, 18, 0x8F8532, LocationType.Hidden,
                     name: "Hidden Item",
                     vanillaItem: ItemType.Missile,
-                    access: items => Logic.CanMoveAtHighSpeeds(items) && Logic.CanPassBombPassages(items) && Logic.CanOpenRedDoors(items),
+                    access: items => CanEnter(items) && Logic.CanPassBombPassages(items),
                     memoryAddress: 0x2,
                     memoryFlag: 0x4,
                     metadata: metadata,
@@ -109,18 +150,24 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
                 MainItem = new Location(this, 19, 0x8F8538, LocationType.Visible,
                     name: "Main Item",
                     vanillaItem: ItemType.Missile,
-                    access: items => Logic.CanMoveAtHighSpeeds(items) && Logic.CanOpenRedDoors(items) && items.Morph,
+                    access: items => CanEnter(items) && items.Morph,
                     memoryAddress: 0x2,
                     memoryFlag: 0x8,
                     metadata: metadata,
                     trackerState: trackerState);
             }
 
+            public Location ReserveTank { get; }
+
             public Location MainItem { get; }
 
             public Location HiddenItem { get; }
-        }
 
+            public bool CanEnter(Progression items)
+            {
+                return Logic.CanOpenRedDoors(items) && Logic.CanMoveAtHighSpeeds(items);
+            }
+        }
     }
 
 }

--- a/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Brinstar/KraidsLair.cs
+++ b/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Brinstar/KraidsLair.cs
@@ -11,32 +11,9 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
     {
         public KraidsLair(World world, Config config, IMetadataService? metadata, TrackerState? trackerState) : base(world, config, metadata, trackerState)
         {
-            ETank = new Location(this, 43, 0x8F899C, LocationType.Hidden,
-                name: "Energy Tank, Kraid",
-                vanillaItem: ItemType.ETank,
-                access: items => items.Kraid,
-                relevanceRequirement: items => CanBeatBoss(items),
-                memoryAddress: 0x5,
-                memoryFlag: 0x8,
-                metadata: metadata,
-                trackerState: trackerState);
-            KraidsItem = new Location(this, 48, 0x8F8ACA, LocationType.Chozo,
-                name: "Varia Suit",
-                vanillaItem: ItemType.Varia,
-                access: items => items.Kraid,
-                relevanceRequirement: items => CanBeatBoss(items),
-                memoryAddress: 0x6,
-                memoryFlag: 0x1,
-                metadata: metadata,
-                trackerState: trackerState);
-            MissileBeforeKraid = new Location(this, 44, 0x8F89EC, LocationType.Hidden,
-                name: "Missile (Kraid)",
-                vanillaItem: ItemType.Missile,
-                access: items => Logic.CanUsePowerBombs(items),
-                memoryAddress: 0x5,
-                memoryFlag: 0x10,
-                metadata: metadata,
-                trackerState: trackerState);
+            WarehouseEnergyTank = new WarehouseEnergyTankRoom(this, metadata, trackerState);
+            WarehouseKihunter = new WarehouseKihunterRoom(this, metadata, trackerState);
+            VariaSuit = new VariaSuitRoom(this, metadata, trackerState);
             MemoryRegionId = 1;
             Boss = new Boss(Shared.Enums.BossType.Kraid, World, this, metadata, trackerState);
             Metadata = metadata?.Region(GetType()) ?? new RegionInfo("Kraid's Lair");
@@ -53,11 +30,11 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
 
         public Boss Boss{ get; set; }
 
-        public Location ETank { get; }
+        public WarehouseEnergyTankRoom WarehouseEnergyTank { get; }
 
-        public Location KraidsItem { get; }
+        public WarehouseKihunterRoom WarehouseKihunter { get; }
 
-        public Location MissileBeforeKraid { get; }
+        public VariaSuitRoom VariaSuit { get; }
 
         public override bool CanEnter(Progression items, bool requireRewards)
         {
@@ -71,6 +48,60 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
             return CanEnter(items, true) && items.CardBrinstarBoss;
         }
 
-    }
+        public class WarehouseEnergyTankRoom : Room
+        {
+            public WarehouseEnergyTankRoom(KraidsLair region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Warehouse Energy Tank Room", metadata)
+            {
+                    ETank = new Location(this, 43, 0x8F899C, LocationType.Hidden,
+                        name: "Energy Tank, Kraid",
+                        vanillaItem: ItemType.ETank,
+                        access: items => items.Kraid,
+                        relevanceRequirement: items => region.CanBeatBoss(items),
+                        memoryAddress: 0x5,
+                        memoryFlag: 0x8,
+                        metadata: metadata,
+                        trackerState: trackerState);
+            }
 
+            public Location ETank { get; }
+        }
+
+        public class WarehouseKihunterRoom : Room
+        {
+            public WarehouseKihunterRoom(KraidsLair region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Warehouse Kihunter Room", metadata)
+            {
+                MissileBeforeKraid = new Location(this, 44, 0x8F89EC, LocationType.Hidden,
+                    name: "Missile (Kraid)",
+                    vanillaItem: ItemType.Missile,
+                    access: items => Logic.CanUsePowerBombs(items),
+                    memoryAddress: 0x5,
+                    memoryFlag: 0x10,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location MissileBeforeKraid { get; }
+        }
+
+        public class VariaSuitRoom : Room
+        {
+            public VariaSuitRoom(KraidsLair region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Varia Suit Room", metadata)
+            {
+                KraidsItem = new Location(this, 48, 0x8F8ACA, LocationType.Chozo,
+                    name: "Varia Suit",
+                    vanillaItem: ItemType.Varia,
+                    access: items => items.Kraid,
+                    relevanceRequirement: items => region.CanBeatBoss(items),
+                    memoryAddress: 0x6,
+                    memoryFlag: 0x1,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location KraidsItem { get; }
+        }
+    }
 }

--- a/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Brinstar/PinkBrinstar.cs
+++ b/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Brinstar/PinkBrinstar.cs
@@ -11,75 +11,12 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
         public PinkBrinstar(World world, Config config, IMetadataService? metadata, TrackerState? trackerState) : base(world, config, metadata, trackerState)
         {
             Weight = -4;
-            SporeSpawnReward = new Location(this, 14, 0x8F84E4, LocationType.Chozo,
-                name: "Super Missile (pink Brinstar)",
-                vanillaItem: ItemType.Super,
-                access: items => items.CardBrinstarBoss && Logic.CanPassBombPassages(items) && items.Super,
-                memoryAddress: 0x1,
-                memoryFlag: 0x40,
-                metadata: metadata,
-                trackerState: trackerState);
-            PinkShaftTop = new Location(this, 21, 0x8F8608, LocationType.Visible,
-                name: "Missile (pink Brinstar top)",
-                vanillaItem: ItemType.Missile,
-                access: items => items.Grapple || Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items),
-                memoryAddress: 0x2,
-                memoryFlag: 0x20,
-                metadata: metadata,
-                trackerState: trackerState);
-            PinkShaftBottom = new Location(this, 22, 0x8F860E, LocationType.Visible,
-                name: "Missile (pink Brinstar bottom)",
-                vanillaItem: ItemType.Missile,
-                memoryAddress: 0x2,
-                memoryFlag: 0x40,
-                metadata: metadata,
-                trackerState: trackerState);
-            PinkShaftChozo = new Location(this, 23, 0x8F8614, LocationType.Chozo,
-                name: "Charge Beam",
-                vanillaItem: ItemType.Charge,
-                access: items => Logic.CanPassBombPassages(items),
-                memoryAddress: 0x2,
-                memoryFlag: 0x80,
-                metadata: metadata,
-                trackerState: trackerState);
-            MissionImpossible = new Location(this, 24, 0x8F865C, LocationType.Visible,
-                name: "Power Bomb (pink Brinstar)",
-                vanillaItem: ItemType.PowerBomb,
-                access: items => Logic.CanUsePowerBombs(items) && items.Super && Logic.HasEnergyReserves(items, 1)
-                              && (items.Grapple || Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items)),
-                memoryAddress: 0x3,
-                memoryFlag: 0x1,
-                metadata: metadata,
-                trackerState: trackerState);
-            GreenHillZone = new Location(this, 25, 0x8F8676, LocationType.Visible,
-                name: "Missile (green Brinstar pipe)",
-                vanillaItem: ItemType.Missile,
-                access: items => items.Morph
-                              && (items.PowerBomb || items.Super || Logic.CanAccessNorfairUpperPortal(items))
-                              && (items.HiJump || Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items)),
-                memoryAddress: 0x3,
-                memoryFlag: 0x2,
-                metadata: metadata,
-                trackerState: trackerState);
-            Waterway = new Location(this, 33, 0x8F87FA, LocationType.Visible,
-                name: "Energy Tank, Waterway",
-                vanillaItem: ItemType.ETank,
-                access: items => Logic.CanUsePowerBombs(items) && Logic.CanOpenRedDoors(items) && items.SpeedBooster &&
-                        ((Logic.HasEnergyReserves(items, 1) && !World.Config.LogicConfig.WaterwayNeedsGravitySuit) || items.Gravity),
-                memoryAddress: 0x4,
-                memoryFlag: 0x2,
-                metadata: metadata,
-                trackerState: trackerState);
-            WaveBeamGlitchRoom = new Location(this, 35, 0x8F8824, LocationType.Visible,
-                name: "Energy Tank, Brinstar Gate",
-                vanillaItem: ItemType.ETank,
-                access: items => items.CardBrinstarL2 && Logic.CanUsePowerBombs(items)
-                              && items.Wave && Logic.HasEnergyReserves(items, 1)
-                              && (items.Grapple || Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items)),
-                memoryAddress: 0x4,
-                memoryFlag: 0x8,
-                metadata: metadata,
-                trackerState: trackerState);
+            BigPink = new BigPinkRoom(this, metadata, trackerState);
+            PinkBrinstarPowerBomb = new PinkBrinstarPowerBombRoom(this, metadata, trackerState);
+            Hoptank = new HoptankRoom(this, metadata, trackerState);
+            SporeSpawnSuper = new SporeSpawnSuperRoom(this, metadata, trackerState);
+            WaterwayEnergyTank = new WaterwayEnergyTankRoom(this, metadata, trackerState);
+            GreenHillZone = new GreenHillZoneRoom(this, metadata, trackerState);
             MemoryRegionId = 1;
             Metadata = metadata?.Region(GetType()) ?? new RegionInfo("Pink Brinstar");
         }
@@ -88,26 +25,155 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
 
         public override string Area => "Brinstar";
 
-        public Location SporeSpawnReward { get; }
+        public BigPinkRoom BigPink { get; }
 
-        public Location PinkShaftTop { get; }
+        public PinkBrinstarPowerBombRoom PinkBrinstarPowerBomb { get; }
 
-        public Location PinkShaftBottom { get; }
+        public HoptankRoom Hoptank { get; }
 
-        public Location PinkShaftChozo { get; }
+        public SporeSpawnSuperRoom SporeSpawnSuper { get; }
 
-        public Location MissionImpossible { get; }
+        public WaterwayEnergyTankRoom WaterwayEnergyTank { get; }
 
-        public Location GreenHillZone { get; }
-
-        public Location Waterway { get; }
-
-        public Location WaveBeamGlitchRoom { get; }
+        public GreenHillZoneRoom GreenHillZone { get; }
 
         public override bool CanEnter(Progression items, bool requireRewards) =>
                 (Logic.CanOpenRedDoors(items) && (Logic.CanDestroyBombWalls(items) || Logic.CanParlorSpeedBoost(items))) ||
                 Logic.CanUsePowerBombs(items) ||
                 (Logic.CanAccessNorfairUpperPortal(items) && items.Morph && items.Wave &&
                     (items.Ice || items.HiJump || items.SpaceJump));
+
+        public class BigPinkRoom : Room
+        {
+            public BigPinkRoom(PinkBrinstar region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Big Pink", metadata)
+            {
+                PinkShaftTop = new Location(this, 21, 0x8F8608, LocationType.Visible,
+                    name: "Missile (pink Brinstar top)",
+                    vanillaItem: ItemType.Missile,
+                    access: items => items.Grapple || Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items),
+                    memoryAddress: 0x2,
+                    memoryFlag: 0x20,
+                    metadata: metadata,
+                    trackerState: trackerState);
+                PinkShaftBottom = new Location(this, 22, 0x8F860E, LocationType.Visible,
+                    name: "Missile (pink Brinstar bottom)",
+                    vanillaItem: ItemType.Missile,
+                    memoryAddress: 0x2,
+                    memoryFlag: 0x40,
+                    metadata: metadata,
+                    trackerState: trackerState);
+                PinkShaftChozo = new Location(this, 23, 0x8F8614, LocationType.Chozo,
+                    name: "Charge Beam",
+                    vanillaItem: ItemType.Charge,
+                    access: items => Logic.CanPassBombPassages(items),
+                    memoryAddress: 0x2,
+                    memoryFlag: 0x80,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location PinkShaftTop { get; }
+
+            public Location PinkShaftBottom { get; }
+
+            public Location PinkShaftChozo { get; }
+        }
+
+        public class PinkBrinstarPowerBombRoom : Room
+        {
+            public PinkBrinstarPowerBombRoom(PinkBrinstar region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Pink Brinstar Power Bomb Room", metadata)
+            {
+                MissionImpossible = new Location(this, 24, 0x8F865C, LocationType.Visible,
+                    name: "Power Bomb (pink Brinstar)",
+                    vanillaItem: ItemType.PowerBomb,
+                    access: items => Logic.CanUsePowerBombs(items) && items.Super && Logic.HasEnergyReserves(items, 1)
+                                  && (items.Grapple || Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items)),
+                    memoryAddress: 0x3,
+                    memoryFlag: 0x1,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location MissionImpossible { get; }
+        }
+
+        public class HoptankRoom : Room
+        {
+            public HoptankRoom(PinkBrinstar region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Hoptank Room", metadata)
+            {
+                WaveBeamGlitchRoom = new Location(this, 35, 0x8F8824, LocationType.Visible,
+                    name: "Energy Tank, Brinstar Gate",
+                    vanillaItem: ItemType.ETank,
+                    access: items => items.CardBrinstarL2 && Logic.CanUsePowerBombs(items)
+                                  && items.Wave && Logic.HasEnergyReserves(items, 1)
+                                  && (items.Grapple || Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items)),
+                    memoryAddress: 0x4,
+                    memoryFlag: 0x8,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location WaveBeamGlitchRoom { get; }
+        }
+
+        public class SporeSpawnSuperRoom : Room
+        {
+            public SporeSpawnSuperRoom(PinkBrinstar region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Spore Spawn Super Room", metadata)
+            {
+                SporeSpawnReward = new Location(this, 14, 0x8F84E4, LocationType.Chozo,
+                    name: "Super Missile (pink Brinstar)",
+                    vanillaItem: ItemType.Super,
+                    access: items => items.CardBrinstarBoss && Logic.CanPassBombPassages(items) && items.Super,
+                    memoryAddress: 0x1,
+                    memoryFlag: 0x40,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location SporeSpawnReward { get; }
+        }
+
+        public class WaterwayEnergyTankRoom : Room
+        {
+            public WaterwayEnergyTankRoom(PinkBrinstar region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Waterway Energy Tank Room", metadata)
+            {
+                Waterway = new Location(this, 33, 0x8F87FA, LocationType.Visible,
+                    name: "Energy Tank, Waterway",
+                    vanillaItem: ItemType.ETank,
+                    access: items => Logic.CanUsePowerBombs(items) && Logic.CanOpenRedDoors(items) && items.SpeedBooster &&
+                            ((Logic.HasEnergyReserves(items, 1) && !World.Config.LogicConfig.WaterwayNeedsGravitySuit) || items.Gravity),
+                    memoryAddress: 0x4,
+                    memoryFlag: 0x2,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location Waterway { get; }
+        }
+
+        public class GreenHillZoneRoom : Room
+        {
+            public GreenHillZoneRoom(PinkBrinstar region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Green Hill Zone", metadata)
+            {
+                GreenHillZone = new Location(this, 25, 0x8F8676, LocationType.Visible,
+                    name: "Missile (green Brinstar pipe)",
+                    vanillaItem: ItemType.Missile,
+                    access: items => items.Morph
+                                  && (items.PowerBomb || items.Super || Logic.CanAccessNorfairUpperPortal(items))
+                                  && (items.HiJump || Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items)),
+                    memoryAddress: 0x3,
+                    memoryFlag: 0x2,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location GreenHillZone { get; }
+        }
     }
 }

--- a/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Brinstar/RedBrinstar.cs
+++ b/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Brinstar/RedBrinstar.cs
@@ -12,47 +12,10 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
         {
             // TODO: some of these might expect you to have wall jump, but I'm not sure which or how
 
-            XRayScopeRoom = new Location(this, 38, 0x8F8876, LocationType.Chozo,
-                name: "X-Ray Scope",
-                vanillaItem: ItemType.XRay,
-                access: items => Logic.CanUsePowerBombs(items) && Logic.CanOpenRedDoors(items) && (items.Grapple || items.SpaceJump),
-                memoryAddress: 0x4,
-                memoryFlag: 0x40,
-                metadata: metadata,
-                trackerState: trackerState);
-            BetaPowerBombRoom = new Location(this, 39, 0x8F88CA, LocationType.Visible,
-                name: "Power Bomb (red Brinstar sidehopper room)",
-                vanillaItem: ItemType.PowerBomb,
-                access: items => Logic.CanUsePowerBombs(items) && items.Super,
-                memoryAddress: 0x4,
-                memoryFlag: 0x80,
-                metadata: metadata,
-                trackerState: trackerState);
-            AlphaPowerBombRoom = new Location(this, 40, 0x8F890E, LocationType.Chozo,
-                name: "Power Bomb (red Brinstar spike room)",
-                vanillaItem: ItemType.PowerBomb,
-                access: items => (Logic.CanUsePowerBombs(items) || items.Ice) && items.Super,
-                memoryAddress: 0x5,
-                memoryFlag: 0x1,
-                metadata: metadata,
-                trackerState: trackerState);
-            AlphaPowerBombRoomWall = new Location(this, 41, 0x8F8914, LocationType.Visible,
-                name: "Missile (red Brinstar spike room)",
-                vanillaItem: ItemType.Missile,
-                access: items => Logic.CanUsePowerBombs(items) && items.Super,
-                memoryAddress: 0x5,
-                memoryFlag: 0x2,
-                metadata: metadata,
-                trackerState: trackerState);
-            SpazerRoom = new Location(this, 42, 0x8F896E, LocationType.Chozo,
-                name: "Spazer",
-                vanillaItem: ItemType.Spazer,
-                access: items => Logic.CanPassBombPassages(items) && items.Super
-                              && (items.HiJump || Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items)),
-                memoryAddress: 0x5,
-                memoryFlag: 0x4,
-                metadata: metadata,
-                trackerState: trackerState);
+            XRayScope = new XRayScopeRoom(this, metadata, trackerState);
+            BetaPowerBomb = new BetaPowerBombRoom(this, metadata, trackerState);
+            AlphaPowerBomb = new AlphaPowerBombRoom(this, metadata, trackerState);
+            Spazer = new SpazerRoom(this, metadata, trackerState);
             MemoryRegionId = 1;
             Metadata = metadata?.Region(GetType()) ?? new RegionInfo("Red Brinstar");
         }
@@ -61,15 +24,13 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
 
         public override string Area => "Brinstar";
 
-        public Location XRayScopeRoom { get; }
+        public XRayScopeRoom XRayScope { get; }
 
-        public Location BetaPowerBombRoom { get; }
+        public BetaPowerBombRoom BetaPowerBomb { get; }
 
-        public Location AlphaPowerBombRoom { get; }
+        public AlphaPowerBombRoom AlphaPowerBomb { get; }
 
-        public Location AlphaPowerBombRoomWall { get; }
-
-        public Location SpazerRoom { get; }
+        public SpazerRoom Spazer { get; }
 
         public override bool CanEnter(Progression items, bool requireRewards) =>
                     ((Logic.CanDestroyBombWalls(items) || items.SpeedBooster)
@@ -77,6 +38,87 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
                      && items.Morph) ||
                     (Logic.CanAccessNorfairUpperPortal(items) && (items.Ice || items.HiJump || items.SpaceJump));
 
-    }
+        public class XRayScopeRoom : Room
+        {
+            public XRayScopeRoom(RedBrinstar region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "X-Ray Scope Room", metadata)
+            {
+                XRayScope = new Location(this, 38, 0x8F8876, LocationType.Chozo,
+                    name: "X-Ray Scope",
+                    vanillaItem: ItemType.XRay,
+                    access: items => Logic.CanUsePowerBombs(items) && Logic.CanOpenRedDoors(items) && (items.Grapple || items.SpaceJump),
+                    memoryAddress: 0x4,
+                    memoryFlag: 0x40,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
 
+            public Location XRayScope { get; }
+        }
+
+        public class BetaPowerBombRoom : Room
+        {
+            public BetaPowerBombRoom(RedBrinstar region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Beta Power Bomb Room", metadata)
+            {
+                PowerBomb = new Location(this, 39, 0x8F88CA, LocationType.Visible,
+                    name: "Power Bomb (red Brinstar sidehopper room)",
+                    vanillaItem: ItemType.PowerBomb,
+                    access: items => Logic.CanUsePowerBombs(items) && items.Super,
+                    memoryAddress: 0x4,
+                    memoryFlag: 0x80,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location PowerBomb { get; }
+        }
+
+        public class AlphaPowerBombRoom : Room
+        {
+            public AlphaPowerBombRoom(RedBrinstar region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Alpha Power Bomb Room", metadata)
+            {
+                PowerBomb = new Location(this, 40, 0x8F890E, LocationType.Chozo,
+                    name: "Power Bomb (red Brinstar spike room)",
+                    vanillaItem: ItemType.PowerBomb,
+                    access: items => (Logic.CanUsePowerBombs(items) || items.Ice) && items.Super,
+                    memoryAddress: 0x5,
+                    memoryFlag: 0x1,
+                    metadata: metadata,
+                    trackerState: trackerState);
+                AlphaPowerBombRoomWall = new Location(this, 41, 0x8F8914, LocationType.Visible,
+                    name: "Missile (red Brinstar spike room)",
+                    vanillaItem: ItemType.Missile,
+                    access: items => Logic.CanUsePowerBombs(items) && items.Super,
+                    memoryAddress: 0x5,
+                    memoryFlag: 0x2,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location PowerBomb { get; }
+
+            public Location AlphaPowerBombRoomWall { get; }
+        }
+
+        public class SpazerRoom : Room
+        {
+            public SpazerRoom(RedBrinstar region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Spazer Room", metadata)
+            {
+                Spazer = new Location(this, 42, 0x8F896E, LocationType.Chozo,
+                    name: "Spazer",
+                    vanillaItem: ItemType.Spazer,
+                    access: items => Logic.CanPassBombPassages(items) && items.Super
+                                  && (items.HiJump || Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items)),
+                    memoryAddress: 0x5,
+                    memoryFlag: 0x4,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location Spazer { get; }
+        }
+    }
 }

--- a/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Crateria/CentralCrateria.cs
+++ b/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Crateria/CentralCrateria.cs
@@ -13,47 +13,11 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Crateria
         public CentralCrateria(World world, Config config, IMetadataService? metadata, TrackerState? trackerState)
             : base(world, config, metadata, trackerState)
         {
-            PowerBombRoom = new Location(this, 0, 0x8F81CC, LocationType.Visible,
-                name: "Power Bomb (Crateria surface)",
-                vanillaItem: ItemType.PowerBomb,
-                access: items => (Config.MetroidKeysanity ? items.CardCrateriaL1 : Logic.CanUsePowerBombs(items)) && (items.SpeedBooster || Logic.CanFly(items)),
-                memoryAddress: 0x0,
-                memoryFlag: 0x1,
-                metadata: metadata,
-                trackerState: trackerState);
-            FinalMissileBombWay = new Location(this, 12, 0x8F8486, LocationType.Visible,
-                name: "Missile (Crateria middle)",
-                vanillaItem: ItemType.Missile,
-                access: items => Logic.CanPassBombPassages(items),
-                memoryAddress: 0x1,
-                memoryFlag: 0x10,
-                metadata: metadata,
-                trackerState: trackerState);
-            MotherBrainTreasure = new Location(this, 6, 0x8F83EE, LocationType.Visible,
-                name: "Missile (Crateria bottom)",
-                vanillaItem: ItemType.Missile,
-                access: items => Logic.CanDestroyBombWalls(items),
-                memoryAddress: 0x0,
-                memoryFlag: 0x40,
-                metadata: metadata,
-                trackerState: trackerState);
-            SuperMissile = new Location(this, 11, 0x8F8478, LocationType.Visible,
-                name: "Super Missile (Crateria)",
-                vanillaItem: ItemType.Super,
-                access: items => Logic.CanUsePowerBombs(items) && Logic.HasEnergyReserves(items, 2) && items.SpeedBooster && (!World.Config.LogicConfig.LaunchPadRequiresIceBeam || items.Ice),
-                memoryAddress: 0x1,
-                memoryFlag: 0x8,
-                metadata: metadata,
-                trackerState: trackerState);
-            BombTorizo = new Location(this, 7, 0x8F8404, LocationType.Chozo,
-                name: "Bombs",
-                vanillaItem: ItemType.Bombs,
-                access: items => (Config.MetroidKeysanity ? items.CardCrateriaBoss : Logic.CanOpenRedDoors(items))
-                                 && (Logic.CanPassBombPassages(items) || Logic.CanWallJump(WallJumpDifficulty.Hard)),
-                memoryAddress: 0x0,
-                memoryFlag: 0x80,
-                metadata: metadata,
-                trackerState: trackerState);
+            PowerBomb = new PowerBombRoom(this, metadata, trackerState);
+            TheFinalMissile = new TheFinalMissileRoom(this, metadata, trackerState);
+            Pit = new PitRoom(this, metadata, trackerState);
+            CrateriaSuper = new CrateriaSuperRoom(this, metadata, trackerState);
+            BombTorizo = new BombTorizoRoom(this, metadata, trackerState);
             MemoryRegionId = 0;
             Metadata = metadata?.Region(GetType()) ?? new RegionInfo("Central Crateria");
         }
@@ -62,14 +26,105 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Crateria
 
         public override string Area => "Crateria";
 
-        public Location PowerBombRoom { get; }
+        public PowerBombRoom PowerBomb { get; }
 
-        public Location FinalMissileBombWay { get; }
+        public TheFinalMissileRoom TheFinalMissile { get; }
 
-        public Location MotherBrainTreasure { get; }
+        public PitRoom Pit { get; }
 
-        public Location SuperMissile { get; }
+        public CrateriaSuperRoom CrateriaSuper { get; }
 
-        public Location BombTorizo { get; }
+        public BombTorizoRoom BombTorizo { get; }
+
+        public class PowerBombRoom : Room
+        {
+            public PowerBombRoom(CentralCrateria region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Crateria Power Bomb Room", metadata)
+            {
+                PowerBomb = new Location(this, 0, 0x8F81CC, LocationType.Visible,
+                    name: "Power Bomb (Crateria surface)",
+                    vanillaItem: ItemType.PowerBomb,
+                    access: items => (Config.MetroidKeysanity ? items.CardCrateriaL1 : Logic.CanUsePowerBombs(items)) && (items.SpeedBooster || Logic.CanFly(items)),
+                    memoryAddress: 0x0,
+                    memoryFlag: 0x1,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location PowerBomb { get; }
+        }
+
+        public class TheFinalMissileRoom : Room
+        {
+            public TheFinalMissileRoom(CentralCrateria region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "The Final Missile Room", metadata)
+            {
+                FinalMissileBombWay = new Location(this, 12, 0x8F8486, LocationType.Visible,
+                    name: "Missile (Crateria middle)",
+                    vanillaItem: ItemType.Missile,
+                    access: items => Logic.CanPassBombPassages(items),
+                    memoryAddress: 0x1,
+                    memoryFlag: 0x10,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location FinalMissileBombWay { get; }
+        }
+
+        public class PitRoom : Room
+        {
+            public PitRoom(CentralCrateria region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Pit Room", metadata)
+            {
+                MotherBrainTreasure = new Location(this, 6, 0x8F83EE, LocationType.Visible,
+                    name: "Missile (Crateria bottom)",
+                    vanillaItem: ItemType.Missile,
+                    access: items => Logic.CanDestroyBombWalls(items),
+                    memoryAddress: 0x0,
+                    memoryFlag: 0x40,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location MotherBrainTreasure { get; }
+        }
+
+        public class CrateriaSuperRoom : Room
+        {
+            public CrateriaSuperRoom(CentralCrateria region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Crateria Super Room", metadata)
+            {
+                SuperMissile = new Location(this, 11, 0x8F8478, LocationType.Visible,
+                    name: "Super Missile (Crateria)",
+                    vanillaItem: ItemType.Super,
+                    access: items => Logic.CanUsePowerBombs(items) && Logic.HasEnergyReserves(items, 2) && items.SpeedBooster && (!World.Config.LogicConfig.LaunchPadRequiresIceBeam || items.Ice),
+                    memoryAddress: 0x1,
+                    memoryFlag: 0x8,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location SuperMissile { get; }
+        }
+
+        public class BombTorizoRoom : Room
+        {
+            public BombTorizoRoom(CentralCrateria region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Bomb Torizo Room", metadata)
+            {
+                BombTorizo = new Location(this, 7, 0x8F8404, LocationType.Chozo,
+                    name: "Bombs",
+                    vanillaItem: ItemType.Bombs,
+                    access: items => (Config.MetroidKeysanity ? items.CardCrateriaBoss : Logic.CanOpenRedDoors(items))
+                                     && (Logic.CanPassBombPassages(items) || Logic.CanWallJump(WallJumpDifficulty.Hard)),
+                    memoryAddress: 0x0,
+                    memoryFlag: 0x80,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location BombTorizo { get; }
+        }
     }
 }

--- a/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Crateria/EastCrateria.cs
+++ b/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Crateria/EastCrateria.cs
@@ -10,40 +10,8 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Crateria
     {
         public EastCrateria(World world, Config config, IMetadataService? metadata, TrackerState? trackerState) : base(world, config, metadata, trackerState)
         {
-            FloodedCavernUnderWater = new Location(this, 1, 0x8F81E8, LocationType.Visible,
-                name: "Missile (outside Wrecked Ship bottom)",
-                vanillaItem: ItemType.Missile,
-                access: items => CanAccessFloodedCavernUnderWater(items, true),
-                relevanceRequirement: items => CanAccessFloodedCavernUnderWater(items, false),
-                memoryAddress: 0x0,
-                memoryFlag: 0x2,
-                metadata: metadata,
-                trackerState: trackerState);
-            SkyMissile = new Location(this, 2, 0x8F81EE, LocationType.Hidden,
-                name: "Missile (outside Wrecked Ship top)",
-                vanillaItem: ItemType.Missile,
-                access: items => CanAccessSkyItem(items, true),
-                relevanceRequirement: items => CanAccessSkyItem(items, false),
-                memoryAddress: 0x0,
-                memoryFlag: 0x4,
-                metadata: metadata,
-                trackerState: trackerState);
-            MorphBallMaze = new Location(this, 3, 0x8F81F4, LocationType.Visible,
-                name: "Missile (outside Wrecked Ship middle)",
-                vanillaItem: ItemType.Missile,
-                access: items => CanPassThroughWreckedShip(items, true),
-                relevanceRequirement: items => CanPassThroughWreckedShip(items, false),
-                memoryAddress: 0x0,
-                memoryFlag: 0x8,
-                metadata: metadata,
-                trackerState: trackerState);
-            Moat = new Location(this, 4, 0x8F8248, LocationType.Visible,
-                name: "Missile (Crateria moat)",
-                vanillaItem: ItemType.Missile,
-                memoryAddress: 0x0,
-                memoryFlag: 0x10,
-                metadata: metadata,
-                trackerState: trackerState);
+            WestOcean = new WestOceanRoom(this, metadata, trackerState);
+            TheMoat = new TheMoatRoom(this, metadata, trackerState);
             MemoryRegionId = 0;
             Metadata = metadata?.Region(GetType()) ?? new RegionInfo("East Crateria");
         }
@@ -52,27 +20,9 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Crateria
 
         public override string Area => "Crateria";
 
-        public Location FloodedCavernUnderWater { get; }
+        public WestOceanRoom WestOcean { get; }
 
-        public Location SkyMissile { get; }
-
-        public Location MorphBallMaze { get; }
-
-        public Location Moat { get; }
-
-        private bool CanAccessFloodedCavernUnderWater(Progression items, bool requireRewards)
-            => items.Morph && (
-                Logic.CanMoatSpeedBoost(items)
-                || items.Grapple
-                || items.SpaceJump
-                || (items.Gravity && (Logic.CanIbj(items) || items.HiJump))
-                || World.WreckedShip.CanEnter(items, true));
-
-        private bool CanPassThroughWreckedShip(Progression items, bool requireRewards)
-            => World.WreckedShip.CanEnter(items, requireRewards) && World.WreckedShip.CanAccessShutDownRooms(items, requireRewards);
-
-        private bool CanAccessSkyItem(Progression items, bool requireRewards)
-            => CanPassThroughWreckedShip(items, requireRewards) && (items.SpaceJump || items.SpeedBooster || !Config.LogicConfig.EasyEastCrateriaSkyItem);
+        public TheMoatRoom TheMoat { get; }
 
         public override bool CanEnter(Progression items, bool requireRewards)
         {
@@ -87,9 +37,81 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Crateria
                         /* Oasis -> Forgotten Highway */
                         (items.CardMaridiaL2 && Logic.CanDestroyBombWalls(items)) ||
                         /* Draygon -> Cactus Alley -> Forgotten Highway */
-                        World.InnerMaridia.DraygonTreasure.IsAvailable(items))) ||
+                        World.InnerMaridia.SpaceJump.DraygonTreasure.IsAvailable(items))) ||
                     /*Through Maridia from Pipe*/
                     (Logic.CanUsePowerBombs(items) && items.Super && items.Gravity);
+        }
+
+        public class WestOceanRoom : Room
+        {
+            public WestOceanRoom(EastCrateria region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "West Ocean", metadata)
+            {
+                FloodedCavernUnderWater = new Location(this, 1, 0x8F81E8, LocationType.Visible,
+                    name: "Missile (outside Wrecked Ship bottom)",
+                    vanillaItem: ItemType.Missile,
+                    access: items => CanAccessFloodedCavernUnderWater(items, true),
+                    relevanceRequirement: items => CanAccessFloodedCavernUnderWater(items, false),
+                    memoryAddress: 0x0,
+                    memoryFlag: 0x2,
+                    metadata: metadata,
+                    trackerState: trackerState);
+                SkyMissile = new Location(this, 2, 0x8F81EE, LocationType.Hidden,
+                    name: "Missile (outside Wrecked Ship top)",
+                    vanillaItem: ItemType.Missile,
+                    access: items => CanAccessSkyItem(items, true),
+                    relevanceRequirement: items => CanAccessSkyItem(items, false),
+                    memoryAddress: 0x0,
+                    memoryFlag: 0x4,
+                    metadata: metadata,
+                    trackerState: trackerState);
+                MorphBallMaze = new Location(this, 3, 0x8F81F4, LocationType.Visible,
+                    name: "Missile (outside Wrecked Ship middle)",
+                    vanillaItem: ItemType.Missile,
+                    access: items => CanPassThroughWreckedShip(items, true),
+                    relevanceRequirement: items => CanPassThroughWreckedShip(items, false),
+                    memoryAddress: 0x0,
+                    memoryFlag: 0x8,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location FloodedCavernUnderWater { get; }
+
+            public Location SkyMissile { get; }
+
+            public Location MorphBallMaze { get; }
+
+            private bool CanAccessFloodedCavernUnderWater(Progression items, bool requireRewards)
+                => items.Morph && (
+                    Logic.CanMoatSpeedBoost(items)
+                    || items.Grapple
+                    || items.SpaceJump
+                    || (items.Gravity && (Logic.CanIbj(items) || items.HiJump))
+                    || World.WreckedShip.CanEnter(items, true));
+
+            private bool CanPassThroughWreckedShip(Progression items, bool requireRewards)
+                => World.WreckedShip.CanEnter(items, requireRewards) && World.WreckedShip.CanAccessShutDownRooms(items, requireRewards);
+
+            private bool CanAccessSkyItem(Progression items, bool requireRewards)
+                => CanPassThroughWreckedShip(items, requireRewards) && (items.SpaceJump || items.SpeedBooster || !Config.LogicConfig.EasyEastCrateriaSkyItem);
+        }
+
+        public class TheMoatRoom : Room
+        {
+            public TheMoatRoom(EastCrateria region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "The Moat", metadata)
+            {
+                Moat = new Location(this, 4, 0x8F8248, LocationType.Visible,
+                    name: "Missile (Crateria moat)",
+                    vanillaItem: ItemType.Missile,
+                    memoryAddress: 0x0,
+                    memoryFlag: 0x10,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location Moat { get; }
         }
     }
 }

--- a/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Crateria/WestCrateria.cs
+++ b/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Crateria/WestCrateria.cs
@@ -10,22 +10,9 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Crateria
     {
         public WestCrateria(World world, Config config, IMetadataService? metadata, TrackerState? trackerState) : base(world, config, metadata, trackerState)
         {
-            Terminator = new Location(this, 8, 0x8F8432, LocationType.Visible,
-                name: "Energy Tank, Terminator",
-                vanillaItem: ItemType.ETank,
-                memoryAddress: 0x1,
-                memoryFlag: 0x1,
-                metadata: metadata,
-                trackerState: trackerState);
-            Gauntlet = new Location(this, 5, 0x8F8264, LocationType.Visible,
-                name: "Energy Tank, Gauntlet",
-                vanillaItem: ItemType.ETank,
-                access: items => CanEnterAndLeaveGauntlet(items) && Logic.HasEnergyReserves(items, 1),
-                memoryAddress: 0x0,
-                memoryFlag: 0x20,
-                metadata: metadata,
-                trackerState: trackerState);
             GauntletShaft = new GauntletShaftRoom(this, metadata, trackerState);
+            GauntletEnergyTank = new GauntletEnergyTankRoom(this, metadata, trackerState);
+            Terminator = new TerminatorRoom(this, metadata, trackerState);
             MemoryRegionId = 0;
             Metadata = metadata?.Region(GetType()) ?? new RegionInfo("West Crateria");
         }
@@ -34,11 +21,11 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Crateria
 
         public override string Area => "Crateria";
 
-        public Location Terminator { get; }
-
-        public Location Gauntlet { get; }
-
         public GauntletShaftRoom GauntletShaft { get; }
+
+        public GauntletEnergyTankRoom GauntletEnergyTank { get; }
+
+        public TerminatorRoom Terminator { get; }
 
         public override bool CanEnter(Progression items, bool requireRewards)
         {
@@ -83,6 +70,39 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Crateria
             public Location GauntletLeft { get; }
         }
 
-    }
+        public class GauntletEnergyTankRoom : Room
+        {
+            public GauntletEnergyTankRoom(WestCrateria region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Gauntlet Energy Tank Room", metadata)
+            {
+                Gauntlet = new Location(this, 5, 0x8F8264, LocationType.Visible,
+                    name: "Energy Tank, Gauntlet",
+                    vanillaItem: ItemType.ETank,
+                    access: items => region.CanEnterAndLeaveGauntlet(items) && Logic.HasEnergyReserves(items, 1),
+                    memoryAddress: 0x0,
+                    memoryFlag: 0x20,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
 
+            public Location Gauntlet { get; }
+        }
+
+        public class TerminatorRoom : Room
+        {
+            public TerminatorRoom(WestCrateria region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Terminator Room", metadata)
+            {
+                Terminator = new Location(this, 8, 0x8F8432, LocationType.Visible,
+                    name: "Energy Tank, Terminator",
+                    vanillaItem: ItemType.ETank,
+                    memoryAddress: 0x1,
+                    memoryFlag: 0x1,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location Terminator { get; }
+        }
+    }
 }

--- a/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Maridia/InnerMaridia.cs
+++ b/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Maridia/InnerMaridia.cs
@@ -11,103 +11,16 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Maridia
     {
         public InnerMaridia(World world, Config config, IMetadataService? metadata, TrackerState? trackerState) : base(world, config, metadata, trackerState)
         {
-            PseudoSparkRoom = new Location(this, 142, 0x8FC533, LocationType.Visible,
-                name: "Missile (yellow Maridia false wall)",
-                vanillaItem: ItemType.Missile,
-                access: items => items.CardMaridiaL1 && Logic.CanPassBombPassages(items) && CanPassPipeCrossroads(items) && CanReachAqueduct(items, Logic, true),
-                relevanceRequirement: items => items.CardMaridiaL1 && Logic.CanPassBombPassages(items) && CanPassPipeCrossroads(items) && CanReachAqueduct(items, Logic, false),
-                memoryAddress: 0x11,
-                memoryFlag: 0x40,
-                metadata: metadata,
-                trackerState: trackerState);
-            PlasmaBeamRoom = new Location(this, 143, 0x8FC559, LocationType.Chozo,
-                name: "Plasma Beam",
-                vanillaItem: ItemType.Plasma,
-                access: items => CanAccessPlasmaBeamRoom(items, requireRewards: true),
-                relevanceRequirement: items => CanAccessPlasmaBeamRoom(items, requireRewards: false),
-                memoryAddress: 0x11,
-                memoryFlag: 0x80,
-                metadata: metadata,
-                trackerState: trackerState);
-            RightSandPitLeft = new Location(this, 146, 0x8FC5EB, LocationType.Visible,
-                name: "Missile (right Maridia sand pit room)",
-                vanillaItem: ItemType.Missile,
-                access: items => CanReachRightSandPit(items, true),
-                relevanceRequirement: items => CanReachRightSandPit(items, false),
-                memoryAddress: 0x12,
-                memoryFlag: 0x4,
-                metadata: metadata,
-                trackerState: trackerState);
-            RightSandPitRight = new Location(this, 147, 0x8FC5F1, LocationType.Visible,
-                name: "Power Bomb (right Maridia sand pit room)",
-                vanillaItem: ItemType.PowerBomb,
-                access: items => CanReachRightSandPit(items, true),
-                relevanceRequirement: items => CanReachRightSandPit(items, false),
-                memoryAddress: 0x12,
-                memoryFlag: 0x8,
-                metadata: metadata,
-                trackerState: trackerState);
-            AqueductLeft = new Location(this, 148, 0x8FC603, LocationType.Visible,
-                name: "Missile (pink Maridia)",
-                vanillaItem: ItemType.Missile,
-                access: items => CanReachAqueduct(items, Logic, true) && items.SpeedBooster,
-                relevanceRequirement: items => CanReachAqueduct(items, Logic, false) && items.SpeedBooster,
-                memoryAddress: 0x12,
-                memoryFlag: 0x10,
-                metadata: metadata,
-                trackerState: trackerState);
-            AqueductRight = new Location(this, 149, 0x8FC609, LocationType.Visible,
-                name: "Super Missile (pink Maridia)",
-                vanillaItem: ItemType.Super,
-                access: items => CanReachAqueduct(items, Logic, true) && items.SpeedBooster,
-                relevanceRequirement: items => CanReachAqueduct(items, Logic, false) && items.SpeedBooster,
-                memoryAddress: 0x12,
-                memoryFlag: 0x20,
-                metadata: metadata,
-                trackerState: trackerState);
-            ShaktoolItem = new Location(this, 150, 0x8FC6E5, LocationType.Chozo,
-                name: "Spring Ball",
-                vanillaItem: ItemType.SpringBall,
-                access: items => items.Super && Logic.CanUsePowerBombs(items) && items.Grapple
-                              && (items.SpaceJump || (items.HiJump && Logic.CanWallJump(WallJumpDifficulty.Medium)))
-                              && (Logic.CanWallJump(WallJumpDifficulty.Medium) || items.SpringBall || items.SpaceJump), // Leaving again
-                memoryAddress: 0x12,
-                memoryFlag: 0x40,
-                metadata: metadata,
-                trackerState: trackerState);
-            PreDraygonRoom = new Location(this, 151, 0x8FC74D, LocationType.Hidden,
-                name: "Missile (Draygon)",
-                vanillaItem: ItemType.Missile,
-                access: items => CanAccessPreciousRoom(items, true),
-                relevanceRequirement: items => CanAccessPreciousRoom(items, false),
-                memoryAddress: 0x12,
-                memoryFlag: 0x80,
-                metadata: metadata,
-                trackerState: trackerState);
-            Botwoon = new Location(this, 152, 0x8FC755, LocationType.Visible,
-                name: "Energy Tank, Botwoon",
-                vanillaItem: ItemType.ETank,
-                access: items => (items.CardMaridiaL1 && items.CardMaridiaL2 && CanDefeatBotwoon(items, true))
-                                  || (Logic.CanAccessMaridiaPortal(items, requireRewards: true) && items.CardMaridiaL2),
-                relevanceRequirement: items => (items.CardMaridiaL1 && items.CardMaridiaL2 && CanDefeatBotwoon(items, false))
-                                  || (Logic.CanAccessMaridiaPortal(items, requireRewards: false) && items.CardMaridiaL2),
-                memoryAddress: 0x13,
-                memoryFlag: 0x1,
-                metadata: metadata,
-                trackerState: trackerState);
-            DraygonTreasure = new Location(this, 154, 0x8FC7A7, LocationType.Chozo,
-                name: "Space Jump",
-                vanillaItem: ItemType.SpaceJump,
-                access: items => items.Draygon,
-                relevanceRequirement: items => CanDefeatDraygon(items, false),
-                memoryAddress: 0x13,
-                memoryFlag: 0x4,
-                metadata: metadata,
-                trackerState: trackerState);
-
             WateringHole = new WateringHoleRoom(this, metadata, trackerState);
+            PseudoPlasmaSpark = new PseudoPlasmaSparkRoom(this, metadata, trackerState);
+            Plasma = new PlasmaRoom(this, metadata, trackerState);
             LeftSandPit = new LeftSandPitRoom(this, metadata, trackerState);
-
+            RightSandPit = new RightSandPitRoom(this, metadata, trackerState);
+            Aqueduct = new AqueductRoom(this, metadata, trackerState);
+            SpringBall = new SpringBallRoom(this, metadata, trackerState);
+            ThePrecious = new ThePreciousRoom(this, metadata, trackerState);
+            Botwoons = new BotwoonsRoom(this, metadata, trackerState);
+            SpaceJump = new SpaceJumpRoom(this, metadata, trackerState);
             MemoryRegionId = 4;
             Boss = new Boss(Shared.Enums.BossType.Draygon, world, this, metadata, trackerState);
             Metadata = metadata?.Region(GetType()) ?? new RegionInfo("Inner Maridia");
@@ -119,29 +32,25 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Maridia
 
         public Boss Boss{ get; set; }
 
-        public Location PseudoSparkRoom { get; }
-
-        public Location PlasmaBeamRoom { get; }
-
-        public Location RightSandPitLeft { get; }
-
-        public Location RightSandPitRight { get; }
-
-        public Location AqueductLeft { get; }
-
-        public Location AqueductRight { get; }
-
-        public Location ShaktoolItem { get; }
-
-        public Location PreDraygonRoom { get; }
-
-        public Location Botwoon { get; }
-
-        public Location DraygonTreasure { get; }
-
         public WateringHoleRoom WateringHole { get; }
 
+        public PseudoPlasmaSparkRoom PseudoPlasmaSpark { get; }
+
+        public PlasmaRoom Plasma { get; }
+
         public LeftSandPitRoom LeftSandPit { get; }
+
+        public RightSandPitRoom RightSandPit { get; }
+
+        public AqueductRoom Aqueduct { get; }
+
+        public SpringBallRoom SpringBall { get; }
+
+        public ThePreciousRoom ThePrecious { get; }
+
+        public BotwoonsRoom Botwoons { get; }
+
+        public SpaceJumpRoom SpaceJump { get; }
 
         public override bool CanEnter(Progression items, bool requireRewards)
             => items.Gravity && (
@@ -164,9 +73,9 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Maridia
             => CanAccessPreciousRoom(items, requireRewards) && items.CardMaridiaBoss;
 
         private bool CanDefeatDraygon(Progression items, bool requireRewards)
-            => CanAccessDraygon(items, requireRewards) && CanLeaveDrayonRoom(items);
+            => CanAccessDraygon(items, requireRewards) && CanLeaveDraygonRoom(items);
 
-        private bool CanLeaveDrayonRoom(Progression items)
+        private bool CanLeaveDraygonRoom(Progression items)
             => (items.SpeedBooster && items.HiJump && Logic.CanWallJump(WallJumpDifficulty.Easy)) || Logic.CanFly(items);
 
         private bool CanDefeatBotwoon(Progression items, bool requireRewards)
@@ -180,9 +89,6 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Maridia
             (items.Draygon || (!requireRewards && CanDefeatDraygon(items, requireRewards)))
             && (items.ScrewAttack || items.Plasma)
             && ((items.HiJump && Logic.CanWallJump(WallJumpDifficulty.Medium)) || Logic.CanFly(items));
-
-        private bool CanReachRightSandPit(Progression items, bool requireReweards)
-            => CanReachAqueduct(items, Logic, requireReweards) && items.Super && (Logic.CanWallJump(WallJumpDifficulty.Easy) || items.HiJump || items.SpaceJump);
 
         // Large room on the west side of Maridia where you are intended to grapple over
         private static bool CanPassMountDeath(Progression items, ILogic logic)
@@ -221,6 +127,44 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Maridia
             public Location Right { get; }
         }
 
+        public class PseudoPlasmaSparkRoom : Room
+        {
+            public PseudoPlasmaSparkRoom(InnerMaridia region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Pseudo Plasma Spark Room", metadata)
+            {
+                PseudoSparkRoom = new Location(this, 142, 0x8FC533, LocationType.Visible,
+                    name: "Missile (yellow Maridia false wall)",
+                    vanillaItem: ItemType.Missile,
+                    access: items => items.CardMaridiaL1 && Logic.CanPassBombPassages(items) && region.CanPassPipeCrossroads(items) && CanReachAqueduct(items, Logic, true),
+                    relevanceRequirement: items => items.CardMaridiaL1 && Logic.CanPassBombPassages(items) && region.CanPassPipeCrossroads(items) && CanReachAqueduct(items, Logic, false),
+                    memoryAddress: 0x11,
+                    memoryFlag: 0x40,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location PseudoSparkRoom { get; }
+        }
+
+        public class PlasmaRoom : Room
+        {
+            public PlasmaRoom(InnerMaridia region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Plasma Room", metadata, "Plasma Beam Room")
+            {
+                PlasmaBeam = new Location(this, 143, 0x8FC559, LocationType.Chozo,
+                    name: "Plasma Beam",
+                    vanillaItem: ItemType.Plasma,
+                    access: items => region.CanAccessPlasmaBeamRoom(items, requireRewards: true),
+                    relevanceRequirement: items => region.CanAccessPlasmaBeamRoom(items, requireRewards: false),
+                    memoryAddress: 0x11,
+                    memoryFlag: 0x80,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location PlasmaBeam { get; }
+        }
+
         public class LeftSandPitRoom : Room
         {
             public LeftSandPitRoom(InnerMaridia region, IMetadataService? metadata, TrackerState? trackerState)
@@ -253,6 +197,148 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Maridia
 
             public bool CanEnter(Progression items, bool requireRewards)
                 => InnerMaridia.CanReachAqueduct(items, Logic, requireRewards) && items.Super && Logic.CanPassBombPassages(items);
+        }
+
+        public class RightSandPitRoom : Room
+        {
+            public RightSandPitRoom(InnerMaridia region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Right Sand Pit", metadata)
+            {
+                Left = new Location(this, 146, 0x8FC5EB, LocationType.Visible,
+                    name: "Missile (right Maridia sand pit room)",
+                    vanillaItem: ItemType.Missile,
+                    access: items => CanReachRightSandPit(items, true),
+                    relevanceRequirement: items => CanReachRightSandPit(items, false),
+                    memoryAddress: 0x12,
+                    memoryFlag: 0x4,
+                    metadata: metadata,
+                    trackerState: trackerState);
+                Right = new Location(this, 147, 0x8FC5F1, LocationType.Visible,
+                    name: "Power Bomb (right Maridia sand pit room)",
+                    vanillaItem: ItemType.PowerBomb,
+                    access: items => CanReachRightSandPit(items, true),
+                    relevanceRequirement: items => CanReachRightSandPit(items, false),
+                    memoryAddress: 0x12,
+                    memoryFlag: 0x8,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location Left { get; }
+
+            public Location Right { get; }
+
+            private bool CanReachRightSandPit(Progression items, bool requireRewards)
+                => CanReachAqueduct(items, Logic, requireRewards) && items.Super && (Logic.CanWallJump(WallJumpDifficulty.Easy) || items.HiJump || items.SpaceJump);
+        }
+
+        public class AqueductRoom: Room
+        {
+            public AqueductRoom(InnerMaridia region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Aqueduct", metadata)
+            {
+                AqueductLeft = new Location(this, 148, 0x8FC603, LocationType.Visible,
+                    name: "Missile (pink Maridia)",
+                    vanillaItem: ItemType.Missile,
+                    access: items => CanReachAqueduct(items, Logic, true) && items.SpeedBooster,
+                    relevanceRequirement: items => CanReachAqueduct(items, Logic, false) && items.SpeedBooster,
+                    memoryAddress: 0x12,
+                    memoryFlag: 0x10,
+                    metadata: metadata,
+                    trackerState: trackerState);
+                AqueductRight = new Location(this, 149, 0x8FC609, LocationType.Visible,
+                    name: "Super Missile (pink Maridia)",
+                    vanillaItem: ItemType.Super,
+                    access: items => CanReachAqueduct(items, Logic, true) && items.SpeedBooster,
+                    relevanceRequirement: items => CanReachAqueduct(items, Logic, false) && items.SpeedBooster,
+                    memoryAddress: 0x12,
+                    memoryFlag: 0x20,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location AqueductLeft { get; }
+
+            public Location AqueductRight { get; }
+        }
+
+        public class SpringBallRoom : Room
+        {
+            public SpringBallRoom(InnerMaridia region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Spring Ball Room", metadata)
+            {
+                ShaktoolItem = new Location(this, 150, 0x8FC6E5, LocationType.Chozo,
+                    name: "Spring Ball",
+                    vanillaItem: ItemType.SpringBall,
+                    access: items => items.Super && Logic.CanUsePowerBombs(items) && items.Grapple
+                                  && (items.SpaceJump || (items.HiJump && Logic.CanWallJump(WallJumpDifficulty.Medium)))
+                                  && (Logic.CanWallJump(WallJumpDifficulty.Medium) || items.SpringBall || items.SpaceJump), // Leaving again
+                    memoryAddress: 0x12,
+                    memoryFlag: 0x40,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location ShaktoolItem { get; }
+        }
+
+        public class ThePreciousRoom : Room
+        {
+            public ThePreciousRoom(InnerMaridia region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "The Precious Room", metadata)
+            {
+                PreDraygonRoom = new Location(this, 151, 0x8FC74D, LocationType.Hidden,
+                    name: "Missile (Draygon)",
+                    vanillaItem: ItemType.Missile,
+                    access: items => region.CanAccessPreciousRoom(items, true),
+                    relevanceRequirement: items => region.CanAccessPreciousRoom(items, false),
+                    memoryAddress: 0x12,
+                    memoryFlag: 0x80,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location PreDraygonRoom { get; }
+        }
+
+        public class BotwoonsRoom : Room
+        {
+            public BotwoonsRoom(InnerMaridia region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Botwoon's Room", metadata)
+            {
+                Botwoon = new Location(this, 152, 0x8FC755, LocationType.Visible,
+                    name: "Energy Tank, Botwoon",
+                    vanillaItem: ItemType.ETank,
+                    access: items => (items.CardMaridiaL1 && items.CardMaridiaL2 && region.CanDefeatBotwoon(items, true))
+                                      || (Logic.CanAccessMaridiaPortal(items, requireRewards: true) && items.CardMaridiaL2),
+                    relevanceRequirement: items => (items.CardMaridiaL1 && items.CardMaridiaL2 && region.CanDefeatBotwoon(items, false))
+                                      || (Logic.CanAccessMaridiaPortal(items, requireRewards: false) && items.CardMaridiaL2),
+                    memoryAddress: 0x13,
+                    memoryFlag: 0x1,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location Botwoon { get; }
+        }
+
+        public class SpaceJumpRoom : Room
+        {
+            public SpaceJumpRoom(InnerMaridia region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Space Jump Room", metadata)
+            {
+                DraygonTreasure = new Location(this, 154, 0x8FC7A7, LocationType.Chozo,
+                    name: "Space Jump",
+                    vanillaItem: ItemType.SpaceJump,
+                    access: items => items.Draygon,
+                    relevanceRequirement: items => region.CanDefeatDraygon(items, false),
+                    memoryAddress: 0x13,
+                    memoryFlag: 0x4,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location DraygonTreasure { get; }
         }
     }
 }

--- a/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Maridia/OuterMaridia.cs
+++ b/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Maridia/OuterMaridia.cs
@@ -10,47 +10,8 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Maridia
     {
         public OuterMaridia(World world, Config config, IMetadataService? metadata, TrackerState? trackerState) : base(world, config, metadata, trackerState)
         {
-            MainStreetCeiling = new Location(this, 136, 0x8FC437, LocationType.Visible,
-                name: "Missile (green Maridia shinespark)",
-                vanillaItem: ItemType.Missile,
-                access: items => items.SpeedBooster,
-                memoryAddress: 0x11,
-                memoryFlag: 0x1,
-                metadata: metadata,
-                trackerState: trackerState);
-            MainStreetCrabSupers = new Location(this, 137, 0x8FC43D, LocationType.Visible,
-                name: "Super Missile (green Maridia)",
-                vanillaItem: ItemType.Super,
-                access: items => Logic.CanWallJump(WallJumpDifficulty.Medium)
-                              || (Logic.CanWallJump(WallJumpDifficulty.Easy) && items.Ice)
-                              || items.HiJump || Logic.CanFly(items),
-                memoryAddress: 0x11,
-                memoryFlag: 0x2,
-                metadata: metadata,
-                trackerState: trackerState);
-            MamaTurtleRoom = new Location(this, 138, 0x8FC47D, LocationType.Visible,
-                name: "Energy Tank, Mama turtle",
-                vanillaItem: ItemType.ETank,
-                access: items => CanReachTurtleRoom(items)
-                              && (Logic.CanFly(items)
-                                  || items.SpeedBooster
-                                  || items.Grapple), // Reaching the item
-                memoryAddress: 0x11,
-                memoryFlag: 0x4,
-                metadata: metadata,
-                trackerState: trackerState);
-            MamaTurtleWallItem = new Location(this, 139, 0x8FC483, LocationType.Hidden,
-                name: "Missile (green Maridia tatori)",
-                vanillaItem: ItemType.Missile,
-                access: items => CanReachTurtleRoom(items)
-                              && (Logic.CanWallJump(WallJumpDifficulty.Easy)
-                                  || items.SpeedBooster
-                                  || (items.Grapple && items.HiJump)
-                                  || Logic.CanFly(items)), // Reaching the item
-                memoryAddress: 0x11,
-                memoryFlag: 0x8,
-                metadata: metadata,
-                trackerState: trackerState);
+            MainStreet = new MainStreetRoom(this, metadata, trackerState);
+            MamaTurtle = new MamaTurtleRoom(this, metadata, trackerState);
             MemoryRegionId = 4;
             Metadata = metadata?.Region(GetType()) ?? new RegionInfo("Outer Maridia");
         }
@@ -59,13 +20,9 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Maridia
 
         public override string Area => "Maridia";
 
-        public Location MainStreetCeiling { get; }
+        public MainStreetRoom MainStreet { get; }
 
-        public Location MainStreetCrabSupers { get; }
-
-        public Location MamaTurtleRoom { get; }
-
-        public Location MamaTurtleWallItem { get; }
+        public MamaTurtleRoom MamaTurtle { get; }
 
         public override bool CanEnter(Progression items, bool requireRewards)
         {
@@ -82,6 +39,70 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Maridia
                 || (Logic.CanWallJump(WallJumpDifficulty.Easy) && (items.Plasma || items.ScrewAttack))
                 || items.HiJump
                 || Logic.CanFly(items));
-    }
 
+        public class MainStreetRoom : Room
+        {
+            public MainStreetRoom(OuterMaridia region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Main Street Room", metadata, "Main Street")
+            {
+                MainStreetCeiling = new Location(this, 136, 0x8FC437, LocationType.Visible,
+                    name: "Missile (green Maridia shinespark)",
+                    vanillaItem: ItemType.Missile,
+                    access: items => items.SpeedBooster,
+                    memoryAddress: 0x11,
+                    memoryFlag: 0x1,
+                    metadata: metadata,
+                    trackerState: trackerState);
+                MainStreetCrabSupers = new Location(this, 137, 0x8FC43D, LocationType.Visible,
+                    name: "Super Missile (green Maridia)",
+                    vanillaItem: ItemType.Super,
+                    access: items => Logic.CanWallJump(WallJumpDifficulty.Medium)
+                                  || (Logic.CanWallJump(WallJumpDifficulty.Easy) && items.Ice)
+                                  || items.HiJump || Logic.CanFly(items),
+                    memoryAddress: 0x11,
+                    memoryFlag: 0x2,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location MainStreetCeiling { get; }
+
+            public Location MainStreetCrabSupers { get; }
+        }
+
+        public class MamaTurtleRoom : Room
+        {
+            public MamaTurtleRoom(OuterMaridia region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Mama Turtle Room", metadata)
+            {
+                EnergyTank = new Location(this, 138, 0x8FC47D, LocationType.Visible,
+                    name: "Energy Tank, Mama turtle",
+                    vanillaItem: ItemType.ETank,
+                    access: items => region.CanReachTurtleRoom(items)
+                                  && (Logic.CanFly(items)
+                                      || items.SpeedBooster
+                                      || items.Grapple), // Reaching the item
+                    memoryAddress: 0x11,
+                    memoryFlag: 0x4,
+                    metadata: metadata,
+                    trackerState: trackerState);
+                MamaTurtleWallItem = new Location(this, 139, 0x8FC483, LocationType.Hidden,
+                    name: "Missile (green Maridia tatori)",
+                    vanillaItem: ItemType.Missile,
+                    access: items => region.CanReachTurtleRoom(items)
+                                  && (Logic.CanWallJump(WallJumpDifficulty.Easy)
+                                      || items.SpeedBooster
+                                      || (items.Grapple && items.HiJump)
+                                      || Logic.CanFly(items)), // Reaching the item
+                    memoryAddress: 0x11,
+                    memoryFlag: 0x8,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location EnergyTank { get; }
+
+            public Location MamaTurtleWallItem { get; }
+        }
+    }
 }

--- a/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Norfair/LowerNorfairEast.cs
+++ b/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Norfair/LowerNorfairEast.cs
@@ -10,55 +10,12 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
     {
         public LowerNorfairEast(World world, Config config, IMetadataService? metadata, TrackerState? trackerState) : base(world, config, metadata, trackerState)
         {
-            SpringBallMaze = new Location(this, 74, 0x8F8FCA, LocationType.Visible,
-                name: "Missile (lower Norfair above fire flea room)",
-                vanillaItem: ItemType.Missile,
-                access: items => CanExit(items),
-                memoryAddress: 0x9,
-                memoryFlag: 0x4,
-                metadata: metadata,
-                trackerState: trackerState);
-            EscapePowerBombRoom = new Location(this, 75, 0x8F8FD2, LocationType.Visible,
-                name: "Power Bomb (lower Norfair above fire flea room)",
-                vanillaItem: ItemType.PowerBomb,
-                access: items => CanExit(items),
-                memoryAddress: 0x9,
-                memoryFlag: 0x8,
-                metadata: metadata,
-                trackerState: trackerState);
-            PowerBombOfShame = new Location(this, 76, 0x8F90C0, LocationType.Visible,
-                name: "Power Bomb (Power Bombs of shame)",
-                vanillaItem: ItemType.PowerBomb,
-                access: items => CanExit(items) && Logic.CanUsePowerBombs(items),
-                memoryAddress: 0x9,
-                memoryFlag: 0x10,
-                metadata: metadata,
-                trackerState: trackerState);
-            ThreeMusketeersRoom = new Location(this, 77, 0x8F9100, LocationType.Visible,
-                name: "Missile (lower Norfair near Wave Beam)",
-                vanillaItem: ItemType.Missile,
-                access: CanExit,
-                memoryAddress: 0x9,
-                memoryFlag: 0x20,
-                metadata: metadata,
-                trackerState: trackerState);
-            RidleyTreasure = new Location(this, 78, 0x8F9108, LocationType.Hidden,
-                name: "Energy Tank, Ridley",
-                vanillaItem: ItemType.ETank,
-                access: items => items.Ridley,
-                relevanceRequirement: CanBeatBoss,
-                memoryAddress: 0x9,
-                memoryFlag: 0x40,
-                metadata: metadata,
-                trackerState: trackerState);
-            FirefleaRoom = new Location(this, 80, 0x8F9184, LocationType.Visible,
-                name: "Energy Tank, Firefleas",
-                vanillaItem: ItemType.ETank,
-                access: CanExit,
-                memoryAddress: 0xA,
-                memoryFlag: 0x1,
-                metadata: metadata,
-                trackerState: trackerState);
+            SpringBallMaze = new SpringBallMazeRoom(this, metadata, trackerState);
+            EscapePowerBomb = new EscapePowerBombRoom(this, metadata, trackerState);
+            Wasteland = new WastelandRoom(this, metadata, trackerState);
+            ThreeMusketeers = new ThreeMusketeersRoom(this, metadata, trackerState);
+            RidleyTank = new RidleyTankRoom(this, metadata, trackerState);
+            Fireflea = new FirefleaRoom(this, metadata, trackerState);
             MemoryRegionId = 2;
             Boss = new Boss(Shared.Enums.BossType.Ridley, world, this, metadata, trackerState);
             Metadata = metadata?.Region(GetType()) ?? new RegionInfo("Lower Norfair East");
@@ -70,17 +27,17 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
 
         public Boss Boss { get; set; }
 
-        public Location SpringBallMaze { get; }
+        public SpringBallMazeRoom SpringBallMaze { get; }
 
-        public Location EscapePowerBombRoom { get; }
+        public EscapePowerBombRoom EscapePowerBomb { get; }
 
-        public Location PowerBombOfShame { get; }
+        public WastelandRoom Wasteland { get; }
 
-        public Location ThreeMusketeersRoom { get; }
+        public ThreeMusketeersRoom ThreeMusketeers { get; }
 
-        public Location RidleyTreasure { get; }
+        public RidleyTankRoom RidleyTank { get; }
 
-        public Location FirefleaRoom { get; }
+        public FirefleaRoom Fireflea { get; }
 
         public override bool CanEnter(Progression items, bool requireRewards) => items.Varia && items.CardLowerNorfairL1 && (
                     // Access via elevator from upper norfair east past Ridley's mouth
@@ -102,6 +59,115 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
         {
             return items.CardNorfairL2 /*Bubble Mountain*/ ||
                     (items.Gravity && items.Wave /* Volcano Room and Blue Gate */ && (items.Grapple || items.SpaceJump /*Spikey Acid Snakes and Croc Escape*/));
+        }
+
+        public class SpringBallMazeRoom : Room
+        {
+            public SpringBallMazeRoom(LowerNorfairEast region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Spring Ball Maze Room", metadata)
+            {
+                SpringBallMaze = new Location(this, 74, 0x8F8FCA, LocationType.Visible,
+                    name: "Missile (lower Norfair above fire flea room)",
+                    vanillaItem: ItemType.Missile,
+                    access: items => region.CanExit(items),
+                    memoryAddress: 0x9,
+                    memoryFlag: 0x4,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location SpringBallMaze { get; }
+        }
+
+        public class EscapePowerBombRoom : Room
+        {
+            public EscapePowerBombRoom(LowerNorfairEast region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Escape Power Bomb Room", metadata)
+            {
+                PowerBomb = new Location(this, 75, 0x8F8FD2, LocationType.Visible,
+                    name: "Power Bomb (lower Norfair above fire flea room)",
+                    vanillaItem: ItemType.PowerBomb,
+                    access: items => region.CanExit(items),
+                    memoryAddress: 0x9,
+                    memoryFlag: 0x8,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location PowerBomb { get; }
+        }
+
+        public class WastelandRoom : Room
+        {
+            public WastelandRoom(LowerNorfairEast region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Wasteland", metadata, "Power Bomb of Shame Room")
+            {
+                PowerBombOfShame = new Location(this, 76, 0x8F90C0, LocationType.Visible,
+                    name: "Power Bomb (Power Bombs of shame)",
+                    vanillaItem: ItemType.PowerBomb,
+                    access: items => region.CanExit(items) && Logic.CanUsePowerBombs(items),
+                    memoryAddress: 0x9,
+                    memoryFlag: 0x10,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location PowerBombOfShame { get; }
+        }
+
+        public class ThreeMusketeersRoom : Room
+        {
+            public ThreeMusketeersRoom(LowerNorfairEast region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Three Musketeers' Room", metadata)
+            {
+                Missile = new Location(this, 77, 0x8F9100, LocationType.Visible,
+                    name: "Missile (lower Norfair near Wave Beam)",
+                    vanillaItem: ItemType.Missile,
+                    access: region.CanExit,
+                    memoryAddress: 0x9,
+                    memoryFlag: 0x20,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location Missile { get; }
+        }
+
+        public class RidleyTankRoom : Room
+        {
+            public RidleyTankRoom(LowerNorfairEast region, IMetadataService? metadata, TrackerState? trackerState)
+               : base(region, "Ridley Tank Room", metadata)
+           {
+                RidleyTreasure = new Location(this, 78, 0x8F9108, LocationType.Hidden,
+                    name: "Energy Tank, Ridley",
+                    vanillaItem: ItemType.ETank,
+                    access: items => items.Ridley,
+                    relevanceRequirement: region.CanBeatBoss,
+                    memoryAddress: 0x9,
+                    memoryFlag: 0x40,
+                    metadata: metadata,
+                    trackerState: trackerState);
+           }
+
+            public Location RidleyTreasure { get; }
+        }
+
+        public class FirefleaRoom : Room
+        {
+            public FirefleaRoom(LowerNorfairEast region, IMetadataService? metadata, TrackerState? trackerState)
+               : base(region, "Lower Norfair Fireflea Room", metadata)
+            {
+                EnergyTank = new Location(this, 80, 0x8F9184, LocationType.Visible,
+                    name: "Energy Tank, Firefleas",
+                    vanillaItem: ItemType.ETank,
+                    access: region.CanExit,
+                    memoryAddress: 0xA,
+                    memoryFlag: 0x1,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location EnergyTank { get; }
         }
     }
 }

--- a/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Norfair/LowerNorfairWest.cs
+++ b/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Norfair/LowerNorfairWest.cs
@@ -10,49 +10,9 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
     {
         public LowerNorfairWest(World world, Config config, IMetadataService? metadata, TrackerState? trackerState) : base(world, config, metadata, trackerState)
         {
-            BeforeGoldTorizo = new Location(this, 70, 0x8F8E6E, LocationType.Visible,
-                name: "Missile (Gold Torizo)",
-                vanillaItem: ItemType.Missile,
-                access: items => Logic.CanUsePowerBombs(items) && items.SpaceJump && items.Super,
-                memoryAddress: 0x8,
-                memoryFlag: 0x40,
-                metadata: metadata,
-                trackerState: trackerState);
-            GoldTorizoCeiling = new Location(this, 71, 0x8F8E74, LocationType.Hidden,
-                name: "Super Missile (Gold Torizo)",
-                vanillaItem: ItemType.Super,
-                access: items => Logic.CanDestroyBombWalls(items)
-                                 && (items.Super || items.Charge)
-                                 && (Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items))
-                                 && (Logic.CanAccessNorfairLowerPortal(items) || (items.SpaceJump && Logic.CanUsePowerBombs(items))),
-                memoryAddress: 0x8,
-                memoryFlag: 0x80,
-                metadata: metadata,
-                trackerState: trackerState);
-            ScrewAttackRoom = new Location(this, 79, 0x8F9110, LocationType.Chozo,
-                name: "Screw Attack",
-                access: items => (Logic.CanDestroyBombWalls(items) || items.ScrewAttack) && (items.SpaceJump && Logic.CanUsePowerBombs(items) || Logic.CanAccessNorfairLowerPortal(items)),
-                memoryAddress: 0x9,
-                memoryFlag: 0x80,
-                metadata: metadata,
-                trackerState: trackerState);
-            MickeyMouseClubhouse = new Location(this, 73, 0x8F8F30, LocationType.Visible,
-                name: "Missile (Mickey Mouse room)",
-                vanillaItem: ItemType.Missile,
-                access: items => items.Morph && items.Super && (
-                            Logic.CanWallJump(WallJumpDifficulty.Insane) ||
-                            (items.HiJump && Logic.CanWallJump(WallJumpDifficulty.Hard)) ||
-                            Logic.CanFly(items)
-                        ) &&
-                        /*Exit to Upper Norfair*/
-                        (((items.CardLowerNorfairL1 || items.Gravity /*Vanilla or Reverse Lava Dive*/) && items.CardNorfairL2) /*Bubble Mountain*/ ||
-                        (items.Gravity && items.Wave /* Volcano Room and Blue Gate */ && (items.Grapple || items.SpaceJump)) /*Spikey Acid Snakes and Croc Escape*/ ||
-                        /*Exit via GT fight and Portal*/
-                        (Logic.CanUsePowerBombs(items) && items.SpaceJump && (items.Super || items.Charge))),
-                memoryAddress: 0x9,
-                memoryFlag: 0x2,
-                metadata: metadata,
-                trackerState: trackerState);
+            GoldenTorizos = new GoldenTorizosRoom(this, metadata, trackerState);
+            MickeyMouse = new MickeyMouseRoom(this, metadata, trackerState);
+            ScrewAttack = new ScrewAttackRoom(this, metadata, trackerState);
             MemoryRegionId = 2;
             Metadata = metadata?.Region(GetType()) ?? new RegionInfo("Lower Norfair West");
         }
@@ -61,13 +21,11 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
 
         public override string Area => "Lower Norfair";
 
-        public Location BeforeGoldTorizo { get; }
+        public GoldenTorizosRoom GoldenTorizos { get; }
 
-        public Location GoldTorizoCeiling { get; }
+        public MickeyMouseRoom MickeyMouse { get; }
 
-        public Location ScrewAttackRoom { get; }
-
-        public Location MickeyMouseClubhouse { get; }
+        public ScrewAttackRoom ScrewAttack { get; }
 
         // Todo: account for Croc Speedway once Norfair Upper East also do so, otherwise it would be inconsistent to do so here
         public override bool CanEnter(Progression items, bool requireRewards)
@@ -83,6 +41,79 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
                     );
         }
 
-    }
+        public class GoldenTorizosRoom : Room
+        {
+            public GoldenTorizosRoom(LowerNorfairWest region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Golden Torizo's Room", metadata)
+            {
+                BeforeGoldTorizo = new Location(this, 70, 0x8F8E6E, LocationType.Visible,
+                    name: "Missile (Gold Torizo)",
+                    vanillaItem: ItemType.Missile,
+                    access: items => Logic.CanUsePowerBombs(items) && items.SpaceJump && items.Super,
+                    memoryAddress: 0x8,
+                    memoryFlag: 0x40,
+                    metadata: metadata,
+                    trackerState: trackerState);
+                GoldTorizoCeiling = new Location(this, 71, 0x8F8E74, LocationType.Hidden,
+                    name: "Super Missile (Gold Torizo)",
+                    vanillaItem: ItemType.Super,
+                    access: items => Logic.CanDestroyBombWalls(items)
+                                     && (items.Super || items.Charge)
+                                     && (Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items))
+                                     && (Logic.CanAccessNorfairLowerPortal(items) || (items.SpaceJump && Logic.CanUsePowerBombs(items))),
+                    memoryAddress: 0x8,
+                    memoryFlag: 0x80,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
 
+            public Location BeforeGoldTorizo { get; }
+
+            public Location GoldTorizoCeiling { get; }
+        }
+
+        public class MickeyMouseRoom : Room
+        {
+            public MickeyMouseRoom(LowerNorfairWest region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Mickey Mouse Room", metadata, "Mickey Mouse Clubhouse")
+            {
+                MickeyMouseClubhouse = new Location(this, 73, 0x8F8F30, LocationType.Visible,
+                    name: "Missile (Mickey Mouse room)",
+                    vanillaItem: ItemType.Missile,
+                    access: items => items.Morph && items.Super && (
+                                Logic.CanWallJump(WallJumpDifficulty.Insane) ||
+                                (items.HiJump && Logic.CanWallJump(WallJumpDifficulty.Hard)) ||
+                                Logic.CanFly(items)
+                            ) &&
+                            /*Exit to Upper Norfair*/
+                            (((items.CardLowerNorfairL1 || items.Gravity /*Vanilla or Reverse Lava Dive*/) && items.CardNorfairL2) /*Bubble Mountain*/ ||
+                            (items.Gravity && items.Wave /* Volcano Room and Blue Gate */ && (items.Grapple || items.SpaceJump)) /*Spikey Acid Snakes and Croc Escape*/ ||
+                            /*Exit via GT fight and Portal*/
+                            (Logic.CanUsePowerBombs(items) && items.SpaceJump && (items.Super || items.Charge))),
+                    memoryAddress: 0x9,
+                    memoryFlag: 0x2,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location MickeyMouseClubhouse { get; }
+        }
+
+        public class ScrewAttackRoom : Room
+        {
+            public ScrewAttackRoom(LowerNorfairWest region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Screw Attack Room", metadata)
+            {
+                ScrewAttack = new Location(this, 79, 0x8F9110, LocationType.Chozo,
+                    name: "Screw Attack",
+                    access: items => (Logic.CanDestroyBombWalls(items) || items.ScrewAttack) && (items.SpaceJump && Logic.CanUsePowerBombs(items) || Logic.CanAccessNorfairLowerPortal(items)),
+                    memoryAddress: 0x9,
+                    memoryFlag: 0x80,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location ScrewAttack { get; }
+        }
+    }
 }

--- a/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Norfair/UpperNorfairCrocomire.cs
+++ b/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Norfair/UpperNorfairCrocomire.cs
@@ -10,66 +10,12 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
     {
         public UpperNorfairCrocomire(World world, Config config, IMetadataService? metadata, TrackerState? trackerState) : base(world, config, metadata, trackerState)
         {
-            Crocomire = new Location(this, 52, 0x8F8BA4, LocationType.Visible,
-                name: "Energy Tank, Crocomire",
-                vanillaItem: ItemType.ETank,
-                access: items => CanAccessCrocomire(items) && ((Logic.HasEnergyReserves(items, 1) && Logic.CanWallJump(WallJumpDifficulty.Easy)) || items.SpaceJump || items.Grapple),
-                memoryAddress: 0x6,
-                memoryFlag: 0x10,
-                metadata: metadata,
-                trackerState: trackerState);
-            CrocomireEscape = new Location(this, 54, 0x8F8BC0, LocationType.Visible,
-                name: "Missile (above Crocomire)",
-                vanillaItem: ItemType.Missile,
-                access: items => Logic.CanFly(items) || items.Grapple || (items.HiJump && items.SpeedBooster && Logic.CanWallJump(WallJumpDifficulty.Hard)),
-                memoryAddress: 0x6,
-                memoryFlag: 0x40,
-                metadata: metadata,
-                trackerState: trackerState);
-            PostCrocPowerBombRoom = new Location(this, 57, 0x8F8C04, LocationType.Visible,
-                name: "Power Bomb (Crocomire)",
-                vanillaItem: ItemType.PowerBomb,
-                access: items => CanAccessCrocomire(items) && (Logic.CanFly(items) || items.HiJump || items.Grapple),
-                memoryAddress: 0x7,
-                memoryFlag: 0x2,
-                metadata: metadata,
-                trackerState: trackerState);
-            CosineRoom = new Location(this, 58, 0x8F8C14, LocationType.Visible,
-                name: "Missile (below Crocomire)",
-                vanillaItem: ItemType.Missile,
-                access: items =>
-                    // Can access item
-                    CanAccessCrocomire(items) && items.Morph &&
-                    // Can return
-                    (Logic.CanFly(items) || Logic.CanWallJump(WallJumpDifficulty.Medium) || (items.SpeedBooster && Logic.CanUsePowerBombs(items) && items.HiJump && items.Grapple)),
-                memoryAddress: 0x7,
-                memoryFlag: 0x4,
-                metadata: metadata,
-                trackerState: trackerState);
-            IndianaJonesRoom = new Location(this, 59, 0x8F8C2A, LocationType.Visible,
-                name: "Missile (Grappling Beam)",
-                vanillaItem: ItemType.Missile,
-                access: items =>
-                    // Can access item
-                    CanAccessCrocomire(items) && items.Morph && (Logic.CanFly(items) || (items.SpeedBooster && Logic.CanUsePowerBombs(items))) &&
-                    // Can return
-                    (Logic.CanFly(items) || Logic.CanWallJump(WallJumpDifficulty.Medium) || (items.HiJump && items.Grapple)),
-                memoryAddress: 0x7,
-                memoryFlag: 0x8,
-                metadata: metadata,
-                trackerState: trackerState);
-            GrappleBeamRoom = new Location(this, 60, 0x8F8C36, LocationType.Chozo,
-                name: "Grappling Beam",
-                vanillaItem: ItemType.Grapple,
-                access: items =>
-                    // Can access item
-                    CanAccessCrocomire(items) && items.Morph && (Logic.CanFly(items) || (items.SpeedBooster && Logic.CanUsePowerBombs(items))) &&
-                    // Can return
-                    (Logic.CanFly(items) || Logic.CanWallJump(WallJumpDifficulty.Medium) || (items.HiJump && items.Grapple)),
-                memoryAddress: 0x7,
-                memoryFlag: 0x10,
-                metadata: metadata,
-                trackerState: trackerState);
+            Crocomires = new CrocomiresRoom(this, metadata, trackerState);
+            CrocomireEscape = new CrocomireEscapeRoom(this, metadata, trackerState);
+            PostCrocomirePowerBomb = new PostCrocomirePowerBombRoom(this, metadata, trackerState);
+            PostCrocomireMissile = new PostCrocomireMissileRoom(this, metadata, trackerState);
+            PostCrocomireJump = new PostCrocomireJumpRoom(this, metadata, trackerState);
+            GrappleBeam = new GrappleBeamRoom(this, metadata, trackerState);
             MemoryRegionId = 2;
             Metadata = metadata?.Region(GetType()) ?? new RegionInfo("Upper Norfair Crocomire");
         }
@@ -77,17 +23,17 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
         public override string Name => "Upper Norfair, Crocomire";
         public override string Area => "Upper Norfair";
 
-        public Location Crocomire { get; }
+        public CrocomiresRoom Crocomires { get; }
 
-        public Location CrocomireEscape { get; }
+        public CrocomireEscapeRoom CrocomireEscape { get; }
 
-        public Location PostCrocPowerBombRoom { get; }
+        public PostCrocomirePowerBombRoom PostCrocomirePowerBomb { get; }
 
-        public Location CosineRoom { get; }
+        public PostCrocomireMissileRoom PostCrocomireMissile { get; }
 
-        public Location IndianaJonesRoom { get; }
+        public PostCrocomireJumpRoom PostCrocomireJump { get; }
 
-        public Location GrappleBeamRoom { get; }
+        public GrappleBeamRoom GrappleBeam { get; }
 
         public override bool CanEnter(Progression items, bool requireRewards)
         {
@@ -114,6 +60,126 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
         private bool CanAccessCrocomire(Progression items)
         {
             return (Config.MetroidKeysanity ? items.CardNorfairBoss : items.Super) && (items.HiJump || items.SpeedBooster || Logic.CanFly(items) || Logic.CanWallJump(WallJumpDifficulty.Easy));
+        }
+
+        public class CrocomiresRoom : Room
+        {
+            public CrocomiresRoom(UpperNorfairCrocomire region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Crocomire's Room", metadata)
+            {
+                Crocomire = new Location(this, 52, 0x8F8BA4, LocationType.Visible,
+                    name: "Energy Tank, Crocomire",
+                    vanillaItem: ItemType.ETank,
+                    access: items => region.CanAccessCrocomire(items) && ((Logic.HasEnergyReserves(items, 1) && Logic.CanWallJump(WallJumpDifficulty.Easy)) || items.SpaceJump || items.Grapple),
+                    memoryAddress: 0x6,
+                    memoryFlag: 0x10,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location Crocomire { get; }
+        }
+
+        public class CrocomireEscapeRoom : Room
+        {
+            public CrocomireEscapeRoom(UpperNorfairCrocomire region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Crocomire Escape", metadata)
+            {
+                CrocomireEscape = new Location(this, 54, 0x8F8BC0, LocationType.Visible,
+                    name: "Missile (above Crocomire)",
+                    vanillaItem: ItemType.Missile,
+                    access: items => Logic.CanFly(items) || items.Grapple || (items.HiJump && items.SpeedBooster && Logic.CanWallJump(WallJumpDifficulty.Hard)),
+                    memoryAddress: 0x6,
+                    memoryFlag: 0x40,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location CrocomireEscape { get; }
+        }
+
+        public class PostCrocomirePowerBombRoom : Room
+        {
+            public PostCrocomirePowerBombRoom(UpperNorfairCrocomire region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Post Crocomire Power Bomb Room", metadata)
+            {
+                PostCrocPowerBombRoom = new Location(this, 57, 0x8F8C04, LocationType.Visible,
+                    name: "Power Bomb (Crocomire)",
+                    vanillaItem: ItemType.PowerBomb,
+                    access: items => region.CanAccessCrocomire(items) && (Logic.CanFly(items) || items.HiJump || items.Grapple),
+                    memoryAddress: 0x7,
+                    memoryFlag: 0x2,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location PostCrocPowerBombRoom { get; }
+        }
+
+        public class PostCrocomireMissileRoom : Room
+        {
+            public PostCrocomireMissileRoom(UpperNorfairCrocomire region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Post Crocomire Missile Room", metadata, "Cosine Room")
+            {
+                CosineRoom = new Location(this, 58, 0x8F8C14, LocationType.Visible,
+                    name: "Missile (below Crocomire)",
+                    vanillaItem: ItemType.Missile,
+                    access: items =>
+                        // Can access item
+                        region.CanAccessCrocomire(items) && items.Morph &&
+                        // Can return
+                        (Logic.CanFly(items) || Logic.CanWallJump(WallJumpDifficulty.Medium) || (items.SpeedBooster && Logic.CanUsePowerBombs(items) && items.HiJump && items.Grapple)),
+                    memoryAddress: 0x7,
+                    memoryFlag: 0x4,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location CosineRoom { get; }
+        }
+
+        public class PostCrocomireJumpRoom : Room
+        {
+            public PostCrocomireJumpRoom(UpperNorfairCrocomire region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Post Crocomire Jump Room", metadata, "Indiana Jones Room", "Pantry")
+            {
+                IndianaJonesRoom = new Location(this, 59, 0x8F8C2A, LocationType.Visible,
+                    name: "Missile (Grappling Beam)",
+                    vanillaItem: ItemType.Missile,
+                    access: items =>
+                        // Can access item
+                        region.CanAccessCrocomire(items) && items.Morph && (Logic.CanFly(items) || (items.SpeedBooster && Logic.CanUsePowerBombs(items))) &&
+                        // Can return
+                        (Logic.CanFly(items) || Logic.CanWallJump(WallJumpDifficulty.Medium) || (items.HiJump && items.Grapple)),
+                    memoryAddress: 0x7,
+                    memoryFlag: 0x8,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location IndianaJonesRoom { get; }
+        }
+
+        public class GrappleBeamRoom : Room
+        {
+            public GrappleBeamRoom(UpperNorfairCrocomire region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Grapple Beam Room", metadata)
+            {
+                GrappleBeam = new Location(this, 60, 0x8F8C36, LocationType.Chozo,
+                    name: "Grappling Beam",
+                    vanillaItem: ItemType.Grapple,
+                    access: items =>
+                        // Can access item
+                        region.CanAccessCrocomire(items) && items.Morph && (Logic.CanFly(items) || (items.SpeedBooster && Logic.CanUsePowerBombs(items))) &&
+                        // Can return
+                        (Logic.CanFly(items) || Logic.CanWallJump(WallJumpDifficulty.Medium) || (items.HiJump && items.Grapple)),
+                    memoryAddress: 0x7,
+                    memoryFlag: 0x10,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location GrappleBeam { get; }
         }
     }
 }

--- a/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Norfair/UpperNorfairEast.cs
+++ b/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Norfair/UpperNorfairEast.cs
@@ -10,62 +10,13 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
     {
         public UpperNorfairEast(World world, Config config, IMetadataService? metadata, TrackerState? trackerState) : base(world, config, metadata, trackerState)
         {
-
-            BubbleMountainMissileRoom = new Location(this, 63, 0x8F8C52, LocationType.Visible,
-                name: "Missile (bubble Norfair green door)",
-                vanillaItem: ItemType.Missile,
-                access: items => items.CardNorfairL2 && CanReachBubbleMountainLeftSide(items),
-                memoryAddress: 0x7,
-                memoryFlag: 0x80,
-                metadata: metadata,
-                trackerState: trackerState);
-            BubbleMountain = new Location(this, 64, 0x8F8C66, LocationType.Visible,
-                name: "Missile (bubble Norfair)",
-                vanillaItem: ItemType.Missile,
-                access: items => items.CardNorfairL2,
-                memoryAddress: 0x8,
-                memoryFlag: 0x1,
-                metadata: metadata,
-                trackerState: trackerState);
-            SpeedBoosterHallCeiling = new Location(this, 65, 0x8F8C74, LocationType.Hidden,
-                name: "Missile (Speed Booster)",
-                vanillaItem: ItemType.Missile,
-                access: items => items.CardNorfairL2 && CanReachBubbleMountainRightSide(items)
-                                 && (Logic.CanWallJump(WallJumpDifficulty.Easy) || items.HiJump),
-                memoryAddress: 0x8,
-                memoryFlag: 0x2,
-                metadata: metadata,
-                trackerState: trackerState);
-            SpeedBoosterRoom = new Location(this, 66, 0x8F8C82, LocationType.Chozo,
-                name: "Speed Booster",
-                vanillaItem: ItemType.SpeedBooster,
-                access: items => items.CardNorfairL2 && CanReachBubbleMountainRightSide(items)
-                                 && (Logic.CanWallJump(WallJumpDifficulty.Easy) || items.HiJump),
-                memoryAddress: 0x8,
-                memoryFlag: 0x4,
-                metadata: metadata,
-                trackerState: trackerState);
-            DoubleChamber = new Location(this, 67, 0x8F8CBC, LocationType.Visible,
-                name: "Missile (Wave Beam)",
-                vanillaItem: ItemType.Missile,
-                access: items => (items.CardNorfairL2 && CanReachBubbleMountainRightSide(items)) ||
-                    (items.SpeedBooster && items.Wave && items.Morph && items.Super),
-                memoryAddress: 0x8,
-                memoryFlag: 0x8,
-                metadata: metadata,
-                trackerState: trackerState);
-            WaveBeamRoom = new Location(this, 68, 0x8F8CCA, LocationType.Chozo,
-                name: "Wave Beam",
-                vanillaItem: ItemType.Wave,
-                access: items => items.Morph && (
-                        (items.CardNorfairL2 && CanReachBubbleMountainRightSide(items)) ||
-                        (items.SpeedBooster && items.Wave && items.Morph && items.Super)
-                    ),
-                memoryAddress: 0x8,
-                memoryFlag: 0x10,
-                metadata: metadata,
-                trackerState: trackerState);
             BubbleMountainHiddenHall = new BubbleMountainHiddenHallRoom(this, metadata, trackerState);
+            GreenBubblesMissile = new GreenBubblesMissileRoom(this, metadata, trackerState);
+            BubbleMountain = new BubbleMountainRoom(this, metadata, trackerState);
+            SpeedBoosterHall = new SpeedBoosterHallRoom(this, metadata, trackerState);
+            SpeedBooster = new SpeedBoosterRoom(this, metadata, trackerState);
+            DoubleChamber = new DoubleChamberRoom(this, metadata, trackerState);
+            WaveBeam = new WaveBeamRoom(this, metadata, trackerState);
             MemoryRegionId = 2;
             Metadata = metadata?.Region(GetType()) ?? new RegionInfo("Upper Norfair East");
         }
@@ -74,19 +25,19 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
 
         public override string Area => "Upper Norfair";
 
-        public Location BubbleMountainMissileRoom { get; }
-
-        public Location BubbleMountain { get; }
-
-        public Location SpeedBoosterHallCeiling { get; }
-
-        public Location SpeedBoosterRoom { get; }
-
-        public Location DoubleChamber { get; }
-
-        public Location WaveBeamRoom { get; }
-
         public BubbleMountainHiddenHallRoom BubbleMountainHiddenHall { get; }
+
+        public GreenBubblesMissileRoom GreenBubblesMissile { get; }
+
+        public BubbleMountainRoom BubbleMountain { get; }
+
+        public SpeedBoosterHallRoom SpeedBoosterHall { get; }
+
+        public SpeedBoosterRoom SpeedBooster { get; }
+
+        public DoubleChamberRoom DoubleChamber { get; }
+
+        public WaveBeamRoom WaveBeam { get; }
 
         // Todo: Super is not actually needed for Frog Speedway, but changing this will affect locations
         // Todo: Ice Beam -> Croc Speedway is not considered
@@ -147,6 +98,119 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
 
             public Location HiddenItem { get; }
         }
-    }
 
+        public class GreenBubblesMissileRoom : Room
+        {
+            public GreenBubblesMissileRoom(UpperNorfairEast region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Green Bubbles Missile Room", metadata)
+            {
+                BubbleMountainMissileRoom = new Location(this, 63, 0x8F8C52, LocationType.Visible,
+                    name: "Missile (bubble Norfair green door)",
+                    vanillaItem: ItemType.Missile,
+                    access: items => items.CardNorfairL2 && region.CanReachBubbleMountainLeftSide(items),
+                    memoryAddress: 0x7,
+                    memoryFlag: 0x80,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location BubbleMountainMissileRoom { get; }
+        }
+
+        public class BubbleMountainRoom : Room
+        {
+            public BubbleMountainRoom(UpperNorfairEast region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Bubbles Mountain", metadata)
+            {
+                BubbleMountain = new Location(this, 64, 0x8F8C66, LocationType.Visible,
+                    name: "Missile (bubble Norfair)",
+                    vanillaItem: ItemType.Missile,
+                    access: items => items.CardNorfairL2,
+                    memoryAddress: 0x8,
+                    memoryFlag: 0x1,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location BubbleMountain { get; }
+        }
+
+        public class SpeedBoosterHallRoom : Room
+        {
+            public SpeedBoosterHallRoom(UpperNorfairEast region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Speed Booster Hall", metadata)
+            {
+                SpeedBoosterHallCeiling = new Location(this, 65, 0x8F8C74, LocationType.Hidden,
+                    name: "Missile (Speed Booster)",
+                    vanillaItem: ItemType.Missile,
+                    access: items => items.CardNorfairL2 && region.CanReachBubbleMountainRightSide(items)
+                                     && (Logic.CanWallJump(WallJumpDifficulty.Easy) || items.HiJump),
+                    memoryAddress: 0x8,
+                    memoryFlag: 0x2,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location SpeedBoosterHallCeiling { get; }
+        }
+
+        public class SpeedBoosterRoom : Room
+        {
+            public SpeedBoosterRoom(UpperNorfairEast region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Speed Booster Room", metadata)
+            {
+                SpeedBooster = new Location(this, 66, 0x8F8C82, LocationType.Chozo,
+                    name: "Speed Booster",
+                    vanillaItem: ItemType.SpeedBooster,
+                    access: items => items.CardNorfairL2 && region.CanReachBubbleMountainRightSide(items)
+                                     && (Logic.CanWallJump(WallJumpDifficulty.Easy) || items.HiJump),
+                    memoryAddress: 0x8,
+                    memoryFlag: 0x4,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location SpeedBooster { get; }
+        }
+
+        public class DoubleChamberRoom : Room
+        {
+            public DoubleChamberRoom(UpperNorfairEast region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Double Chamber Room", metadata)
+            {
+                DoubleChamber = new Location(this, 67, 0x8F8CBC, LocationType.Visible,
+                    name: "Missile (Wave Beam)",
+                    vanillaItem: ItemType.Missile,
+                    access: items => (items.CardNorfairL2 && region.CanReachBubbleMountainRightSide(items)) ||
+                        (items.SpeedBooster && items.Wave && items.Morph && items.Super),
+                    memoryAddress: 0x8,
+                    memoryFlag: 0x8,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location DoubleChamber { get; }
+        }
+
+        public class WaveBeamRoom : Room
+        {
+            public WaveBeamRoom(UpperNorfairEast region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Wave Beam Room", metadata)
+            {
+                WaveBeam = new Location(this, 68, 0x8F8CCA, LocationType.Chozo,
+                    name: "Wave Beam",
+                    vanillaItem: ItemType.Wave,
+                    access: items => items.Morph && (
+                            (items.CardNorfairL2 && region.CanReachBubbleMountainRightSide(items)) ||
+                            (items.SpeedBooster && items.Wave && items.Morph && items.Super)
+                        ),
+                    memoryAddress: 0x8,
+                    memoryFlag: 0x10,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location WaveBeam { get; }
+        }
+    }
 }

--- a/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Norfair/UpperNorfairWest.cs
+++ b/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Norfair/UpperNorfairWest.cs
@@ -11,77 +11,26 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
     {
         public UpperNorfairWest(World world, Config config, IMetadataService? metadata, TrackerState? trackerState) : base(world, config, metadata, trackerState)
         {
-            LavaRoom = new Location(this, 49, 0x8F8AE4, LocationType.Hidden,
-                name: "Missile (lava room)",
-                vanillaItem: ItemType.Missile,
-                access: items => items.Varia && (
-                            (Logic.CanOpenRedDoors(items) && (Logic.CanFly(items) || items.HiJump || items.SpeedBooster)) ||
-                            (World.UpperNorfairEast.CanEnter(items, true) && items.CardNorfairL2)
-                        ) && items.Morph,
-                memoryAddress: 0x6,
-                memoryFlag: 0x2,
-                metadata: metadata,
-                trackerState: trackerState);
-            IceBeamRoom = new Location(this, 50, 0x8F8B24, LocationType.Chozo,
-                name: "Ice Beam",
-                vanillaItem: ItemType.Ice,
-                access: items => (Config.MetroidKeysanity ? items.CardNorfairL1 : items.Super)
-                                 && Logic.CanPassBombPassages(items) && items.Varia && Logic.CanMoveAtHighSpeeds(items),
-                memoryAddress: 0x6,
-                memoryFlag: 0x4,
-                metadata: metadata,
-                trackerState: trackerState);
-            CrumbleShaft = new Location(this, 51, 0x8F8B46, LocationType.Hidden,
-                name: "Missile (below Ice Beam)",
-                vanillaItem: ItemType.Missile,
-                access: items => (Config.MetroidKeysanity ? items.CardNorfairL1 : items.Super)
-                                 && Logic.CanUsePowerBombs(items) && items.Varia && Logic.CanMoveAtHighSpeeds(items)
-                                 && (Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items)),
-                memoryAddress: 0x6,
-                memoryFlag: 0x8,
-                metadata: metadata,
-                trackerState: trackerState);
-            HiJumpBootsRoom = new Location(this, 53, 0x8F8BAC, LocationType.Chozo,
-                name: "Hi-Jump Boots",
-                vanillaItem: ItemType.HiJump,
-                access: items => Logic.CanOpenRedDoors(items) && Logic.CanPassBombPassages(items),
-                memoryAddress: 0x6,
-                memoryFlag: 0x20,
-                metadata: metadata,
-                trackerState: trackerState);
-            HiJumpLobbyBack = new Location(this, 55, 0x8F8BE6, LocationType.Visible,
-                name: "Missile (Hi-Jump Boots)",
-                vanillaItem: ItemType.Missile,
-                access: items => Logic.CanOpenRedDoors(items) && items.Morph,
-                memoryAddress: 0x6,
-                memoryFlag: 0x80,
-                metadata: metadata,
-                trackerState: trackerState);
-            HiJumpLobbyEntrance = new Location(this, 56, 0x8F8BEC, LocationType.Visible,
-                name: "Energy Tank (Hi-Jump Boots)",
-                vanillaItem: ItemType.ETank,
-                access: items => Logic.CanOpenRedDoors(items),
-                memoryAddress: 0x7,
-                memoryFlag: 0x1,
-                metadata: metadata,
-                trackerState: trackerState);
+            Cathedral = new CathedralRoom(this, metadata, trackerState);
+            IceBeam = new IceBeamRoom(this, metadata, trackerState);
+            CrumbleShaft = new CrumbleShaftRoom(this, metadata, trackerState);
+            HiJumpBoots = new HiJumpBootsRoom(this, metadata, trackerState);
+            HiJumpEnergyTank = new HiJumpEnergyTankRoom(this, metadata, trackerState);
             MemoryRegionId = 2;
             Metadata = metadata?.Region(GetType()) ?? new RegionInfo("Upper Norfair West");
         }
         public override string Name => "Upper Norfair, West";
         public override string Area => "Upper Norfair";
 
-        public Location LavaRoom { get; }
+        public CathedralRoom Cathedral { get; }
 
-        public Location IceBeamRoom { get; }
+        public IceBeamRoom IceBeam { get; }
 
-        public Location CrumbleShaft { get; }
+        public CrumbleShaftRoom CrumbleShaft { get; }
 
-        public Location HiJumpBootsRoom { get; }
+        public HiJumpBootsRoom HiJumpBoots { get; }
 
-        public Location HiJumpLobbyBack { get; }
-
-        public Location HiJumpLobbyEntrance { get; }
+        public HiJumpEnergyTankRoom HiJumpEnergyTank { get; }
 
         public override bool CanEnter(Progression items, bool requireRewards)
         {
@@ -89,6 +38,110 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
                 Logic.CanAccessNorfairUpperPortal(items);
         }
 
-    }
+        public class CathedralRoom : Room
+        {
+            public CathedralRoom(UpperNorfairWest region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Cathedral", metadata, "Lava Room")
+            {
+                LavaRoom = new Location(this, 49, 0x8F8AE4, LocationType.Hidden,
+                    name: "Missile (lava room)",
+                    vanillaItem: ItemType.Missile,
+                    access: items => items.Varia && (
+                                (Logic.CanOpenRedDoors(items) && (Logic.CanFly(items) || items.HiJump || items.SpeedBooster)) ||
+                                (World.UpperNorfairEast.CanEnter(items, true) && items.CardNorfairL2)
+                            ) && items.Morph,
+                    memoryAddress: 0x6,
+                    memoryFlag: 0x2,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
 
+            public Location LavaRoom { get; }
+        }
+
+        public class IceBeamRoom : Room
+        {
+            public IceBeamRoom(UpperNorfairWest region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Ice Beam Room", metadata)
+            {
+                IceBeam = new Location(this, 50, 0x8F8B24, LocationType.Chozo,
+                    name: "Ice Beam",
+                    vanillaItem: ItemType.Ice,
+                    access: items => (Config.MetroidKeysanity ? items.CardNorfairL1 : items.Super)
+                                     && Logic.CanPassBombPassages(items) && items.Varia && Logic.CanMoveAtHighSpeeds(items),
+                    memoryAddress: 0x6,
+                    memoryFlag: 0x4,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location IceBeam { get; }
+        }
+
+        public class CrumbleShaftRoom : Room
+        {
+            public CrumbleShaftRoom(UpperNorfairWest region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Crumble Shaft Room", metadata)
+            {
+                CrumbleShaft = new Location(this, 51, 0x8F8B46, LocationType.Hidden,
+                    name: "Missile (below Ice Beam)",
+                    vanillaItem: ItemType.Missile,
+                    access: items => (Config.MetroidKeysanity ? items.CardNorfairL1 : items.Super)
+                                     && Logic.CanUsePowerBombs(items) && items.Varia && Logic.CanMoveAtHighSpeeds(items)
+                                     && (Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items)),
+                    memoryAddress: 0x6,
+                    memoryFlag: 0x8,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location CrumbleShaft { get; }
+        }
+
+        public class HiJumpBootsRoom : Room
+        {
+            public HiJumpBootsRoom(UpperNorfairWest region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Hi-Jump Boots Room", metadata)
+            {
+                HiJumpBoots = new Location(this, 53, 0x8F8BAC, LocationType.Chozo,
+                    name: "Hi-Jump Boots",
+                    vanillaItem: ItemType.HiJump,
+                    access: items => Logic.CanOpenRedDoors(items) && Logic.CanPassBombPassages(items),
+                    memoryAddress: 0x6,
+                    memoryFlag: 0x20,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location HiJumpBoots { get; }
+        }
+
+        public class HiJumpEnergyTankRoom : Room
+        {
+            public HiJumpEnergyTankRoom(UpperNorfairWest region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Hi-Jump Energy Tank Room", metadata, "Hi-Jump Lobby")
+            {
+                HiJumpLobbyBack = new Location(this, 55, 0x8F8BE6, LocationType.Visible,
+                    name: "Missile (Hi-Jump Boots)",
+                    vanillaItem: ItemType.Missile,
+                    access: items => Logic.CanOpenRedDoors(items) && items.Morph,
+                    memoryAddress: 0x6,
+                    memoryFlag: 0x80,
+                    metadata: metadata,
+                    trackerState: trackerState);
+                HiJumpLobbyEntrance = new Location(this, 56, 0x8F8BEC, LocationType.Visible,
+                    name: "Energy Tank (Hi-Jump Boots)",
+                    vanillaItem: ItemType.ETank,
+                    access: items => Logic.CanOpenRedDoors(items),
+                    memoryAddress: 0x7,
+                    memoryFlag: 0x1,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location HiJumpLobbyBack { get; }
+
+            public Location HiJumpLobbyEntrance { get; }
+        }
+    }
 }

--- a/src/Randomizer.Data/WorldData/Regions/SuperMetroid/WreckedShip.cs
+++ b/src/Randomizer.Data/WorldData/Regions/SuperMetroid/WreckedShip.cs
@@ -10,77 +10,13 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid
     {
         public WreckedShip(World world, Config config, IMetadataService? metadata, TrackerState? trackerState) : base(world, config, metadata, trackerState)
         {
-            MainShaftSideRoom = new Location(this, 128, 0x8FC265, LocationType.Visible,
-                name: "Missile (Wrecked Ship middle)",
-                vanillaItem: ItemType.Missile,
-                access: items => Logic.CanPassBombPassages(items),
-                memoryAddress: 0x10,
-                memoryFlag: 0x1,
-                metadata: metadata,
-                trackerState: trackerState);
-            PostChozoConcertSpeedBoosterItem = new Location(this, 129, 0x8FC2E9, LocationType.Chozo, // This isn't a Chozo item?
-                name: "Reserve Tank, Wrecked Ship",
-                vanillaItem: ItemType.ReserveTank,
-                access: items => CanViewConcert(items, requireRewards: true) && items.SpeedBooster && Logic.CanUsePowerBombs(items),
-                relevanceRequirement: items => CanViewConcert(items, requireRewards: false) && items.SpeedBooster && Logic.CanUsePowerBombs(items),
-                memoryAddress: 0x10,
-                memoryFlag: 0x2,
-                metadata: metadata,
-                trackerState: trackerState);
-            PostChozoConcertBreakableChozo = new Location(this, 130, 0x8FC2EF, LocationType.Visible,
-                name: "Missile (Gravity Suit)",
-                vanillaItem: ItemType.Missile,
-                access: items => CanViewConcert(items, requireRewards: true),
-                relevanceRequirement: items => CanViewConcert(items, requireRewards: false),
-                memoryAddress: 0x10,
-                memoryFlag: 0x4,
-                metadata: metadata,
-                trackerState: trackerState);
-            AtticAssemblyLine = new Location(this, 131, 0x8FC319, LocationType.Visible,
-                name: "Missile (Wrecked Ship top)",
-                vanillaItem: ItemType.Missile,
-                access: items => CanAccessShutDownRooms(items, requireRewards: true),
-                relevanceRequirement: items => CanAccessShutDownRooms(items, requireRewards: false),
-                memoryAddress: 0x10,
-                memoryFlag: 0x8,
-                metadata: metadata,
-                trackerState: trackerState);
-            WreckedPool = new Location(this, 132, 0x8FC337, LocationType.Visible,
-                name: "Energy Tank, Wrecked Ship",
-                vanillaItem: ItemType.ETank,
-                access: items => CanAccessWreckedPool(items, requireRewards: true),
-                relevanceRequirement: items => CanAccessWreckedPool(items, requireRewards: false),
-                memoryAddress: 0x10,
-                memoryFlag: 0x10,
-                metadata: metadata,
-                trackerState: trackerState);
-            LeftSuperMissileChamber = new Location(this, 133, 0x8FC357, LocationType.Visible,
-                name: "Super Missile (Wrecked Ship left)",
-                vanillaItem: ItemType.Super,
-                access: items => CanAccessShutDownRooms(items, requireRewards: true),
-                relevanceRequirement: items => CanAccessShutDownRooms(items, requireRewards: false),
-                memoryAddress: 0x10,
-                memoryFlag: 0x20,
-                metadata: metadata,
-                trackerState: trackerState);
-            RightSuperMissileChamber = new Location(this, 134, 0x8FC365, LocationType.Visible,
-                name: "Right Super, Wrecked Ship",
-                vanillaItem: ItemType.Super,
-                access: items => CanAccessShutDownRooms(items, requireRewards: true),
-                relevanceRequirement: items => CanAccessShutDownRooms(items, requireRewards: false),
-                memoryAddress: 0x10,
-                memoryFlag: 0x40,
-                metadata: metadata,
-                trackerState: trackerState);
-            PostChozoConcertGravitySuitChamber = new Location(this, 135, 0x8FC36D, LocationType.Chozo,
-                name: "Gravity Suit",
-                vanillaItem: ItemType.Gravity,
-                access: items => CanViewConcert(items, requireRewards: true),
-                relevanceRequirement: items => CanViewConcert(items, requireRewards: false),
-                memoryAddress: 0x10,
-                memoryFlag: 0x80,
-                metadata: metadata,
-                trackerState: trackerState);
+            MainShaft = new MainShaftRoom(this, metadata, trackerState);
+            BowlingAlley = new BowlingAlleyRoom(this, metadata, trackerState);
+            AssemblyLine = new AssemblyLineRoom(this, metadata, trackerState);
+            EnergyTank = new EnergyTankRoom(this, metadata, trackerState);
+            WestSuper = new WestSuperRoom(this, metadata, trackerState);
+            EastSuper = new EastSuperRoom(this, metadata, trackerState);
+            GravitySuit = new GravitySuitRoom(this, metadata, trackerState);
             MemoryRegionId = 3;
             Boss = new Boss(Shared.Enums.BossType.Phantoon, world, this, metadata, trackerState);
             Metadata = metadata?.Region(GetType()) ?? new RegionInfo("Wrecked Ship");
@@ -92,21 +28,19 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid
 
         public Boss Boss { get; set; }
 
-        public Location MainShaftSideRoom { get; }
+        public MainShaftRoom MainShaft { get; }
 
-        public Location PostChozoConcertSpeedBoosterItem { get; }
+        public BowlingAlleyRoom BowlingAlley { get; }
 
-        public Location PostChozoConcertBreakableChozo { get; }
+        public AssemblyLineRoom AssemblyLine { get; }
 
-        public Location AtticAssemblyLine { get; }
+        public EnergyTankRoom EnergyTank { get; }
 
-        public Location WreckedPool { get; }
+        public WestSuperRoom WestSuper { get; }
 
-        public Location LeftSuperMissileChamber { get; }
+        public EastSuperRoom EastSuper { get; }
 
-        public Location RightSuperMissileChamber { get; }
-
-        public Location PostChozoConcertGravitySuitChamber { get; }
+        public GravitySuitRoom GravitySuit { get; }
 
         public override bool CanEnter(Progression items, bool requireRewards)
         {
@@ -122,7 +56,7 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid
                         /* From Maridia portal -> Forgotten Highway */
                         (Logic.CanAccessMaridiaPortal(items, requireRewards) && CanPassReverseForgottenHighway(items) && (
                             (Logic.CanDestroyBombWalls(items) && items.CardMaridiaL2) ||
-                            World.InnerMaridia.DraygonTreasure.IsAvailable(items)
+                            World.InnerMaridia.SpaceJump.DraygonTreasure.IsAvailable(items)
                         ))
                     );
         }
@@ -152,6 +86,149 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid
         public bool CanUnlockShip(Progression items)
         {
             return items.CardWreckedShipBoss && Logic.CanPassBombPassages(items);
+        }
+
+        public class MainShaftRoom : Room
+        {
+            public MainShaftRoom(WreckedShip region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Wrecked Ship Main Shaft", metadata)
+            {
+                MainShaftSideRoom = new Location(this, 128, 0x8FC265, LocationType.Visible,
+                    name: "Missile (Wrecked Ship middle)",
+                    vanillaItem: ItemType.Missile,
+                    access: items => Logic.CanPassBombPassages(items),
+                    memoryAddress: 0x10,
+                    memoryFlag: 0x1,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location MainShaftSideRoom { get; }
+        }
+
+        public class BowlingAlleyRoom : Room
+        {
+            public BowlingAlleyRoom(WreckedShip region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Bowling Alley", metadata, "Post Chozo Concert")
+            {
+                PostChozoConcertSpeedBoosterItem = new Location(this, 129, 0x8FC2E9, LocationType.Chozo, // This isn't a Chozo item?
+                    name: "Reserve Tank, Wrecked Ship",
+                    vanillaItem: ItemType.ReserveTank,
+                    access: items => region.CanViewConcert(items, requireRewards: true) && items.SpeedBooster && Logic.CanUsePowerBombs(items),
+                    relevanceRequirement: items => region.CanViewConcert(items, requireRewards: false) && items.SpeedBooster && Logic.CanUsePowerBombs(items),
+                    memoryAddress: 0x10,
+                    memoryFlag: 0x2,
+                    metadata: metadata,
+                    trackerState: trackerState);
+                PostChozoConcertBreakableChozo = new Location(this, 130, 0x8FC2EF, LocationType.Visible,
+                    name: "Missile (Gravity Suit)",
+                    vanillaItem: ItemType.Missile,
+                    access: items => region.CanViewConcert(items, requireRewards: true),
+                    relevanceRequirement: items => region.CanViewConcert(items, requireRewards: false),
+                    memoryAddress: 0x10,
+                    memoryFlag: 0x4,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location PostChozoConcertSpeedBoosterItem { get; }
+
+            public Location PostChozoConcertBreakableChozo { get; }
+        }
+
+        public class AssemblyLineRoom : Room
+        {
+            public AssemblyLineRoom(WreckedShip region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Assembly Line", metadata)
+            {
+                AtticAssemblyLine = new Location(this, 131, 0x8FC319, LocationType.Visible,
+                    name: "Missile (Wrecked Ship top)",
+                    vanillaItem: ItemType.Missile,
+                    access: items => region.CanAccessShutDownRooms(items, requireRewards: true),
+                    relevanceRequirement: items => region.CanAccessShutDownRooms(items, requireRewards: false),
+                    memoryAddress: 0x10,
+                    memoryFlag: 0x8,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location AtticAssemblyLine { get; }
+        }
+
+        public class EnergyTankRoom : Room
+        {
+            public EnergyTankRoom(WreckedShip region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Wrecked Ship Energy Tank Room", metadata, "Wrecked Pool")
+            {
+                WreckedPool = new Location(this, 132, 0x8FC337, LocationType.Visible,
+                    name: "Energy Tank, Wrecked Ship",
+                    vanillaItem: ItemType.ETank,
+                    access: items => region.CanAccessWreckedPool(items, requireRewards: true),
+                    relevanceRequirement: items => region.CanAccessWreckedPool(items, requireRewards: false),
+                    memoryAddress: 0x10,
+                    memoryFlag: 0x10,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location WreckedPool { get; }
+        }
+
+        public class WestSuperRoom : Room
+        {
+            public WestSuperRoom(WreckedShip region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Wrecked Ship West Super Room", metadata)
+            {
+                LeftSuperMissileChamber = new Location(this, 133, 0x8FC357, LocationType.Visible,
+                    name: "Super Missile (Wrecked Ship left)",
+                    vanillaItem: ItemType.Super,
+                    access: items => region.CanAccessShutDownRooms(items, requireRewards: true),
+                    relevanceRequirement: items => region.CanAccessShutDownRooms(items, requireRewards: false),
+                    memoryAddress: 0x10,
+                    memoryFlag: 0x20,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location LeftSuperMissileChamber { get; }
+        }
+
+        public class EastSuperRoom : Room
+        {
+            public EastSuperRoom(WreckedShip region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Wrecked Ship East Super Room", metadata)
+            {
+                RightSuperMissileChamber = new Location(this, 134, 0x8FC365, LocationType.Visible,
+                    name: "Right Super, Wrecked Ship",
+                    vanillaItem: ItemType.Super,
+                    access: items => region.CanAccessShutDownRooms(items, requireRewards: true),
+                    relevanceRequirement: items => region.CanAccessShutDownRooms(items, requireRewards: false),
+                    memoryAddress: 0x10,
+                    memoryFlag: 0x40,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location RightSuperMissileChamber { get; }
+        }
+
+        public class GravitySuitRoom : Room
+        {
+            public GravitySuitRoom(WreckedShip region, IMetadataService? metadata, TrackerState? trackerState)
+                : base(region, "Gravity Suit Room", metadata)
+            {
+                PostChozoConcertGravitySuitChamber = new Location(this, 135, 0x8FC36D, LocationType.Chozo,
+                    name: "Gravity Suit",
+                    vanillaItem: ItemType.Gravity,
+                    access: items => region.CanViewConcert(items, requireRewards: true),
+                    relevanceRequirement: items => region.CanViewConcert(items, requireRewards: false),
+                    memoryAddress: 0x10,
+                    memoryFlag: 0x80,
+                    metadata: metadata,
+                    trackerState: trackerState);
+            }
+
+            public Location PostChozoConcertGravitySuitChamber { get; }
         }
     }
 }

--- a/src/Randomizer.SMZ3.Tracking/Tracker.cs
+++ b/src/Randomizer.SMZ3.Tracking/Tracker.cs
@@ -2580,7 +2580,7 @@ namespace Randomizer.SMZ3.Tracking
                     .OrderByDescending(x => x.Count())
                     .ThenBy(x => x.Key.Name);
 
-                if (newlyAccessible.Contains(World.InnerMaridia.ShaktoolItem))
+                if (newlyAccessible.Contains(World.InnerMaridia.SpringBall.ShaktoolItem))
                     Say(Responses.ShaktoolAvailable);
 
                 if (newlyAccessible.Contains(World.DarkWorldNorthWest.PegWorld))

--- a/src/Randomizer.SMZ3/Generation/GameHintService.cs
+++ b/src/Randomizer.SMZ3/Generation/GameHintService.cs
@@ -333,7 +333,9 @@ namespace Randomizer.SMZ3.Generation
             }
             else if (locations.All(x => x.Room != null))
             {
-                var name = _metadataService.Room(locations.First().Room!).Name;
+                var room = locations.First().Room!;
+                var roomInfo = _metadataService.Room(room);
+                var name = roomInfo?.Name ?? room.Name;
                 return $"{name}{GetMultiworldSuffix(hintPlayerWorld, locations.First().World)}";
             }
             else

--- a/src/Randomizer.SMZ3/Generation/GameHintService.cs
+++ b/src/Randomizer.SMZ3/Generation/GameHintService.cs
@@ -331,17 +331,21 @@ namespace Randomizer.SMZ3.Generation
             {
                 return GetLocationName(hintPlayerWorld, locations.First());
             }
-            else if (locations.All(x => x.Room != null))
-            {
-                var room = locations.First().Room!;
-                var roomInfo = _metadataService.Room(room);
-                var name = roomInfo?.Name ?? room.Name;
-                return $"{name}{GetMultiworldSuffix(hintPlayerWorld, locations.First().World)}";
-            }
             else
             {
-                var name = _metadataService.Region(locations.First().Region).Name;
-                return $"{name}{GetMultiworldSuffix(hintPlayerWorld, locations.First().World)}";
+                var room = locations.First().Room;
+
+                if (room != null && locations.All(x => x.Room == room))
+                {
+                    var roomInfo = _metadataService.Room(room);
+                    var name = roomInfo?.Name ?? room.Name;
+                    return $"{name}{GetMultiworldSuffix(hintPlayerWorld, locations.First().World)}";
+                }
+                else
+                {
+                    var name = _metadataService.Region(locations.First().Region).Name;
+                    return $"{name}{GetMultiworldSuffix(hintPlayerWorld, locations.First().World)}";
+                }
             }
         }
 

--- a/tests/Randomizer.SMZ3.Tests/LogicTests/LocationLogicTests.cs
+++ b/tests/Randomizer.SMZ3.Tests/LogicTests/LocationLogicTests.cs
@@ -62,7 +62,7 @@ namespace Randomizer.SMZ3.Tests.LogicTests
         public void LocationWithTwoMissingItemsReturnsTwoMissingItems()
         {
             var emptyProgression = new Progression(World.ItemPools.Keycards, new List<Reward>(), new List<Boss>());
-            var missingItems = Logic.GetMissingRequiredItems(World.GreenBrinstar.PowerBomb, emptyProgression, out _);
+            var missingItems = Logic.GetMissingRequiredItems(World.GreenBrinstar.GreenBrinstarMainShaft.PowerBomb, emptyProgression, out _);
             missingItems.Should().ContainEquivalentOf(new[] { ItemType.Morph, ItemType.PowerBomb });
         }
 
@@ -70,7 +70,7 @@ namespace Randomizer.SMZ3.Tests.LogicTests
         public void LocationWithMultipleOptionsReturnsAllOptions()
         {
             var emptyProgression = new Progression(World.ItemPools.Keycards, new List<Reward>(), new List<Boss>());
-            var missingItems = Logic.GetMissingRequiredItems(World.BlueBrinstar.Ceiling, emptyProgression, out _);
+            var missingItems = Logic.GetMissingRequiredItems(World.BlueBrinstar.BlueBrinstarEnergyTank.Ceiling, emptyProgression, out _);
             missingItems.Should().ContainEquivalentOf(new[] { ItemType.SpaceJump })
                 .And.ContainEquivalentOf(new[] { ItemType.HiJump })
                 .And.ContainEquivalentOf(new[] { ItemType.SpeedBooster })
@@ -81,7 +81,7 @@ namespace Randomizer.SMZ3.Tests.LogicTests
         public void LocationWithThreeMissingItemsReturnsThreeMissingItems()
         {
             var emptyProgression = new Progression(World.ItemPools.Keycards, new List<Reward>(), new List<Boss>());
-            var missingItems = Logic.GetMissingRequiredItems(World.CentralCrateria.BombTorizo, emptyProgression, out _);
+            var missingItems = Logic.GetMissingRequiredItems(World.CentralCrateria.BombTorizo.BombTorizo, emptyProgression, out _);
             missingItems.Should().ContainEquivalentOf(new[] { ItemType.Morph, ItemType.Super, ItemType.PowerBomb });
         }
     }

--- a/tests/Randomizer.SMZ3.Tests/LogicTests/LogicConfigTests.cs
+++ b/tests/Randomizer.SMZ3.Tests/LogicTests/LogicConfigTests.cs
@@ -42,17 +42,17 @@ namespace Randomizer.SMZ3.Tests.LogicTests
             config.LogicConfig.PreventScrewAttackSoftLock = false;
             World tempWorld = new World(config, "", 0, "");
             var progression = new Progression(new[] { ItemType.ScrewAttack }, new List<RewardType>(), new List<BossType>());
-            var missingItems = Logic.GetMissingRequiredItems(tempWorld.WestCrateria.Terminator, progression, out _);
+            var missingItems = Logic.GetMissingRequiredItems(tempWorld.WestCrateria.Terminator.Terminator, progression, out _);
             missingItems.Should().BeEmpty();
-            tempWorld.WestCrateria.Terminator.IsAvailable(progression).Should().BeTrue();
+            tempWorld.WestCrateria.Terminator.Terminator.IsAvailable(progression).Should().BeTrue();
 
             config.LogicConfig.PreventScrewAttackSoftLock = true;
             tempWorld = new World(config, "", 0, "");
             progression = new Progression(new[] { ItemType.ScrewAttack }, new List<RewardType>(), new List<BossType>());
-            missingItems = Logic.GetMissingRequiredItems(tempWorld.WestCrateria.Terminator, progression, out _);
+            missingItems = Logic.GetMissingRequiredItems(tempWorld.WestCrateria.Terminator.Terminator, progression, out _);
             missingItems.Should().HaveCount(1)
                 .And.ContainEquivalentOf(new[] { ItemType.Morph });
-            tempWorld.WestCrateria.Terminator.IsAvailable(progression).Should().BeFalse();
+            tempWorld.WestCrateria.Terminator.Terminator.IsAvailable(progression).Should().BeFalse();
         }
 
         [Fact]
@@ -63,24 +63,24 @@ namespace Randomizer.SMZ3.Tests.LogicTests
             config.LogicConfig.PreventFivePowerBombSeed = false;
             World tempWorld = new World(config, "", 0, "");
             var progression = new Progression(new[] { ItemType.Morph, ItemType.PowerBomb }, new List<RewardType>(), new List<BossType>());
-            var missingItems = Logic.GetMissingRequiredItems(tempWorld.WestCrateria.Terminator, progression, out _);
+            var missingItems = Logic.GetMissingRequiredItems(tempWorld.WestCrateria.Terminator.Terminator, progression, out _);
             missingItems.Should().BeEmpty();
-            tempWorld.WestCrateria.Terminator.IsAvailable(progression).Should().BeTrue();
+            tempWorld.WestCrateria.Terminator.Terminator.IsAvailable(progression).Should().BeTrue();
 
             config.LogicConfig.PreventFivePowerBombSeed = true;
             tempWorld = new World(config, "", 0, "");
             progression = new Progression(new[] { ItemType.Morph, ItemType.PowerBomb }, new List<RewardType>(), new List<BossType>());
-            missingItems = Logic.GetMissingRequiredItems(tempWorld.WestCrateria.Terminator, progression, out _);
+            missingItems = Logic.GetMissingRequiredItems(tempWorld.WestCrateria.Terminator.Terminator, progression, out _);
             missingItems.Should().HaveCount(3)
                 .And.ContainEquivalentOf(new[] { ItemType.Bombs })
                 .And.ContainEquivalentOf(new[] { ItemType.ScrewAttack })
                 .And.ContainEquivalentOf(new[] { ItemType.PowerBomb });
-            tempWorld.WestCrateria.Terminator.IsAvailable(progression).Should().BeFalse();
+            tempWorld.WestCrateria.Terminator.Terminator.IsAvailable(progression).Should().BeFalse();
 
             progression = new Progression(new[] { ItemType.Morph, ItemType.PowerBomb, ItemType.PowerBomb }, new List<RewardType>(), new List<BossType>());
-            missingItems = Logic.GetMissingRequiredItems(tempWorld.WestCrateria.Terminator, progression, out _);
+            missingItems = Logic.GetMissingRequiredItems(tempWorld.WestCrateria.Terminator.Terminator, progression, out _);
             missingItems.Should().BeEmpty();
-            tempWorld.WestCrateria.Terminator.IsAvailable(progression).Should().BeTrue();
+            tempWorld.WestCrateria.Terminator.Terminator.IsAvailable(progression).Should().BeTrue();
         }
 
         [Fact]
@@ -119,18 +119,18 @@ namespace Randomizer.SMZ3.Tests.LogicTests
             config.LogicConfig.InfiniteBombJump = false;
             World tempWorld = new World(config, "", 0, "");
             var progression = new Progression(new[] { ItemType.Morph, ItemType.PowerBomb, ItemType.Bombs }, new List<RewardType>(), new List<BossType>());
-            var missingItems = Logic.GetMissingRequiredItems(tempWorld.CentralCrateria.PowerBombRoom, progression, out _);
+            var missingItems = Logic.GetMissingRequiredItems(tempWorld.CentralCrateria.PowerBomb.PowerBomb, progression, out _);
             missingItems.Should().HaveCount(2)
                 .And.ContainEquivalentOf(new[] { ItemType.SpaceJump })
                 .And.ContainEquivalentOf(new[] { ItemType.SpeedBooster });
-            tempWorld.CentralCrateria.PowerBombRoom.IsAvailable(progression).Should().BeFalse();
+            tempWorld.CentralCrateria.PowerBomb.PowerBomb.IsAvailable(progression).Should().BeFalse();
 
             config.LogicConfig.InfiniteBombJump = true;
             tempWorld = new World(config, "", 0, "");
             progression = new Progression(new[] { ItemType.Morph, ItemType.PowerBomb, ItemType.Bombs }, new List<RewardType>(), new List<BossType>());
-            missingItems = Logic.GetMissingRequiredItems(tempWorld.CentralCrateria.PowerBombRoom, progression, out _);
+            missingItems = Logic.GetMissingRequiredItems(tempWorld.CentralCrateria.PowerBomb.PowerBomb, progression, out _);
             missingItems.Should().BeEmpty();
-            tempWorld.CentralCrateria.PowerBombRoom.IsAvailable(progression).Should().BeTrue();
+            tempWorld.CentralCrateria.PowerBomb.PowerBomb.IsAvailable(progression).Should().BeTrue();
         }
 
         [Fact]
@@ -141,23 +141,23 @@ namespace Randomizer.SMZ3.Tests.LogicTests
             config.LogicConfig.ParlorSpeedBooster = false;
             World tempWorld = new World(config, "", 0, "");
             var progression = new Progression();
-            var missingItems = Logic.GetMissingRequiredItems(tempWorld.WestCrateria.Terminator, progression, out _);
+            var missingItems = Logic.GetMissingRequiredItems(tempWorld.WestCrateria.Terminator.Terminator, progression, out _);
             missingItems.Should().HaveCount(7)
                 .And.NotContainEquivalentOf(new[] { ItemType.SpeedBooster });
-            tempWorld.WestCrateria.Terminator.IsAvailable(progression).Should().BeFalse();
+            tempWorld.WestCrateria.Terminator.Terminator.IsAvailable(progression).Should().BeFalse();
 
             config.LogicConfig.ParlorSpeedBooster = true;
             tempWorld = new World(config, "", 0, "");
             progression = new Progression();
-            missingItems = Logic.GetMissingRequiredItems(tempWorld.WestCrateria.Terminator, progression, out _);
+            missingItems = Logic.GetMissingRequiredItems(tempWorld.WestCrateria.Terminator.Terminator, progression, out _);
             missingItems.Should().HaveCount(8)
                 .And.ContainEquivalentOf(new[] { ItemType.SpeedBooster });
-            tempWorld.WestCrateria.Terminator.IsAvailable(progression).Should().BeFalse();
+            tempWorld.WestCrateria.Terminator.Terminator.IsAvailable(progression).Should().BeFalse();
 
             progression = new Progression(new[] { ItemType.SpeedBooster }, new List<RewardType>(), new List<BossType>());
-            missingItems = Logic.GetMissingRequiredItems(tempWorld.WestCrateria.Terminator, progression, out _);
+            missingItems = Logic.GetMissingRequiredItems(tempWorld.WestCrateria.Terminator.Terminator, progression, out _);
             missingItems.Should().BeEmpty();
-            tempWorld.WestCrateria.Terminator.IsAvailable(progression).Should().BeTrue();
+            tempWorld.WestCrateria.Terminator.Terminator.IsAvailable(progression).Should().BeTrue();
         }
 
         [Fact]
@@ -168,23 +168,23 @@ namespace Randomizer.SMZ3.Tests.LogicTests
             config.LogicConfig.MockBall = false;
             World tempWorld = new World(config, "", 0, "");
             var progression = new Progression(new[] { ItemType.Morph, ItemType.Bombs , ItemType.Missile , ItemType.PowerBomb, ItemType.ScrewAttack }, new List<RewardType>(), new List<BossType>());
-            var missingItems = Logic.GetMissingRequiredItems(tempWorld.GreenBrinstar.TopSuperMissile, progression, out _);
+            var missingItems = Logic.GetMissingRequiredItems(tempWorld.GreenBrinstar.MockballHall.TopSuperMissile, progression, out _);
             missingItems.Should().HaveCount(1)
                 .And.ContainEquivalentOf(new[] { ItemType.SpeedBooster });
-            tempWorld.GreenBrinstar.TopSuperMissile.IsAvailable(progression).Should().BeFalse();
+            tempWorld.GreenBrinstar.MockballHall.TopSuperMissile.IsAvailable(progression).Should().BeFalse();
 
             config.LogicConfig.MockBall = true;
             tempWorld = new World(config, "", 0, "");
-            missingItems = Logic.GetMissingRequiredItems(tempWorld.GreenBrinstar.TopSuperMissile, progression, out _);
+            missingItems = Logic.GetMissingRequiredItems(tempWorld.GreenBrinstar.MockballHall.TopSuperMissile, progression, out _);
             missingItems.Should().BeEmpty();
-            tempWorld.GreenBrinstar.TopSuperMissile.IsAvailable(progression).Should().BeTrue();
+            tempWorld.GreenBrinstar.MockballHall.TopSuperMissile.IsAvailable(progression).Should().BeTrue();
 
             progression = new Progression(new[] { ItemType.Bombs, ItemType.Missile, ItemType.PowerBomb, ItemType.ScrewAttack }, new List<RewardType>(), new List<BossType>());
-            missingItems = Logic.GetMissingRequiredItems(tempWorld.GreenBrinstar.TopSuperMissile, progression, out _);
+            missingItems = Logic.GetMissingRequiredItems(tempWorld.GreenBrinstar.MockballHall.TopSuperMissile, progression, out _);
             missingItems.Should().HaveCount(2)
                 .And.ContainEquivalentOf(new[] { ItemType.SpeedBooster })
                 .And.ContainEquivalentOf(new[] { ItemType.Morph });
-            tempWorld.GreenBrinstar.TopSuperMissile.IsAvailable(progression).Should().BeFalse();
+            tempWorld.GreenBrinstar.MockballHall.TopSuperMissile.IsAvailable(progression).Should().BeFalse();
         }
 
         [Fact]
@@ -294,21 +294,21 @@ namespace Randomizer.SMZ3.Tests.LogicTests
             config.LogicConfig.LaunchPadRequiresIceBeam = false;
             var tempWorld = new World(config, "", 0, "");
             var progression = new Progression(new[] { ItemType.ETank, ItemType.ETank, ItemType.Morph, ItemType.SpeedBooster, ItemType.PowerBomb, ItemType.PowerBomb}, new List<RewardType>(), new List<BossType>());
-            var missingItems = Logic.GetMissingRequiredItems(tempWorld.CentralCrateria.SuperMissile, progression, out _);
+            var missingItems = Logic.GetMissingRequiredItems(tempWorld.CentralCrateria.CrateriaSuper.SuperMissile, progression, out _);
             missingItems.Should().BeEmpty();
-            tempWorld.CentralCrateria.SuperMissile.IsAvailable(progression).Should().BeTrue();
+            tempWorld.CentralCrateria.CrateriaSuper.SuperMissile.IsAvailable(progression).Should().BeTrue();
 
             config.LogicConfig.LaunchPadRequiresIceBeam = true;
             tempWorld = new World(config, "", 0, "");
-            missingItems = Logic.GetMissingRequiredItems(tempWorld.CentralCrateria.SuperMissile, progression, out _);
+            missingItems = Logic.GetMissingRequiredItems(tempWorld.CentralCrateria.CrateriaSuper.SuperMissile, progression, out _);
             missingItems.Should().HaveCount(1)
                 .And.ContainEquivalentOf(new[] { ItemType.Ice });
-            tempWorld.CentralCrateria.SuperMissile.IsAvailable(progression).Should().BeFalse();
+            tempWorld.CentralCrateria.CrateriaSuper.SuperMissile.IsAvailable(progression).Should().BeFalse();
 
             progression = new Progression(new[] { ItemType.ETank, ItemType.ETank, ItemType.Morph, ItemType.SpeedBooster, ItemType.PowerBomb, ItemType.PowerBomb, ItemType.Ice }, new List<RewardType>(), new List<BossType>());
-            missingItems = Logic.GetMissingRequiredItems(tempWorld.CentralCrateria.SuperMissile, progression, out _);
+            missingItems = Logic.GetMissingRequiredItems(tempWorld.CentralCrateria.CrateriaSuper.SuperMissile, progression, out _);
             missingItems.Should().BeEmpty();
-            tempWorld.CentralCrateria.SuperMissile.IsAvailable(progression).Should().BeTrue();
+            tempWorld.CentralCrateria.CrateriaSuper.SuperMissile.IsAvailable(progression).Should().BeTrue();
         }
 
         [Fact]
@@ -319,21 +319,21 @@ namespace Randomizer.SMZ3.Tests.LogicTests
             config.LogicConfig.WaterwayNeedsGravitySuit = false;
             var tempWorld = new World(config, "", 0, "");
             var progression = new Progression(new[] { ItemType.ETank, ItemType.ETank, ItemType.Morph, ItemType.SpeedBooster, ItemType.PowerBomb, ItemType.PowerBomb, ItemType.Missile }, new List<RewardType>(), new List<BossType>());
-            var missingItems = Logic.GetMissingRequiredItems(tempWorld.PinkBrinstar.Waterway, progression, out _);
+            var missingItems = Logic.GetMissingRequiredItems(tempWorld.PinkBrinstar.WaterwayEnergyTank.Waterway, progression, out _);
             missingItems.Should().BeEmpty();
-            tempWorld.PinkBrinstar.Waterway.IsAvailable(progression).Should().BeTrue();
+            tempWorld.PinkBrinstar.WaterwayEnergyTank.Waterway.IsAvailable(progression).Should().BeTrue();
 
             config.LogicConfig.WaterwayNeedsGravitySuit = true;
             tempWorld = new World(config, "", 0, "");
-            missingItems = Logic.GetMissingRequiredItems(tempWorld.PinkBrinstar.Waterway, progression, out _);
+            missingItems = Logic.GetMissingRequiredItems(tempWorld.PinkBrinstar.WaterwayEnergyTank.Waterway, progression, out _);
             missingItems.Should().HaveCount(1)
                 .And.ContainEquivalentOf(new[] { ItemType.Gravity });
-            tempWorld.PinkBrinstar.Waterway.IsAvailable(progression).Should().BeFalse();
+            tempWorld.PinkBrinstar.WaterwayEnergyTank.Waterway.IsAvailable(progression).Should().BeFalse();
 
             progression = new Progression(new[] { ItemType.ETank, ItemType.ETank, ItemType.Morph, ItemType.SpeedBooster, ItemType.PowerBomb, ItemType.PowerBomb, ItemType.Missile, ItemType.Gravity }, new List<RewardType>(), new List<BossType>());
-            missingItems = Logic.GetMissingRequiredItems(tempWorld.CentralCrateria.SuperMissile, progression, out _);
+            missingItems = Logic.GetMissingRequiredItems(tempWorld.CentralCrateria.CrateriaSuper.SuperMissile, progression, out _);
             missingItems.Should().BeEmpty();
-            tempWorld.PinkBrinstar.Waterway.IsAvailable(progression).Should().BeTrue();
+            tempWorld.PinkBrinstar.WaterwayEnergyTank.Waterway.IsAvailable(progression).Should().BeTrue();
         }
 
         [Fact]
@@ -344,23 +344,23 @@ namespace Randomizer.SMZ3.Tests.LogicTests
             config.LogicConfig.EasyEastCrateriaSkyItem = false;
             var tempWorld = new World(config, "", 0, "");
             var progression = new Progression(new[] { ItemType.ETank, ItemType.ETank, ItemType.Morph, ItemType.PowerBomb, ItemType.PowerBomb, ItemType.Super, ItemType.Gravity, ItemType.Grapple }, new List<RewardType>(), new List<BossType>() { BossType.Phantoon });
-            var missingItems = Logic.GetMissingRequiredItems(tempWorld.EastCrateria.SkyMissile, progression, out _);
+            var missingItems = Logic.GetMissingRequiredItems(tempWorld.EastCrateria.WestOcean.SkyMissile, progression, out _);
             missingItems.Should().BeEmpty();
-            tempWorld.EastCrateria.SkyMissile.IsAvailable(progression).Should().BeTrue();
+            tempWorld.EastCrateria.WestOcean.SkyMissile.IsAvailable(progression).Should().BeTrue();
 
             config.LogicConfig.EasyEastCrateriaSkyItem = true;
             tempWorld = new World(config, "", 0, "");
-            missingItems = Logic.GetMissingRequiredItems(tempWorld.EastCrateria.SkyMissile, progression, out _);
+            missingItems = Logic.GetMissingRequiredItems(tempWorld.EastCrateria.WestOcean.SkyMissile, progression, out _);
             missingItems.Should().HaveCount(2)
                 .And.ContainEquivalentOf(new[] { ItemType.SpaceJump })
                 .And.ContainEquivalentOf(new[] { ItemType.SpeedBooster });
 
-            tempWorld.EastCrateria.SkyMissile.IsAvailable(progression).Should().BeFalse();
+            tempWorld.EastCrateria.WestOcean.SkyMissile.IsAvailable(progression).Should().BeFalse();
 
             progression = new Progression(new[] { ItemType.ETank, ItemType.ETank, ItemType.Morph, ItemType.PowerBomb, ItemType.PowerBomb, ItemType.Super, ItemType.Gravity, ItemType.Grapple, ItemType.SpaceJump }, new List<RewardType>(), new List<BossType>() { BossType.Phantoon });
-            missingItems = Logic.GetMissingRequiredItems(tempWorld.EastCrateria.SkyMissile, progression, out _);
+            missingItems = Logic.GetMissingRequiredItems(tempWorld.EastCrateria.WestOcean.SkyMissile, progression, out _);
             missingItems.Should().BeEmpty();
-            tempWorld.EastCrateria.SkyMissile.IsAvailable(progression).Should().BeTrue();
+            tempWorld.EastCrateria.WestOcean.SkyMissile.IsAvailable(progression).Should().BeTrue();
         }
 
         [Fact]

--- a/tests/Randomizer.SMZ3.Tests/LogicTests/RandomizerTests.cs
+++ b/tests/Randomizer.SMZ3.Tests/LogicTests/RandomizerTests.cs
@@ -25,7 +25,7 @@ namespace Randomizer.SMZ3.Tests.LogicTests
     {
         // If this test breaks, update Smz3Randomizer.Version
         [Theory]
-        [InlineData("test", 123066760)] // Smz3Randomizer v4.0
+        [InlineData("test", -420637834)] // Smz3Randomizer v4.0
         public void StandardFillerWithSameSeedGeneratesSameWorld(string seed, int expectedHash)
         {
             var filler = new StandardFiller(GetLogger<StandardFiller>());


### PR DESCRIPTION
Closes #14. I don't know if we want to try to squeeze this into this week's release or give it a little more time to bake, but here's the PR. I tried not to mess too much with existing logic or property names, except when the location had the same name as the room it went into and the compiler didn't like that. Asking for hints and clearing locations seemed to be working well. I did have to add a workaround so rooms not declared in `rooms.yml` wouldn't cause problems; I don't know if we want something more robust in place there.

Room names are from this wiki: https://wiki.supermetroid.run/List_of_rooms

Also closes #327, by way of giving the room with the Plasma Beam the name "Plasma Beam Room".