### PR TITLE
Update Hints to Require Crystal Dungeons

### DIFF
--- a/src/Randomizer.SMZ3/Generation/GameHintService.cs
+++ b/src/Randomizer.SMZ3/Generation/GameHintService.cs
@@ -299,11 +299,14 @@ namespace Randomizer.SMZ3.Generation
                     }
                 }
 
-                // Make sure all crystal dungeons are beatable
+                // Make sure the required amount of crystal dungeons are beatable
                 foreach (var world in allWorlds)
                 {
-                    var numCrystalsNeeded =
-                        Math.Max(world.Config.GanonCrystalCount, world.Config.GanonsTowerCrystalCount);
+                    var numCrystalsNeeded = world.Config.GanonCrystalCount;
+                    if (!world.Config.OpenPyramid && world.Config.GanonsTowerCrystalCount > numCrystalsNeeded)
+                    {
+                        numCrystalsNeeded = world.Config.GanonsTowerCrystalCount;
+                    }
                     var currentCrystalCount = world.Dungeons.Count(d =>
                         d.IsCrystalDungeon && sphereLocations.Any(l =>
                             l.World.Id == world.Id && l.Id == s_dungeonBossLocations[d.GetType()]));

--- a/src/Randomizer.SMZ3/Generation/GameHintService.cs
+++ b/src/Randomizer.SMZ3/Generation/GameHintService.cs
@@ -300,11 +300,17 @@ namespace Randomizer.SMZ3.Generation
                 }
 
                 // Make sure all crystal dungeons are beatable
-                if (allWorlds.SelectMany(x => x.Dungeons).Any(d =>
-                        d.IsCrystalDungeon && !sphereLocations.Any(l =>
-                            d.DungeonState.WorldId == l.World.Id && l.Id == s_dungeonBossLocations[d.GetType()])))
+                foreach (var world in allWorlds)
                 {
-                    return LocationUsefulness.Mandatory;
+                    var numCrystalsNeeded =
+                        Math.Max(world.Config.GanonCrystalCount, world.Config.GanonsTowerCrystalCount);
+                    var currentCrystalCount = world.Dungeons.Count(d =>
+                        d.IsCrystalDungeon && sphereLocations.Any(l =>
+                            l.World.Id == world.Id && l.Id == s_dungeonBossLocations[d.GetType()]));
+                    if (currentCrystalCount < numCrystalsNeeded)
+                    {
+                        return LocationUsefulness.Mandatory;
+                    }
                 }
 
                 if (!canBeatGT || !canBeatKraid || !canBeatPhantoon || !canBeatDraygon || !canBeatRidley || !allCrateriaBosSKeys)

--- a/src/Randomizer.SMZ3/Generation/GameHintService.cs
+++ b/src/Randomizer.SMZ3/Generation/GameHintService.cs
@@ -57,6 +57,20 @@ namespace Randomizer.SMZ3.Generation
             256 + 215, // GT Validation Chest
         };
 
+        private static readonly Dictionary<Type, int> s_dungeonBossLocations = new()
+        {
+            { typeof(EasternPalace), 256 + 108 },
+            { typeof(DesertPalace), 256 + 114 },
+            { typeof(TowerOfHera), 256 + 120 },
+            { typeof(PalaceOfDarkness), 256 + 134 },
+            { typeof(SwampPalace), 256 + 144 },
+            { typeof(SkullWoods), 256 + 152 },
+            { typeof(ThievesTown), 256 + 160 },
+            { typeof(IcePalace), 256 + 168 },
+            { typeof(MiseryMire), 256 + 176 },
+            { typeof(TurtleRock), 256 + 188 },
+        };
+
         private readonly ILogger<GameHintService> _logger;
         private readonly IMetadataService _metadataService;
         private readonly GameLinesConfig _gameLines;
@@ -283,6 +297,14 @@ namespace Randomizer.SMZ3.Generation
                     {
                         return LocationUsefulness.Mandatory;
                     }
+                }
+
+                // Make sure all crystal dungeons are beatable
+                if (allWorlds.SelectMany(x => x.Dungeons).Any(d =>
+                        d.IsCrystalDungeon && !sphereLocations.Any(l =>
+                            d.DungeonState.WorldId == l.World.Id && l.Id == s_dungeonBossLocations[d.GetType()])))
+                {
+                    return LocationUsefulness.Mandatory;
                 }
 
                 if (!canBeatGT || !canBeatKraid || !canBeatPhantoon || !canBeatDraygon || !canBeatRidley || !allCrateriaBosSKeys)


### PR DESCRIPTION
This resolves an issue brought up by ProfHammerRadd. Basically if GT has a smaller crystal count than Ganon, then it could think that a seed is beatable sooner than it could be because it was just looking for if the moldorm chest and not give the proper hint.

This change will make it so that hint tiles will make sure you can access the number of crystals you need (max between GT and Ganon).