### PR TITLE
Resend Missed Multiworld Items

### DIFF
--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/AutoTracker.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/AutoTracker.cs
@@ -108,6 +108,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
                 Address = 0x7ef000,
                 Length = 0x250,
                 Game = Game.Zelda,
+                FrequencySeconds = 1,
                 Action = CheckZeldaRooms
             });
 
@@ -119,6 +120,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
                 Address = 0x7ef280,
                 Length = 0x200,
                 Game = Game.Zelda,
+                FrequencySeconds = 1,
                 Action = CheckZeldaMisc
             });
 
@@ -141,6 +143,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
                 Address = 0xA17400,
                 Length = 0x120,
                 Game = Game.Both,
+                FrequencySeconds = 1,
                 Action = CheckBeatFinalBosses
             });
 
@@ -152,6 +155,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
                 Address = 0x7ed870,
                 Length = 0x20,
                 Game = Game.SM,
+                FrequencySeconds = 1,
                 Action = CheckMetroidLocations
             });
 
@@ -163,6 +167,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
                 Address = 0x7ed828,
                 Length = 0x08,
                 Game = Game.SM,
+                FrequencySeconds = 1,
                 Action = CheckMetroidBosses
             });
 
@@ -193,15 +198,28 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
             {
                 Type = EmulatorActionType.ReadBlock,
                 Domain = MemoryDomain.CartRAM,
-                Address = 0xA26602,
-                Length = 0x2,
+                Address = 0xA26000,
+                Length = 0x300,
                 Game = Game.Both,
-                Action = test =>
+                FrequencySeconds = 30,
+                Action = action =>
                 {
-                    if (Tracker.GameService != null)
-                    {
-                        Tracker.GameService.ItemCounter = test.CurrentData?.ReadUInt16(0) ?? 0;
-                    }
+                    Tracker.GameService?.SyncItems(action);
+                }
+            });
+
+            // Get the number of items given to the player via the interactor
+            AddReadAction(new()
+            {
+                Type = EmulatorActionType.ReadBlock,
+                Domain = MemoryDomain.CartRAM,
+                Address = 0xA26300,
+                Length = 0x300,
+                Game = Game.Both,
+                FrequencySeconds = 30,
+                Action = action =>
+                {
+                    Tracker.GameService?.SyncItems(action);
                 }
             });
 

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/EmulatorAction.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/EmulatorAction.cs
@@ -55,7 +55,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         public EmulatorMemoryData? CurrentData { get; protected set; }
 
         /// <summary>
-        /// How frequently this should be ran
+        /// The amount of time that should happen between consecutive reads
         /// </summary>
         public double FrequencySeconds = 0;
 

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/EmulatorAction.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/EmulatorAction.cs
@@ -55,6 +55,16 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         public EmulatorMemoryData? CurrentData { get; protected set; }
 
         /// <summary>
+        /// How frequently this should be ran
+        /// </summary>
+        public double FrequencySeconds = 0;
+
+        /// <summary>
+        /// When this action was last executed
+        /// </summary>
+        public DateTime? LastRunTime;
+
+        /// <summary>
         /// Update the stored data and invoke the action
         /// </summary>
         /// <param name="data">The data collected from the emulator</param>
@@ -62,6 +72,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         {
             PreviousData = CurrentData;
             CurrentData = data;
+            LastRunTime = DateTime.Now;
             Action?.Invoke(this);
         }
 
@@ -73,7 +84,19 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// <returns>True if the message should be sent.</returns>
         public bool ShouldProcess(Game currentGame, bool hasStartedGame)
         {
-            return (!hasStartedGame && Game == Game.Neither) || (hasStartedGame && Game != Game.Neither && (Game == Game.Both || Game == currentGame));
+            return HasExpired && ((!hasStartedGame && Game == Game.Neither) || (hasStartedGame && Game != Game.Neither && (Game == Game.Both || Game == currentGame)));
+        }
+
+        /// <summary>
+        /// If the previous action's result has expired
+        /// </summary>
+        public bool HasExpired
+        {
+            get
+            {
+                return FrequencySeconds <= 0 || LastRunTime == null ||
+                       (DateTime.Now - LastRunTime.Value).TotalSeconds >= FrequencySeconds;
+            }
         }
 
         /// <summary>

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/EmulatorMemoryData.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/EmulatorMemoryData.cs
@@ -20,6 +20,17 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         }
 
         /// <summary>
+        /// The raw byte array of the data
+        /// </summary>
+        public byte[] Raw
+        {
+            get
+            {
+                return _bytes;
+            }
+        }
+
+        /// <summary>
         /// Returns the memory value at a location
         /// </summary>
         /// <param name="location">The offset location to check</param>

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/GameService.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/GameService.cs
@@ -247,6 +247,8 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
                 return false;
             }
 
+            var bytes = Int16ToBytes(2000);
+
             // Writing the target value to $7EF360 makes the rupee count start counting toward it.
             // Writing the target value to $7EF362 immediately sets the rupee count, but then it starts counting back toward where it was.
             // Writing the target value to both locations immediately sets the rupee count and keeps it there.
@@ -255,7 +257,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
                 Type = EmulatorActionType.WriteBytes,
                 Domain = MemoryDomain.WRAM,
                 Address = 0x7EF360,
-                WriteValues = Int16ToBytes(2000)
+                WriteValues = bytes.Concat(bytes).ToList()
             });
 
             return true;

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/GameService.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/GameService.cs
@@ -58,7 +58,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// <returns>False if it is currently unable to give an item to the player</returns>
         public bool TryGiveItems(List<Item> items, int fromPlayerId)
         {
-            if (AutoTracker is not { IsConnected: true, IsInSMZ3: true })
+            if (!IsInGame())
             {
                 return false;
             }
@@ -75,7 +75,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// <returns>False if it is currently unable to give the items to the player</returns>
         public bool TryGiveItemTypes(List<(ItemType type, int fromPlayerId)> items)
         {
-            if (AutoTracker is not { IsConnected: true, IsInSMZ3: true })
+            if (!IsInGame())
             {
                 return false;
             }
@@ -101,7 +101,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
                     Address = 0xA26000 + (tempItemCounter * 4),
                     WriteValues = bytes
                 };
-                AutoTracker.WriteToMemory(action);
+                AutoTracker!.WriteToMemory(action);
 
                 tempItemCounter += batch.Length;
             }
@@ -114,7 +114,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
                 Address = 0xA26602,
                 WriteValues = Int16ToBytes(tempItemCounter)
             };
-            AutoTracker.WriteToMemory(action);
+            AutoTracker!.WriteToMemory(action);
 
             _itemCounter = tempItemCounter;
 
@@ -127,12 +127,12 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// <returns>False if it is currently unable to give an item to the player</returns>
         public bool TryHealPlayer()
         {
-            if (AutoTracker == null || !AutoTracker.IsConnected || !AutoTracker.IsInSMZ3)
+            if (!IsInGame())
             {
                 return false;
             }
 
-            if (AutoTracker.CurrentGame == Game.Zelda)
+            if (AutoTracker!.CurrentGame == Game.Zelda)
             {
                 AutoTracker.WriteToMemory(new EmulatorAction()
                 {
@@ -176,12 +176,12 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// <returns>False if it is currently unable to give magic to the player</returns>
         public bool TryFillMagic()
         {
-            if (AutoTracker == null || !AutoTracker.IsConnected || AutoTracker.CurrentGame != Game.Zelda || !AutoTracker.IsInSMZ3)
+            if (!IsInGame(Game.Zelda))
             {
                 return false;
             }
 
-            AutoTracker.WriteToMemory(new EmulatorAction()
+            AutoTracker!.WriteToMemory(new EmulatorAction()
             {
                 Type = EmulatorActionType.WriteBytes,
                 Domain = MemoryDomain.WRAM,
@@ -198,12 +198,12 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// <returns>False if it is currently unable to give bombs to the player</returns>
         public bool TryFillZeldaBombs()
         {
-            if (AutoTracker == null || !AutoTracker.IsConnected || AutoTracker.CurrentGame != Game.Zelda || !AutoTracker.IsInSMZ3)
+            if (!IsInGame(Game.Zelda))
             {
                 return false;
             }
 
-            AutoTracker.WriteToMemory(new EmulatorAction()
+            AutoTracker!.WriteToMemory(new EmulatorAction()
             {
                 Type = EmulatorActionType.WriteBytes,
                 Domain = MemoryDomain.WRAM,
@@ -220,12 +220,12 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// <returns>False if it is currently unable to give arrows to the player</returns>
         public bool TryFillArrows()
         {
-            if (AutoTracker == null || !AutoTracker.IsConnected || AutoTracker.CurrentGame != Game.Zelda || !AutoTracker.IsInSMZ3)
+            if (!IsInGame(Game.Zelda))
             {
                 return false;
             }
 
-            AutoTracker.WriteToMemory(new EmulatorAction()
+            AutoTracker!.WriteToMemory(new EmulatorAction()
             {
                 Type = EmulatorActionType.WriteBytes,
                 Domain = MemoryDomain.WRAM,
@@ -242,7 +242,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// <returns>False if it is currently unable to give rupees to the player</returns>
         public bool TryFillRupees()
         {
-            if (AutoTracker == null || !AutoTracker.IsConnected || AutoTracker.CurrentGame != Game.Zelda || !AutoTracker.IsInSMZ3)
+            if (!IsInGame(Game.Zelda))
             {
                 return false;
             }
@@ -252,7 +252,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
             // Writing the target value to $7EF360 makes the rupee count start counting toward it.
             // Writing the target value to $7EF362 immediately sets the rupee count, but then it starts counting back toward where it was.
             // Writing the target value to both locations immediately sets the rupee count and keeps it there.
-            AutoTracker.WriteToMemory(new EmulatorAction()
+            AutoTracker!.WriteToMemory(new EmulatorAction()
             {
                 Type = EmulatorActionType.WriteBytes,
                 Domain = MemoryDomain.WRAM,
@@ -269,12 +269,12 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// <returns>False if it is currently unable to give missiles to the player</returns>
         public bool TryFillMissiles()
         {
-            if (AutoTracker == null || !AutoTracker.IsConnected || AutoTracker.CurrentGame != Game.SM || !AutoTracker.IsInSMZ3)
+            if (!IsInGame(Game.SM))
             {
                 return false;
             }
 
-            var maxMissiles = AutoTracker.MetroidState?.MaxMissiles ?? 0;
+            var maxMissiles = AutoTracker!.MetroidState?.MaxMissiles ?? 0;
             AutoTracker.WriteToMemory(new EmulatorAction()
             {
                 Type = EmulatorActionType.WriteBytes,
@@ -292,12 +292,12 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// <returns>False if it is currently unable to give super missiles to the player</returns>
         public bool TryFillSuperMissiles()
         {
-            if (AutoTracker == null || !AutoTracker.IsConnected || AutoTracker.CurrentGame != Game.SM || !AutoTracker.IsInSMZ3)
+            if (!IsInGame(Game.SM))
             {
                 return false;
             }
 
-            var maxSuperMissiles = AutoTracker.MetroidState?.MaxSuperMissiles ?? 0;
+            var maxSuperMissiles = AutoTracker!.MetroidState?.MaxSuperMissiles ?? 0;
             AutoTracker.WriteToMemory(new EmulatorAction()
             {
                 Type = EmulatorActionType.WriteBytes,
@@ -315,12 +315,12 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// <returns>False if it is currently unable to give power bombs to the player</returns>
         public bool TryFillPowerBombs()
         {
-            if (AutoTracker == null || !AutoTracker.IsConnected || AutoTracker.CurrentGame != Game.SM || !AutoTracker.IsInSMZ3)
+            if (!IsInGame(Game.SM))
             {
                 return false;
             }
 
-            var maxPowerBombs = AutoTracker.MetroidState?.MaxPowerBombs ?? 0;
+            var maxPowerBombs = AutoTracker!.MetroidState?.MaxPowerBombs ?? 0;
             AutoTracker.WriteToMemory(new EmulatorAction()
             {
                 Type = EmulatorActionType.WriteBytes,
@@ -338,12 +338,12 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// <returns>True if successful</returns>
         public bool TryKillPlayer()
         {
-            if (AutoTracker == null || !AutoTracker.IsConnected || !AutoTracker.IsInSMZ3)
+            if (!IsInGame())
             {
                 return false;
             }
 
-            if (AutoTracker.CurrentGame == Game.Zelda)
+            if (AutoTracker!.CurrentGame == Game.Zelda)
             {
                 // Set health to 0
                 AutoTracker.WriteToMemory(new EmulatorAction()
@@ -405,13 +405,13 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// <returns>True if successful</returns>
         public bool TrySetupCrystalFlash()
         {
-            if (AutoTracker == null || !AutoTracker.IsConnected || !AutoTracker.IsInSMZ3 || AutoTracker.CurrentGame != Game.SM)
+            if (!IsInGame(Game.SM))
             {
                 return false;
             }
 
             // Set HP to 50 health
-            AutoTracker.WriteToMemory(new EmulatorAction()
+            AutoTracker!.WriteToMemory(new EmulatorAction()
             {
                 Type = EmulatorActionType.WriteBytes,
                 Domain = MemoryDomain.WRAM,
@@ -521,6 +521,15 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
                 bytes.Reverse();
             }
             return bytes.ToArray();
+        }
+
+        private bool IsInGame(Game game = Game.Both)
+        {
+            if (AutoTracker is { IsConnected: true, IsInSMZ3: true, HasValidState: true })
+            {
+                return game == Game.Both || AutoTracker.CurrentGame == game;
+            }
+            return false;
         }
     }
 }

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/GameService.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/GameService.cs
@@ -1,11 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Randomizer.Shared;
-using Randomizer.Data.Configuration.ConfigTypes;
 using Randomizer.SMZ3.Tracking.Services;
 using Randomizer.SMZ3.Tracking.VoiceCommands;
 using Randomizer.Data.WorldData;
@@ -19,9 +16,11 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
     /// </summary>
     public class GameService : TrackerModule
     {
-        private AutoTracker? _autoTracker => Tracker.AutoTracker;
+        private AutoTracker? AutoTracker => Tracker.AutoTracker;
         private readonly ILogger<GameService> _logger;
-        private readonly int trackerPlayerId;
+        private readonly int _trackerPlayerId;
+        private int _itemCounter;
+        private readonly Dictionary<int, EmulatorAction> _emulatorActions = new();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GameService"/>
@@ -37,7 +36,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         {
             Tracker.GameService = this;
             _logger = logger;
-            trackerPlayerId = worldAccessor.Worlds.Count > 0 ? worldAccessor.Worlds.Count : 0;
+            _trackerPlayerId = worldAccessor.Worlds.Count > 0 ? worldAccessor.Worlds.Count : 0;
         }
 
         /// <summary>
@@ -48,7 +47,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// <returns>False if it is currently unable to give an item to the player</returns>
         public bool TryGiveItem(Item item, int? fromPlayerId)
         {
-            return TryGiveItems(new List<Item>() { item }, fromPlayerId ?? trackerPlayerId);
+            return TryGiveItems(new List<Item>() { item }, fromPlayerId ?? _trackerPlayerId);
         }
 
         /// <summary>
@@ -59,12 +58,29 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// <returns>False if it is currently unable to give an item to the player</returns>
         public bool TryGiveItems(List<Item> items, int fromPlayerId)
         {
-            if (_autoTracker is not { IsConnected: true, IsInSMZ3: true })
+            if (AutoTracker is not { IsConnected: true, IsInSMZ3: true })
             {
                 return false;
             }
 
-            var tempItemCounter = ItemCounter;
+            Tracker.TrackItems(items, true, true);
+
+            return TryGiveItemTypes(items.Select(x => (x.Type, fromPlayerId)).ToList());
+        }
+
+        /// <summary>
+        /// Gives a series of item types from particular players
+        /// </summary>
+        /// <param name="items">The list of item types and the players that are giving the item to the player</param>
+        /// <returns>False if it is currently unable to give the items to the player</returns>
+        public bool TryGiveItemTypes(List<(ItemType type, int fromPlayerId)> items)
+        {
+            if (AutoTracker is not { IsConnected: true, IsInSMZ3: true })
+            {
+                return false;
+            }
+
+            var tempItemCounter = _itemCounter;
             EmulatorAction action;
 
             // First give the player all of the requested items
@@ -74,8 +90,8 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
                 var bytes = new List<byte>();
                 foreach (var item in batch)
                 {
-                    bytes.AddRange(Int16ToBytes(fromPlayerId));
-                    bytes.AddRange(Int16ToBytes((int)item.Type));
+                    bytes.AddRange(Int16ToBytes(item.fromPlayerId));
+                    bytes.AddRange(Int16ToBytes((int)item.type));
                 }
 
                 action = new EmulatorAction()
@@ -85,12 +101,10 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
                     Address = 0xA26000 + (tempItemCounter * 4),
                     WriteValues = bytes
                 };
-                _autoTracker.WriteToMemory(action);
+                AutoTracker.WriteToMemory(action);
 
                 tempItemCounter += batch.Length;
             }
-
-            Tracker.TrackItems(items, true, true);
 
             // Up the item counter to have them actually pick it up
             action = new EmulatorAction()
@@ -100,9 +114,10 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
                 Address = 0xA26602,
                 WriteValues = Int16ToBytes(tempItemCounter)
             };
-            _autoTracker.WriteToMemory(action);
+            AutoTracker.WriteToMemory(action);
 
-            ItemCounter = tempItemCounter;
+            _itemCounter = tempItemCounter;
+
             return true;
         }
 
@@ -112,14 +127,14 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// <returns>False if it is currently unable to give an item to the player</returns>
         public bool TryHealPlayer()
         {
-            if (_autoTracker == null || !_autoTracker.IsConnected || !_autoTracker.IsInSMZ3)
+            if (AutoTracker == null || !AutoTracker.IsConnected || !AutoTracker.IsInSMZ3)
             {
                 return false;
             }
 
-            if (_autoTracker.CurrentGame == Game.Zelda)
+            if (AutoTracker.CurrentGame == Game.Zelda)
             {
-                _autoTracker.WriteToMemory(new EmulatorAction()
+                AutoTracker.WriteToMemory(new EmulatorAction()
                 {
                     Type = EmulatorActionType.WriteBytes,
                     Domain = MemoryDomain.WRAM,
@@ -129,11 +144,11 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
 
                 return true;
             }
-            else if (_autoTracker.CurrentGame == Game.SM && _autoTracker.MetroidState != null)
+            else if (AutoTracker.CurrentGame == Game.SM && AutoTracker.MetroidState != null)
             {
-                var maxHealth = _autoTracker.MetroidState.MaxEnergy;
-                var maxReserves = _autoTracker.MetroidState.MaxReserveTanks;
-                _autoTracker.WriteToMemory(new EmulatorAction()
+                var maxHealth = AutoTracker.MetroidState.MaxEnergy;
+                var maxReserves = AutoTracker.MetroidState.MaxReserveTanks;
+                AutoTracker.WriteToMemory(new EmulatorAction()
                 {
                     Type = EmulatorActionType.WriteBytes,
                     Domain = MemoryDomain.WRAM,
@@ -141,7 +156,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
                     WriteValues = Int16ToBytes(maxHealth)
                 });
 
-                _autoTracker.WriteToMemory(new EmulatorAction()
+                AutoTracker.WriteToMemory(new EmulatorAction()
                 {
                     Type = EmulatorActionType.WriteBytes,
                     Domain = MemoryDomain.WRAM,
@@ -161,12 +176,12 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// <returns>False if it is currently unable to give magic to the player</returns>
         public bool TryFillMagic()
         {
-            if (_autoTracker == null || !_autoTracker.IsConnected || _autoTracker.CurrentGame != Game.Zelda || !_autoTracker.IsInSMZ3)
+            if (AutoTracker == null || !AutoTracker.IsConnected || AutoTracker.CurrentGame != Game.Zelda || !AutoTracker.IsInSMZ3)
             {
                 return false;
             }
 
-            _autoTracker.WriteToMemory(new EmulatorAction()
+            AutoTracker.WriteToMemory(new EmulatorAction()
             {
                 Type = EmulatorActionType.WriteBytes,
                 Domain = MemoryDomain.WRAM,
@@ -183,12 +198,12 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// <returns>False if it is currently unable to give bombs to the player</returns>
         public bool TryFillZeldaBombs()
         {
-            if (_autoTracker == null || !_autoTracker.IsConnected || _autoTracker.CurrentGame != Game.Zelda || !_autoTracker.IsInSMZ3)
+            if (AutoTracker == null || !AutoTracker.IsConnected || AutoTracker.CurrentGame != Game.Zelda || !AutoTracker.IsInSMZ3)
             {
                 return false;
             }
 
-            _autoTracker.WriteToMemory(new EmulatorAction()
+            AutoTracker.WriteToMemory(new EmulatorAction()
             {
                 Type = EmulatorActionType.WriteBytes,
                 Domain = MemoryDomain.WRAM,
@@ -205,12 +220,12 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// <returns>False if it is currently unable to give arrows to the player</returns>
         public bool TryFillArrows()
         {
-            if (_autoTracker == null || !_autoTracker.IsConnected || _autoTracker.CurrentGame != Game.Zelda || !_autoTracker.IsInSMZ3)
+            if (AutoTracker == null || !AutoTracker.IsConnected || AutoTracker.CurrentGame != Game.Zelda || !AutoTracker.IsInSMZ3)
             {
                 return false;
             }
 
-            _autoTracker.WriteToMemory(new EmulatorAction()
+            AutoTracker.WriteToMemory(new EmulatorAction()
             {
                 Type = EmulatorActionType.WriteBytes,
                 Domain = MemoryDomain.WRAM,
@@ -227,27 +242,20 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// <returns>False if it is currently unable to give rupees to the player</returns>
         public bool TryFillRupees()
         {
-            if (_autoTracker == null || !_autoTracker.IsConnected || _autoTracker.CurrentGame != Game.Zelda || !_autoTracker.IsInSMZ3)
+            if (AutoTracker == null || !AutoTracker.IsConnected || AutoTracker.CurrentGame != Game.Zelda || !AutoTracker.IsInSMZ3)
             {
                 return false;
-            }
-
-            List<byte> bytes = BitConverter.GetBytes((short)2000).ToList();
-
-            if (!BitConverter.IsLittleEndian)
-            {
-                bytes.Reverse();
             }
 
             // Writing the target value to $7EF360 makes the rupee count start counting toward it.
             // Writing the target value to $7EF362 immediately sets the rupee count, but then it starts counting back toward where it was.
             // Writing the target value to both locations immediately sets the rupee count and keeps it there.
-            _autoTracker.WriteToMemory(new EmulatorAction()
+            AutoTracker.WriteToMemory(new EmulatorAction()
             {
                 Type = EmulatorActionType.WriteBytes,
                 Domain = MemoryDomain.WRAM,
                 Address = 0x7EF360,
-                WriteValues = bytes.Concat(bytes).ToList()
+                WriteValues = Int16ToBytes(2000)
             });
 
             return true;
@@ -259,13 +267,13 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// <returns>False if it is currently unable to give missiles to the player</returns>
         public bool TryFillMissiles()
         {
-            if (_autoTracker == null || !_autoTracker.IsConnected || _autoTracker.CurrentGame != Game.SM || !_autoTracker.IsInSMZ3)
+            if (AutoTracker == null || !AutoTracker.IsConnected || AutoTracker.CurrentGame != Game.SM || !AutoTracker.IsInSMZ3)
             {
                 return false;
             }
 
-            var maxMissiles = _autoTracker.MetroidState?.MaxMissiles ?? 0;
-            _autoTracker.WriteToMemory(new EmulatorAction()
+            var maxMissiles = AutoTracker.MetroidState?.MaxMissiles ?? 0;
+            AutoTracker.WriteToMemory(new EmulatorAction()
             {
                 Type = EmulatorActionType.WriteBytes,
                 Domain = MemoryDomain.WRAM,
@@ -282,13 +290,13 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// <returns>False if it is currently unable to give super missiles to the player</returns>
         public bool TryFillSuperMissiles()
         {
-            if (_autoTracker == null || !_autoTracker.IsConnected || _autoTracker.CurrentGame != Game.SM || !_autoTracker.IsInSMZ3)
+            if (AutoTracker == null || !AutoTracker.IsConnected || AutoTracker.CurrentGame != Game.SM || !AutoTracker.IsInSMZ3)
             {
                 return false;
             }
 
-            var maxSuperMissiles = _autoTracker.MetroidState?.MaxSuperMissiles ?? 0;
-            _autoTracker.WriteToMemory(new EmulatorAction()
+            var maxSuperMissiles = AutoTracker.MetroidState?.MaxSuperMissiles ?? 0;
+            AutoTracker.WriteToMemory(new EmulatorAction()
             {
                 Type = EmulatorActionType.WriteBytes,
                 Domain = MemoryDomain.WRAM,
@@ -305,13 +313,13 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// <returns>False if it is currently unable to give power bombs to the player</returns>
         public bool TryFillPowerBombs()
         {
-            if (_autoTracker == null || !_autoTracker.IsConnected || _autoTracker.CurrentGame != Game.SM || !_autoTracker.IsInSMZ3)
+            if (AutoTracker == null || !AutoTracker.IsConnected || AutoTracker.CurrentGame != Game.SM || !AutoTracker.IsInSMZ3)
             {
                 return false;
             }
 
-            var maxPowerBombs = _autoTracker.MetroidState?.MaxPowerBombs ?? 0;
-            _autoTracker.WriteToMemory(new EmulatorAction()
+            var maxPowerBombs = AutoTracker.MetroidState?.MaxPowerBombs ?? 0;
+            AutoTracker.WriteToMemory(new EmulatorAction()
             {
                 Type = EmulatorActionType.WriteBytes,
                 Domain = MemoryDomain.WRAM,
@@ -328,15 +336,15 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// <returns>True if successful</returns>
         public bool TryKillPlayer()
         {
-            if (_autoTracker == null || !_autoTracker.IsConnected || !_autoTracker.IsInSMZ3)
+            if (AutoTracker == null || !AutoTracker.IsConnected || !AutoTracker.IsInSMZ3)
             {
                 return false;
             }
 
-            if (_autoTracker.CurrentGame == Game.Zelda)
+            if (AutoTracker.CurrentGame == Game.Zelda)
             {
                 // Set health to 0
-                _autoTracker.WriteToMemory(new EmulatorAction()
+                AutoTracker.WriteToMemory(new EmulatorAction()
                 {
                     Type = EmulatorActionType.WriteBytes,
                     Domain = MemoryDomain.WRAM,
@@ -345,7 +353,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
                 });
 
                 // Deal 1 heart of damage
-                _autoTracker.WriteToMemory(new EmulatorAction()
+                AutoTracker.WriteToMemory(new EmulatorAction()
                 {
                     Type = EmulatorActionType.WriteBytes,
                     Domain = MemoryDomain.WRAM,
@@ -355,10 +363,10 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
 
                 return true;
             }
-            else if (_autoTracker.CurrentGame == Game.SM)
+            else if (AutoTracker.CurrentGame == Game.SM)
             {
                 // Empty reserves
-                _autoTracker.WriteToMemory(new EmulatorAction()
+                AutoTracker.WriteToMemory(new EmulatorAction()
                 {
                     Type = EmulatorActionType.WriteBytes,
                     Domain = MemoryDomain.WRAM,
@@ -367,7 +375,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
                 });
 
                 // Set HP to 1 (to prevent saving with 0 energy)
-                _autoTracker.WriteToMemory(new EmulatorAction()
+                AutoTracker.WriteToMemory(new EmulatorAction()
                 {
                     Type = EmulatorActionType.WriteBytes,
                     Domain = MemoryDomain.WRAM,
@@ -376,7 +384,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
                 });
 
                 // Deal 255 damage to player
-                _autoTracker.WriteToMemory(new EmulatorAction()
+                AutoTracker.WriteToMemory(new EmulatorAction()
                 {
                     Type = EmulatorActionType.WriteBytes,
                     Domain = MemoryDomain.WRAM,
@@ -395,13 +403,13 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// <returns>True if successful</returns>
         public bool TrySetupCrystalFlash()
         {
-            if (_autoTracker == null || !_autoTracker.IsConnected || !_autoTracker.IsInSMZ3 || _autoTracker.CurrentGame != Game.SM)
+            if (AutoTracker == null || !AutoTracker.IsConnected || !AutoTracker.IsInSMZ3 || AutoTracker.CurrentGame != Game.SM)
             {
                 return false;
             }
 
             // Set HP to 50 health
-            _autoTracker.WriteToMemory(new EmulatorAction()
+            AutoTracker.WriteToMemory(new EmulatorAction()
             {
                 Type = EmulatorActionType.WriteBytes,
                 Domain = MemoryDomain.WRAM,
@@ -410,7 +418,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
             });
 
             // Empty reserves
-            _autoTracker.WriteToMemory(new EmulatorAction()
+            AutoTracker.WriteToMemory(new EmulatorAction()
             {
                 Type = EmulatorActionType.WriteBytes,
                 Domain = MemoryDomain.WRAM,
@@ -419,8 +427,8 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
             });
 
             // Fill missiles
-            var maxMissiles = _autoTracker.MetroidState?.MaxMissiles ?? 0;
-            _autoTracker.WriteToMemory(new EmulatorAction()
+            var maxMissiles = AutoTracker.MetroidState?.MaxMissiles ?? 0;
+            AutoTracker.WriteToMemory(new EmulatorAction()
             {
                 Type = EmulatorActionType.WriteBytes,
                 Domain = MemoryDomain.WRAM,
@@ -429,8 +437,8 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
             });
 
             // Fill super missiles
-            var maxSuperMissiles = _autoTracker.MetroidState?.MaxSuperMissiles ?? 0;
-            _autoTracker.WriteToMemory(new EmulatorAction()
+            var maxSuperMissiles = AutoTracker.MetroidState?.MaxSuperMissiles ?? 0;
+            AutoTracker.WriteToMemory(new EmulatorAction()
             {
                 Type = EmulatorActionType.WriteBytes,
                 Domain = MemoryDomain.WRAM,
@@ -439,8 +447,8 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
             });
 
             // Fill power bombs
-            var maxPowerBombs = _autoTracker.MetroidState?.MaxPowerBombs ?? 0;
-            _autoTracker.WriteToMemory(new EmulatorAction()
+            var maxPowerBombs = AutoTracker.MetroidState?.MaxPowerBombs ?? 0;
+            AutoTracker.WriteToMemory(new EmulatorAction()
             {
                 Type = EmulatorActionType.WriteBytes,
                 Domain = MemoryDomain.WRAM,
@@ -452,13 +460,65 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         }
 
         /// <summary>
-        /// The number of items given to the player
+        /// Gives the player any items that tracker thinks they should have but are not in memory as having been gifted
         /// </summary>
-        public int ItemCounter { get; set; }
+        /// <param name="action"></param>
+        public void SyncItems(EmulatorAction action)
+        {
+            if (AutoTracker?.HasValidState != true)
+            {
+                return;
+            }
+
+            _emulatorActions[action.Address] = action;
+
+            if (!_emulatorActions.ContainsKey(0xA26000) || !_emulatorActions.ContainsKey(0xA26300) || !_emulatorActions.Values.All(x =>
+                    x.LastRunTime != null && (DateTime.Now - x.LastRunTime.Value).TotalSeconds < 5))
+            {
+                return;
+            }
+
+            var data = _emulatorActions[0xA26000].CurrentData!.Raw.Concat(_emulatorActions[0xA26300].CurrentData!.Raw).ToArray();
+
+            var previouslyGiftedItems = new List<(ItemType type, int fromPlayerId)>();
+            for (var i = 0; i < 0x150; i++)
+            {
+                var item = (ItemType)BitConverter.ToUInt16(data.AsSpan(i * 4 + 2, 2));
+                if (item == ItemType.Nothing)
+                {
+                    continue;
+                }
+
+                var playerId = BitConverter.ToUInt16(data.AsSpan(i * 4, 2));
+                previouslyGiftedItems.Add((item, playerId));
+            }
+
+            _itemCounter = previouslyGiftedItems.Count;
+
+            var otherCollectedItems = WorldService.Worlds.SelectMany(x => x.Locations)
+                .Where(x => x.State.ItemWorldId == Tracker.World.Id && x.State.WorldId != Tracker.World.Id &&
+                            x.State.Autotracked).Select(x => (x.State.Item, x.State.WorldId)).ToList();
+
+            foreach (var item in previouslyGiftedItems)
+            {
+                otherCollectedItems.Remove(item);
+            }
+
+            if (otherCollectedItems.Any())
+            {
+                _logger.LogInformation("Giving player {ItemCount} missing items", otherCollectedItems.Count);
+                TryGiveItemTypes(otherCollectedItems);
+            }
+        }
 
         private static byte[] Int16ToBytes(int value)
         {
-            return new byte[] { (byte)(value % 256), (byte)(value / 256) };
+            var bytes = BitConverter.GetBytes((short)value).ToList();
+            if (!BitConverter.IsLittleEndian)
+            {
+                bytes.Reverse();
+            }
+            return bytes.ToArray();
         }
     }
 }


### PR DESCRIPTION
1. This adds in a check where it pulls in the items gifted to the player, the ones that should have been sent to the player, and compares them. If any items were missed, it'll resend them.
    - I updated the GameService to use BitConverter and match some more C# stylings.
1. Reads have to happen sequentially, and the above added another read. I've been a bit worried about extra reads causing slowdown and making some things less stable. Due to this, I added in functionality to have reads have an optional frequency. I moved item and boss checks to 1 second because they don't really need to be happening multiple times a second.