### PR TITLE
Switch many function parameters from int to LocationId

### DIFF
--- a/src/Randomizer.App/Windows/GenerateRomWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/GenerateRomWindow.xaml.cs
@@ -184,7 +184,7 @@ namespace Randomizer.App.Windows
             var row = 0;
             foreach (var location in world.Locations.OrderBy(x => x.Room == null ? "" : x.Room.Name).ThenBy(x => x.Name))
             {
-                var locationDetails = _locations.Single(x => x.LocationNumber == location.Id); //TODO: Refactor into IWorldService
+                var locationDetails = _locations.Single(x => x.LocationNumber == (int)location.Id); //TODO: Refactor into IWorldService
                 var name = locationDetails.ToString();
                 var toolTip = "";
                 if (locationDetails.Name.Count > 1)
@@ -382,7 +382,7 @@ namespace Randomizer.App.Windows
             const int numberOfSeeds = 1000;
             var progressDialog = new ProgressDialog(this, $"Generating {numberOfSeeds} seeds...");
             var stats = InitStats();
-            var itemCounts = new ConcurrentDictionary<(int itemId, int locationId), int>();
+            var itemCounts = new ConcurrentDictionary<(int itemId, LocationId locationId), int>();
             var ct = progressDialog.CancellationToken;
             var finished = false;
             ThreadPool.GetAvailableThreads(out int workerThreads, out int completionPortThreads);
@@ -432,7 +432,7 @@ namespace Randomizer.App.Windows
             }
         }
 
-        private void AddToMegaSpoilerLog(ConcurrentDictionary<(int itemId, int locationId), int> itemCounts, SeedData seed)
+        private void AddToMegaSpoilerLog(ConcurrentDictionary<(int itemId, LocationId locationId), int> itemCounts, SeedData seed)
         {
             foreach (var location in seed.WorldGenerationData.LocalWorld.World.Locations)
             {
@@ -478,7 +478,7 @@ namespace Randomizer.App.Windows
                 stats.Increment("The GT Moldorm chest contains a Metroid item");
         }
 
-        private void WriteMegaSpoilerLog(ConcurrentDictionary<(int itemId, int locationId), int> itemCounts, int numberOfSeeds)
+        private void WriteMegaSpoilerLog(ConcurrentDictionary<(int itemId, LocationId locationId), int> itemCounts, int numberOfSeeds)
         {
             var items = Enum.GetValues<ItemType>().ToDictionary(x => (int)x);
             var locations = new World(new Config(), "", 0, "").Locations;
@@ -547,28 +547,28 @@ namespace Randomizer.App.Windows
             };
             Process.Start(startInfo);
 
-            int GetLocationSmallKeyCount(int locationId)
+            int GetLocationSmallKeyCount(LocationId locationId)
             {
                 return itemCounts.Where(x =>
                     x.Key.locationId == locationId &&
                     items[x.Key.itemId].IsInCategory(ItemCategory.SmallKey)).Sum(x => x.Value);
             }
 
-            int GetLocationBigKeyCount(int locationId)
+            int GetLocationBigKeyCount(LocationId locationId)
             {
                 return itemCounts.Where(x =>
                     x.Key.locationId == locationId &&
                     items[x.Key.itemId].IsInCategory(ItemCategory.BigKey)).Sum(x => x.Value);
             }
 
-            int GetLocationMapCompassCount(int locationId)
+            int GetLocationMapCompassCount(LocationId locationId)
             {
                 return itemCounts.Where(x =>
                     x.Key.locationId == locationId &&
                     items[x.Key.itemId].IsInAnyCategory(ItemCategory.Compass, ItemCategory.Map)).Sum(x => x.Value);
             }
 
-            int GetLocationTreasureCount(int locationId)
+            int GetLocationTreasureCount(LocationId locationId)
             {
                 return itemCounts.Where(x =>
                     x.Key.locationId == locationId &&
@@ -576,7 +576,7 @@ namespace Randomizer.App.Windows
                     .Sum(x => x.Value);
             }
 
-            int GetLocationProgressionCount(int locationId)
+            int GetLocationProgressionCount(LocationId locationId)
             {
                 return itemCounts.Where(x =>
                         x.Key.locationId == locationId &&
@@ -587,7 +587,7 @@ namespace Randomizer.App.Windows
         }
 
         private void ReportStats(IDictionary<string, int> stats,
-            ConcurrentDictionary<(int itemId, int locationId), int> itemCounts, int total)
+            ConcurrentDictionary<(int itemId, LocationId locationId), int> itemCounts, int total)
         {
             var message = new StringBuilder();
             message.AppendLine($"If you were to play {total} seeds:");

--- a/src/Randomizer.Data/Configuration/ConfigFiles/DungeonConfig.cs
+++ b/src/Randomizer.Data/Configuration/ConfigFiles/DungeonConfig.cs
@@ -35,7 +35,7 @@ namespace Randomizer.Data.Configuration.ConfigFiles
                     Abbreviation = "EP",
                     Boss = new("Armos Knights"),
                     Type = typeof(Data.WorldData.Regions.Zelda.EasternPalace),
-                    LocationId = 364,
+                    LocationId = LocationId.EasternPalaceArmosKnights,
                 },
                 new DungeonInfo()
                 {
@@ -44,7 +44,7 @@ namespace Randomizer.Data.Configuration.ConfigFiles
                     Abbreviation = "DP",
                     Boss = new("Lanmolas"),
                     Type = typeof(Data.WorldData.Regions.Zelda.DesertPalace),
-                    LocationId = 370,
+                    LocationId = LocationId.DesertPalaceLanmolas,
                 },
                 new DungeonInfo()
                 {
@@ -53,7 +53,7 @@ namespace Randomizer.Data.Configuration.ConfigFiles
                     Abbreviation = "TH",
                     Boss = new("Moldorm"),
                     Type = typeof(Data.WorldData.Regions.Zelda.TowerOfHera),
-                    LocationId = 376,
+                    LocationId = LocationId.TowerOfHeraMoldorm,
                 },
                 new DungeonInfo()
                 {
@@ -62,7 +62,7 @@ namespace Randomizer.Data.Configuration.ConfigFiles
                     Abbreviation = "PD",
                     Boss = new("Helmasaur King", "Helmasaur"),
                     Type = typeof(Data.WorldData.Regions.Zelda.PalaceOfDarkness),
-                    LocationId = 390,
+                    LocationId = LocationId.PalaceOfDarknessHelmasaurKing,
                 },
                 new DungeonInfo()
                 {
@@ -71,7 +71,7 @@ namespace Randomizer.Data.Configuration.ConfigFiles
                     Abbreviation = "SP",
                     Boss = new("Arrghus"),
                     Type = typeof(Data.WorldData.Regions.Zelda.SwampPalace),
-                    LocationId = 400,
+                    LocationId = LocationId.SwampPalaceArrghus,
                 },
                 new DungeonInfo()
                 {
@@ -80,7 +80,7 @@ namespace Randomizer.Data.Configuration.ConfigFiles
                     Abbreviation = "SW",
                     Boss = new(new("Mothula", 0), "MOTHyula"),
                     Type = typeof(Data.WorldData.Regions.Zelda.SkullWoods),
-                    LocationId = 408,
+                    LocationId = LocationId.SkullWoodsMothula,
                 },
                 new DungeonInfo()
                 {
@@ -89,7 +89,7 @@ namespace Randomizer.Data.Configuration.ConfigFiles
                     Abbreviation = "TT",
                     Boss = new("Blind"),
                     Type = typeof(Data.WorldData.Regions.Zelda.ThievesTown),
-                    LocationId = 416,
+                    LocationId = LocationId.ThievesTownBlind,
                 },
                 new DungeonInfo()
                 {
@@ -98,7 +98,7 @@ namespace Randomizer.Data.Configuration.ConfigFiles
                     Abbreviation = "IP",
                     Boss = new("Kholdstare"),
                     Type = typeof(Data.WorldData.Regions.Zelda.IcePalace),
-                    LocationId = 424,
+                    LocationId = LocationId.IcePalaceKholdstare,
                 },
                 new DungeonInfo()
                 {
@@ -107,7 +107,7 @@ namespace Randomizer.Data.Configuration.ConfigFiles
                     Abbreviation = "MM",
                     Boss = new("Vitreous"),
                     Type = typeof(Data.WorldData.Regions.Zelda.MiseryMire),
-                    LocationId = 432,
+                    LocationId = LocationId.MiseryMireVitreous,
                 },
                 new DungeonInfo()
                 {
@@ -116,7 +116,7 @@ namespace Randomizer.Data.Configuration.ConfigFiles
                     Abbreviation = "TR",
                     Boss = new("Trinexx"),
                     Type = typeof(Data.WorldData.Regions.Zelda.TurtleRock),
-                    LocationId = 444,
+                    LocationId = LocationId.TurtleRockTrinexx,
                 },
                 new DungeonInfo()
                 {

--- a/src/Randomizer.Data/Configuration/ConfigTypes/DungeonInfo.cs
+++ b/src/Randomizer.Data/Configuration/ConfigTypes/DungeonInfo.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using Randomizer.Data.WorldData.Regions;
 using Randomizer.Data.WorldData;
+using Randomizer.Shared;
 
 namespace Randomizer.Data.Configuration.ConfigTypes
 {
@@ -76,7 +77,7 @@ namespace Randomizer.Data.Configuration.ConfigTypes
         /// defeating the boss, or <c>null</c> if the dungeon has item reward
         /// for beating the boss.
         /// </summary>
-        public int? LocationId { get; init; }
+        public LocationId? LocationId { get; init; }
 
         /// <summary>
         /// Returns a string representation of the dungeon.

--- a/src/Randomizer.Data/Configuration/ConfigTypes/LocationInfo.cs
+++ b/src/Randomizer.Data/Configuration/ConfigTypes/LocationInfo.cs
@@ -37,12 +37,12 @@ namespace Randomizer.Data.Configuration.ConfigTypes
         /// </summary>
         /// <param name="id">
         /// The ID of the location. Must match an existing <see
-        /// cref="Location.Id"/>.
+        /// cref="LocationId"/>.
         /// </param>
         /// <param name="name">The names for the location.</param>
-        public LocationInfo(int id, string name)
+        public LocationInfo(LocationId id, string name)
         {
-            LocationNumber = id;
+            LocationNumber = (int)id;
             Name = new SchrodingersString(name);
         }
 

--- a/src/Randomizer.Data/Options/Config.cs
+++ b/src/Randomizer.Data/Options/Config.cs
@@ -201,7 +201,7 @@ namespace Randomizer.Data.Options
         public string Seed { get; set; } = "";
         public string SettingsString { get; set; } = "";
         public bool CopySeedAndRaceSettings { get; set; }
-        public IDictionary<int, int> LocationItems { get; set; } = new Dictionary<int, int>();
+        public IDictionary<LocationId, int> LocationItems { get; set; } = new Dictionary<LocationId, int>();
         public LogicConfig LogicConfig { get; set; } = new LogicConfig();
         public CasPatches CasPatches { get; set; } = new();
         public MetroidControlOptions MetroidControls { get; set; } = new();

--- a/src/Randomizer.Data/Options/SeedOptions.cs
+++ b/src/Randomizer.Data/Options/SeedOptions.cs
@@ -49,7 +49,7 @@ namespace Randomizer.Data.Options
         [JsonIgnore]
         public bool CopySeedAndRaceSettings { get; set; }
 
-        public IDictionary<int, int> LocationItems { get; set; } = new Dictionary<int, int>();
+        public IDictionary<LocationId, int> LocationItems { get; set; } = new Dictionary<LocationId, int>();
 
         public IDictionary<string, int> ItemOptions { get; set; } = new Dictionary<string, int>();
     }

--- a/src/Randomizer.Data/Services/IMetadataService.cs
+++ b/src/Randomizer.Data/Services/IMetadataService.cs
@@ -198,7 +198,7 @@ namespace Randomizer.Data.Services
         /// <returns>
         /// A new <see cref="LocationInfo"/> for the specified room.
         /// </returns>
-        public LocationInfo Location(int id);
+        public LocationInfo Location(LocationId id);
 
         /// <summary>
         /// Returns extra information for the specified location.

--- a/src/Randomizer.Data/Services/MetadataService.cs
+++ b/src/Randomizer.Data/Services/MetadataService.cs
@@ -229,12 +229,12 @@ namespace Randomizer.Data.Services
         /// <summary>
         /// Returns extra information for the specified location.
         /// </summary>
-        /// <param name="id">The numeric ID of the location.</param>
+        /// <param name="id">The ID of the location.</param>
         /// <returns>
         /// A new <see cref="LocationInfo"/> for the specified room.
         /// </returns>
-        public LocationInfo Location(int id)
-            => Locations.Single(x => x.LocationNumber == id);
+        public LocationInfo Location(LocationId id)
+            => Locations.Single(x => x.LocationNumber == (int)id);
 
         /// <summary>
         /// Returns extra information for the specified location.
@@ -246,7 +246,7 @@ namespace Randomizer.Data.Services
         /// A new <see cref="LocationInfo"/> for the specified room.
         /// </returns>
         public LocationInfo Location(Location location)
-            => Locations.Single(x => x.LocationNumber == location.Id);
+            => Locations.Single(x => x.LocationNumber == (int)location.Id);
 
         /// <summary>
         /// Returns information about a specified boss

--- a/src/Randomizer.Data/WorldData/Location.cs
+++ b/src/Randomizer.Data/WorldData/Location.cs
@@ -69,7 +69,7 @@ namespace Randomizer.Data.WorldData
             Requirement? relevanceRequirement = null, Requirement? trackerLogic = null)
         {
             Region = region;
-            Id = (int)id;
+            Id = id;
             Name = name;
             Type = type;
             RomAddress = romAddress;
@@ -82,15 +82,15 @@ namespace Randomizer.Data.WorldData
             MemoryType = memoryType;
             _relevanceRequirement = relevanceRequirement ?? (items => _canAccess(items));
             _trackerLogic = trackerLogic ?? (_ => true);
-            Metadata = metadata?.Location((int)id) ?? new LocationInfo((int)id, name);
-            State = trackerState?.LocationStates.First(x => x.LocationId == (int)id && x.WorldId == World.Id) ?? new TrackerLocationState();
+            Metadata = metadata?.Location(id) ?? new LocationInfo(id, name);
+            State = trackerState?.LocationStates.First(x => x.LocationId == id && x.WorldId == World.Id) ?? new TrackerLocationState();
             Item = new Item(ItemType.Nothing, region.World, "");
         }
 
         /// <summary>
         /// Gets the internal identifier of the location.
         /// </summary>
-        public int Id { get; }
+        public LocationId Id { get; }
 
         /// <summary>
         /// Gets the name of the location.

--- a/src/Randomizer.Data/WorldData/Regions/Zelda/DarkWorld/DeathMountain/DarkWorldDeathMountainWest.cs
+++ b/src/Randomizer.Data/WorldData/Regions/Zelda/DarkWorld/DeathMountain/DarkWorldDeathMountainWest.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 using Randomizer.Data.Configuration.ConfigTypes;
+using Randomizer.Shared;
 using Randomizer.Data.Options;
 using Randomizer.Data.Services;
-using Randomizer.Shared;
 using Randomizer.Shared.Models;
 
 namespace Randomizer.Data.WorldData.Regions.Zelda.DarkWorld.DeathMountain

--- a/src/Randomizer.Multiplayer.Client/EventHandlers/TrackLocationEventHandler.cs
+++ b/src/Randomizer.Multiplayer.Client/EventHandlers/TrackLocationEventHandler.cs
@@ -1,5 +1,6 @@
-﻿using Randomizer.Shared.Multiplayer;
+﻿using Randomizer.Shared;
+using Randomizer.Shared.Multiplayer;
 
 namespace Randomizer.Multiplayer.Client.EventHandlers;
 
-public delegate void TrackLocationEventHandler(MultiplayerPlayerState playerState, int locationId);
+public delegate void TrackLocationEventHandler(MultiplayerPlayerState playerState, LocationId locationId);

--- a/src/Randomizer.Multiplayer.Client/GameServices/MultiplayerGameTypeService.cs
+++ b/src/Randomizer.Multiplayer.Client/GameServices/MultiplayerGameTypeService.cs
@@ -238,7 +238,7 @@ public abstract class MultiplayerGameTypeService : IDisposable
     /// <param name="locationId">The id of </param>
     /// <param name="isLocalPlayer"></param>
     /// <returns></returns>
-    public PlayerTrackedLocationEventHandlerArgs? PlayerTrackedLocation(MultiplayerPlayerState player, int locationId, bool isLocalPlayer)
+    public PlayerTrackedLocationEventHandlerArgs? PlayerTrackedLocation(MultiplayerPlayerState player, LocationId locationId, bool isLocalPlayer)
     {
         if (TrackerState == null || isLocalPlayer) return null;
 

--- a/src/Randomizer.Multiplayer.Client/MultiplayerClientService.cs
+++ b/src/Randomizer.Multiplayer.Client/MultiplayerClientService.cs
@@ -375,7 +375,7 @@ public class MultiplayerClientService
     /// </summary>
     /// <param name="locationId">The id of the location that was cleared</param>
     /// <param name="playerGuid">The player whose dungeon was cleared. Set to null to use the local player.</param>
-    public async Task TrackLocation(int locationId, string? playerGuid = null)
+    public async Task TrackLocation(LocationId locationId, string? playerGuid = null)
     {
         playerGuid ??= CurrentPlayerGuid;
         await MakeRequest("TrackLocation", new TrackLocationRequest(playerGuid ?? CurrentPlayerGuid!, locationId));

--- a/src/Randomizer.Multiplayer.Client/MultiplayerGameService.cs
+++ b/src/Randomizer.Multiplayer.Client/MultiplayerGameService.cs
@@ -264,7 +264,7 @@ public class MultiplayerGameService : IDisposable
         if (args != null) PlayerTrackedDeath?.Invoke(args);
     }
 
-    private void ClientOnLocationTracked(MultiplayerPlayerState playerState, int locationId)
+    private void ClientOnLocationTracked(MultiplayerPlayerState playerState, LocationId locationId)
     {
         var args = _currentGameService.PlayerTrackedLocation(playerState, locationId,
             playerState.Guid == _client.CurrentPlayerGuid);

--- a/src/Randomizer.Multiplayer.Server/MultiplayerGame.cs
+++ b/src/Randomizer.Multiplayer.Server/MultiplayerGame.cs
@@ -427,7 +427,7 @@ public class MultiplayerGame
     /// </summary>
     /// <param name="player"></param>
     /// <param name="locationId"></param>
-    public MultiplayerLocationState? TrackLocation(MultiplayerPlayer player, int locationId)
+    public MultiplayerLocationState? TrackLocation(MultiplayerPlayer player, LocationId locationId)
     {
         var location = player.State.TrackLocation(locationId);
         State.LastMessage = DateTimeOffset.Now;

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/AutoTracker.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/AutoTracker.cs
@@ -631,7 +631,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
 
             // Store the locations for this action so that we don't need to grab them each time every half a second or so
             action.Locations ??= _worldService.AllLocations().Where(x =>
-                x.MemoryType == type && ((game == Game.SM && x.Id < 256) || (game == Game.Zelda && x.Id >= 256))).ToList();
+                x.MemoryType == type && ((game == Game.SM && (int)x.Id < 256) || (game == Game.Zelda && (int)x.Id >= 256))).ToList();
 
             foreach (var location in action.Locations)
             {
@@ -655,7 +655,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
                         _logger.LogInformation("Auto tracked {ItemName} from {LocationName}", location.Item.Name, location.Name);
 
                         // Mark HC as cleared if this was Zelda's Cell
-                        if (location.Id == 256 + 98 && Tracker.World.HyruleCastle.DungeonState.Cleared == false)
+                        if (location.Id == LocationId.HyruleCastleZeldasCell && Tracker.World.HyruleCastle.DungeonState.Cleared == false)
                         {
                             Tracker.MarkDungeonAsCleared(Tracker.World.HyruleCastle, null, autoTracked: true);
                         }

--- a/src/Randomizer.SMZ3.Tracking/Services/IWorldService.cs
+++ b/src/Randomizer.SMZ3.Tracking/Services/IWorldService.cs
@@ -83,7 +83,7 @@ namespace Randomizer.SMZ3.Tracking.Services
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>
-        public Location Location(int id);
+        public Location Location(LocationId id);
 
         /// <summary>
         /// Checks if the location is accessible with the given progression

--- a/src/Randomizer.SMZ3.Tracking/Services/WorldService.cs
+++ b/src/Randomizer.SMZ3.Tracking/Services/WorldService.cs
@@ -139,7 +139,7 @@ namespace Randomizer.SMZ3.Tracking.Services
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>
-        public Location Location(int id)
+        public Location Location(LocationId id)
         {
             return AllLocations().First(x => x.Id == id);
         }

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/SpoilerModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/SpoilerModule.cs
@@ -31,7 +31,7 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
         };
 
         private readonly Dictionary<ItemType, int> _itemHintsGiven = new();
-        private readonly Dictionary<int, int> _locationHintsGiven = new();
+        private readonly Dictionary<LocationId, int> _locationHintsGiven = new();
         private readonly Playthrough? _playthrough;
         private readonly IRandomizerConfigService _randomizerConfigService;
         private readonly bool _isMultiworld;

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/TrackerModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/TrackerModule.cs
@@ -202,7 +202,7 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
         /// </returns>
         protected static Location GetLocationFromResult(Tracker tracker, RecognitionResult result)
         {
-            var id = (int)result.Semantics[LocationKey].Value;
+            var id = (LocationId)result.Semantics[LocationKey].Value;
             var location = tracker.World.Locations.First(x => x.Id == id);
             return location ?? throw new Exception($"Could not find a location with ID {id} (\"{result.Text}\")");
         }
@@ -468,7 +468,7 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
             foreach (var location in Tracker.World.Locations)
             {
                 foreach (var name in location.Metadata.Name)
-                    locationNames.Add(new SemanticResultValue(name.Text, location.Id));
+                    locationNames.Add(new SemanticResultValue(name.Text, (int)location.Id));
             }
 
             return locationNames;

--- a/src/Randomizer.SMZ3/FileData/Patcher.cs
+++ b/src/Randomizer.SMZ3/FileData/Patcher.cs
@@ -382,7 +382,7 @@ namespace Randomizer.SMZ3.FileData
         {
             var type = location.Item.World == location.Region.World ? 0 : 1;
             var owner = location.Item.World.Id;
-            return (0x386000 + (location.Id * 8), new[] { type, itemId, owner, 0 }.SelectMany(UshortBytes).ToArray());
+            return (0x386000 + ((int)location.Id * 8), new[] { type, itemId, owner, 0 }.SelectMany(UshortBytes).ToArray());
         }
 
         private void WritePrizeShuffle()

--- a/src/Randomizer.SMZ3/Generation/GameHintService.cs
+++ b/src/Randomizer.SMZ3/Generation/GameHintService.cs
@@ -19,7 +19,7 @@ namespace Randomizer.SMZ3.Generation
     /// </summary>
     public class GameHintService : IGameHintService
     {
-        public static readonly List<string> HintLocations = new List<string>()
+        public static readonly List<string> HintLocations = new()
         {
             "telepathic_tile_eastern_palace",
             "telepathic_tile_tower_of_hera_floor_4",
@@ -38,37 +38,37 @@ namespace Randomizer.SMZ3.Generation
             "telepathic_tile_south_east_darkworld_cave"
         };
 
-        private static readonly List<int> s_importantLocations = new List<int>()
+        private static readonly List<LocationId> s_importantLocations = new()
         {
-            48, // Kraid
-            134, // Phantoon
-            154, // Dragon
-            78, // Ridley
-            256 + 108, // Armos Knights
-            256 + 114, // Lanmolas
-            256 + 120, // Moldorm
-            256 + 134, // Helmasaur King
-            256 + 144, // Arrghus
-            256 + 152, // Mothula
-            256 + 160, // Blind
-            256 + 168, // Kholdstare
-            256 + 176, // Vitreous
-            256 + 188, // Trinexx
-            256 + 215, // GT Validation Chest
+            LocationId.VariaSuit, // After Kraid
+            LocationId.WreckedShipEastSuper, // After Phantoon
+            LocationId.SpaceJump, // After Draygon
+            LocationId.RidleyTank, // After Ridley
+            LocationId.EasternPalaceArmosKnights,
+            LocationId.DesertPalaceLanmolas,
+            LocationId.TowerOfHeraMoldorm,
+            LocationId.PalaceOfDarknessHelmasaurKing,
+            LocationId.SwampPalaceArrghus,
+            LocationId.SkullWoodsMothula,
+            LocationId.ThievesTownBlind,
+            LocationId.IcePalaceKholdstare,
+            LocationId.MiseryMireVitreous,
+            LocationId.TurtleRockTrinexx,
+            LocationId.GanonsTowerMoldormChest,
         };
 
-        private static readonly Dictionary<Type, int> s_dungeonBossLocations = new()
+        private static readonly Dictionary<Type, LocationId> s_dungeonBossLocations = new()
         {
-            { typeof(EasternPalace), 256 + 108 },
-            { typeof(DesertPalace), 256 + 114 },
-            { typeof(TowerOfHera), 256 + 120 },
-            { typeof(PalaceOfDarkness), 256 + 134 },
-            { typeof(SwampPalace), 256 + 144 },
-            { typeof(SkullWoods), 256 + 152 },
-            { typeof(ThievesTown), 256 + 160 },
-            { typeof(IcePalace), 256 + 168 },
-            { typeof(MiseryMire), 256 + 176 },
-            { typeof(TurtleRock), 256 + 188 },
+            { typeof(EasternPalace), LocationId.EasternPalaceArmosKnights },
+            { typeof(DesertPalace), LocationId.DesertPalaceLanmolas },
+            { typeof(TowerOfHera), LocationId.TowerOfHeraMoldorm },
+            { typeof(PalaceOfDarkness), LocationId.PalaceOfDarknessHelmasaurKing },
+            { typeof(SwampPalace), LocationId.SwampPalaceArrghus },
+            { typeof(SkullWoods), LocationId.SkullWoodsMothula },
+            { typeof(ThievesTown), LocationId.ThievesTownBlind },
+            { typeof(IcePalace), LocationId.IcePalaceKholdstare },
+            { typeof(MiseryMire), LocationId.MiseryMireVitreous },
+            { typeof(TurtleRock), LocationId.TurtleRockTrinexx },
         };
 
         private readonly ILogger<GameHintService> _logger;
@@ -196,17 +196,17 @@ namespace Randomizer.SMZ3.Generation
         {
             var hints = new List<string>();
 
-            AddLocationHint(hints, hintPlayerWorld, allWorlds, importantLocations, hintPlayerWorld.Locations.Where(x => x.Id is 33)); // Waterway
-            AddLocationHint(hints, hintPlayerWorld, allWorlds, importantLocations, hintPlayerWorld.Locations.Where(x => x.Id is 132)); // Wrecked pool
-            AddLocationHint(hints, hintPlayerWorld, allWorlds, importantLocations, hintPlayerWorld.Locations.Where(x => x.Id is 129)); // Wrecked ship post chozo speed booster item
-            AddLocationHint(hints, hintPlayerWorld, allWorlds, importantLocations, hintPlayerWorld.Locations.Where(x => x.Id is 150)); // Shaktool
-            AddLocationHint(hints, hintPlayerWorld, allWorlds, importantLocations, hintPlayerWorld.Locations.Where(x => x.Id is 143)); // Plasma beam
-            AddLocationHint(hints, hintPlayerWorld, allWorlds, importantLocations, hintPlayerWorld.Locations.Where(x => x.Id is 256 + 44)); // Sahasrahla
-            AddLocationHint(hints, hintPlayerWorld, allWorlds, importantLocations, hintPlayerWorld.Locations.Where(x => x.Id is 256 + 14)); // Ped
-            AddLocationHint(hints, hintPlayerWorld, allWorlds, importantLocations, hintPlayerWorld.Locations.Where(x => x.Id is 256 + 36)); // Zora
-            AddLocationHint(hints, hintPlayerWorld, allWorlds, importantLocations, hintPlayerWorld.Locations.Where(x => x.Id is 256 + 78)); // Catfish
-            AddLocationHint(hints, hintPlayerWorld, allWorlds, importantLocations, hintPlayerWorld.Locations.Where(x => x.Id is 256 + 117)); // Tower of Hera big key chest
-            AddLocationHint(hints, hintPlayerWorld, allWorlds, importantLocations, hintPlayerWorld.Locations.Where(x => x.Id is 256 + 139 or 256 + 140), "The left side of swamp palace");
+            AddLocationHint(hints, hintPlayerWorld, allWorlds, importantLocations, hintPlayerWorld.Locations.Where(x => x.Id is LocationId.WaterwayEnergyTank));
+            AddLocationHint(hints, hintPlayerWorld, allWorlds, importantLocations, hintPlayerWorld.Locations.Where(x => x.Id is LocationId.WreckedShipEnergyTank)); // Wrecked pool
+            AddLocationHint(hints, hintPlayerWorld, allWorlds, importantLocations, hintPlayerWorld.Locations.Where(x => x.Id is LocationId.BowlingAlleyTop)); // Wrecked ship post chozo speed booster item
+            AddLocationHint(hints, hintPlayerWorld, allWorlds, importantLocations, hintPlayerWorld.Locations.Where(x => x.Id is LocationId.SpringBall)); // Shaktool
+            AddLocationHint(hints, hintPlayerWorld, allWorlds, importantLocations, hintPlayerWorld.Locations.Where(x => x.Id is LocationId.Plasma));
+            AddLocationHint(hints, hintPlayerWorld, allWorlds, importantLocations, hintPlayerWorld.Locations.Where(x => x.Id is LocationId.Sahasrahla));
+            AddLocationHint(hints, hintPlayerWorld, allWorlds, importantLocations, hintPlayerWorld.Locations.Where(x => x.Id is LocationId.MasterSwordPedestal));
+            AddLocationHint(hints, hintPlayerWorld, allWorlds, importantLocations, hintPlayerWorld.Locations.Where(x => x.Id is LocationId.KingZora));
+            AddLocationHint(hints, hintPlayerWorld, allWorlds, importantLocations, hintPlayerWorld.Locations.Where(x => x.Id is LocationId.Catfish));
+            AddLocationHint(hints, hintPlayerWorld, allWorlds, importantLocations, hintPlayerWorld.Locations.Where(x => x.Id is LocationId.TowerOfHeraBigKeyChest));
+            AddLocationHint(hints, hintPlayerWorld, allWorlds, importantLocations, hintPlayerWorld.Locations.Where(x => x.Id is LocationId.SwampPalaceWestChest or LocationId.SwampPalaceBigKeyChest), "The left side of swamp palace");
             AddLocationHint(hints, hintPlayerWorld, allWorlds, importantLocations, hintPlayerWorld.DarkWorldNorthEast.PyramidFairy.Locations);
             AddLocationHint(hints, hintPlayerWorld, allWorlds, importantLocations, hintPlayerWorld.DarkWorldSouth.HypeCave.Locations);
             AddLocationHint(hints, hintPlayerWorld, allWorlds, importantLocations, hintPlayerWorld.DarkWorldDeathMountainEast.HookshotCave.Locations);
@@ -276,11 +276,11 @@ namespace Randomizer.SMZ3.Generation
                 var spheres = Playthrough.GenerateSpheres(worldLocations);
                 var sphereLocations = spheres.SelectMany(x => x.Locations);
 
-                var canBeatGT = CheckSphereLocationCount(sphereLocations, locations, 256 + 215, allWorlds.Count());
-                var canBeatKraid = CheckSphereLocationCount(sphereLocations, locations, 48, allWorlds.Count());
-                var canBeatPhantoon = CheckSphereLocationCount(sphereLocations, locations, 134, allWorlds.Count());
-                var canBeatDraygon = CheckSphereLocationCount(sphereLocations, locations, 154, allWorlds.Count());
-                var canBeatRidley = CheckSphereLocationCount(sphereLocations, locations, 78, allWorlds.Count());
+                var canBeatGT = CheckSphereLocationCount(sphereLocations, locations, LocationId.GanonsTowerMoldormChest, allWorlds.Count());
+                var canBeatKraid = CheckSphereLocationCount(sphereLocations, locations, LocationId.VariaSuit, allWorlds.Count());
+                var canBeatPhantoon = CheckSphereLocationCount(sphereLocations, locations, LocationId.WreckedShipEastSuper, allWorlds.Count());
+                var canBeatDraygon = CheckSphereLocationCount(sphereLocations, locations, LocationId.SpaceJump, allWorlds.Count());
+                var canBeatRidley = CheckSphereLocationCount(sphereLocations, locations, LocationId.RidleyTank, allWorlds.Count());
                 var allCrateriaBosSKeys = CheckSphereCrateriaBossKeys(sphereLocations);
 
                 // Make sure all players have the silver arrows
@@ -339,7 +339,7 @@ namespace Randomizer.SMZ3.Generation
         /// Checks if a given location is found for all worlds in the locations from all spheres
         /// If that location is in the checked locations list, it'll be ignored
         /// </summary>
-        private bool CheckSphereLocationCount(IEnumerable<Location> sphereLocations, IEnumerable<Location> checkedLocations, int locationId, int worldCount)
+        private bool CheckSphereLocationCount(IEnumerable<Location> sphereLocations, IEnumerable<Location> checkedLocations, LocationId locationId, int worldCount)
         {
             var ignoreOwnWorld = checkedLocations.Any(x => x.Id == locationId);
             var matchingLocationCount = sphereLocations.Count(x => x.Id == locationId);

--- a/src/Randomizer.SMZ3/Generation/GameHintService.cs
+++ b/src/Randomizer.SMZ3/Generation/GameHintService.cs
@@ -40,10 +40,10 @@ namespace Randomizer.SMZ3.Generation
 
         private static readonly List<LocationId> s_importantLocations = new()
         {
-            LocationId.VariaSuit, // After Kraid
+            LocationId.KraidsLairVariaSuit, // After Kraid
             LocationId.WreckedShipEastSuper, // After Phantoon
-            LocationId.SpaceJump, // After Draygon
-            LocationId.RidleyTank, // After Ridley
+            LocationId.InnerMaridiaSpaceJump, // After Draygon
+            LocationId.LowerNorfairRidleyTank, // After Ridley
             LocationId.EasternPalaceArmosKnights,
             LocationId.DesertPalaceLanmolas,
             LocationId.TowerOfHeraMoldorm,
@@ -196,11 +196,11 @@ namespace Randomizer.SMZ3.Generation
         {
             var hints = new List<string>();
 
-            AddLocationHint(hints, hintPlayerWorld, allWorlds, importantLocations, hintPlayerWorld.Locations.Where(x => x.Id is LocationId.WaterwayEnergyTank));
+            AddLocationHint(hints, hintPlayerWorld, allWorlds, importantLocations, hintPlayerWorld.Locations.Where(x => x.Id is LocationId.PinkBrinstarWaterwayEnergyTank));
             AddLocationHint(hints, hintPlayerWorld, allWorlds, importantLocations, hintPlayerWorld.Locations.Where(x => x.Id is LocationId.WreckedShipEnergyTank)); // Wrecked pool
-            AddLocationHint(hints, hintPlayerWorld, allWorlds, importantLocations, hintPlayerWorld.Locations.Where(x => x.Id is LocationId.BowlingAlleyTop)); // Wrecked ship post chozo speed booster item
-            AddLocationHint(hints, hintPlayerWorld, allWorlds, importantLocations, hintPlayerWorld.Locations.Where(x => x.Id is LocationId.SpringBall)); // Shaktool
-            AddLocationHint(hints, hintPlayerWorld, allWorlds, importantLocations, hintPlayerWorld.Locations.Where(x => x.Id is LocationId.Plasma));
+            AddLocationHint(hints, hintPlayerWorld, allWorlds, importantLocations, hintPlayerWorld.Locations.Where(x => x.Id is LocationId.WreckedShipBowlingAlleyTop)); // Wrecked ship post chozo speed booster item
+            AddLocationHint(hints, hintPlayerWorld, allWorlds, importantLocations, hintPlayerWorld.Locations.Where(x => x.Id is LocationId.InnerMaridiaSpringBall)); // Shaktool
+            AddLocationHint(hints, hintPlayerWorld, allWorlds, importantLocations, hintPlayerWorld.Locations.Where(x => x.Id is LocationId.InnerMaridiaPlasma));
             AddLocationHint(hints, hintPlayerWorld, allWorlds, importantLocations, hintPlayerWorld.Locations.Where(x => x.Id is LocationId.Sahasrahla));
             AddLocationHint(hints, hintPlayerWorld, allWorlds, importantLocations, hintPlayerWorld.Locations.Where(x => x.Id is LocationId.MasterSwordPedestal));
             AddLocationHint(hints, hintPlayerWorld, allWorlds, importantLocations, hintPlayerWorld.Locations.Where(x => x.Id is LocationId.KingZora));
@@ -277,10 +277,10 @@ namespace Randomizer.SMZ3.Generation
                 var sphereLocations = spheres.SelectMany(x => x.Locations);
 
                 var canBeatGT = CheckSphereLocationCount(sphereLocations, locations, LocationId.GanonsTowerMoldormChest, allWorlds.Count());
-                var canBeatKraid = CheckSphereLocationCount(sphereLocations, locations, LocationId.VariaSuit, allWorlds.Count());
+                var canBeatKraid = CheckSphereLocationCount(sphereLocations, locations, LocationId.KraidsLairVariaSuit, allWorlds.Count());
                 var canBeatPhantoon = CheckSphereLocationCount(sphereLocations, locations, LocationId.WreckedShipEastSuper, allWorlds.Count());
-                var canBeatDraygon = CheckSphereLocationCount(sphereLocations, locations, LocationId.SpaceJump, allWorlds.Count());
-                var canBeatRidley = CheckSphereLocationCount(sphereLocations, locations, LocationId.RidleyTank, allWorlds.Count());
+                var canBeatDraygon = CheckSphereLocationCount(sphereLocations, locations, LocationId.InnerMaridiaSpaceJump, allWorlds.Count());
+                var canBeatRidley = CheckSphereLocationCount(sphereLocations, locations, LocationId.LowerNorfairRidleyTank, allWorlds.Count());
                 var allCrateriaBosSKeys = CheckSphereCrateriaBossKeys(sphereLocations);
 
                 // Make sure all players have the silver arrows

--- a/src/Randomizer.SMZ3/Playthrough.cs
+++ b/src/Randomizer.SMZ3/Playthrough.cs
@@ -130,7 +130,7 @@ namespace Randomizer.SMZ3
                     // We determine this on if all players can beat all 4 golden bosses, access the
                     if (inaccessibleLocations.Select(l => l.Item).Count() >= (15 * worlds.Count()))
                     {
-                        var vitalLocations = allLocations.Where(x => x.Id is 256 + 215 or 48 or 134 or 154 or 78).ToList();
+                        var vitalLocations = allLocations.Where(x => x.Id is LocationId.GanonsTowerMoldormChest or LocationId.VariaSuit or LocationId.WreckedShipEastSuper or LocationId.SpaceJump or LocationId.RidleyTank).ToList();
                         var crateriaBossKeys = items.Count(x => x.Type == ItemType.CardCrateriaBoss);
                         if (accessibleLocations.Count(x => vitalLocations.Contains(x)) != vitalLocations.Count() || crateriaBossKeys != worlds.Count())
                         {

--- a/src/Randomizer.SMZ3/Playthrough.cs
+++ b/src/Randomizer.SMZ3/Playthrough.cs
@@ -130,7 +130,7 @@ namespace Randomizer.SMZ3
                     // We determine this on if all players can beat all 4 golden bosses, access the
                     if (inaccessibleLocations.Select(l => l.Item).Count() >= (15 * worlds.Count()))
                     {
-                        var vitalLocations = allLocations.Where(x => x.Id is LocationId.GanonsTowerMoldormChest or LocationId.VariaSuit or LocationId.WreckedShipEastSuper or LocationId.SpaceJump or LocationId.RidleyTank).ToList();
+                        var vitalLocations = allLocations.Where(x => x.Id is LocationId.GanonsTowerMoldormChest or LocationId.KraidsLairVariaSuit or LocationId.WreckedShipEastSuper or LocationId.InnerMaridiaSpaceJump or LocationId.LowerNorfairRidleyTank).ToList();
                         var crateriaBossKeys = items.Count(x => x.Type == ItemType.CardCrateriaBoss);
                         if (accessibleLocations.Count(x => vitalLocations.Contains(x)) != vitalLocations.Count() || crateriaBossKeys != worlds.Count())
                         {

--- a/src/Randomizer.Shared/Enums/LocationId.cs
+++ b/src/Randomizer.Shared/Enums/LocationId.cs
@@ -1,6 +1,4 @@
-﻿using System.ComponentModel;
-
-namespace Randomizer.Shared
+﻿namespace Randomizer.Shared
 {
     /// <summary>
     /// Specifies the IDs of item locations.

--- a/src/Randomizer.Shared/Models/TrackerHistoryEvent.cs
+++ b/src/Randomizer.Shared/Models/TrackerHistoryEvent.cs
@@ -12,7 +12,7 @@ namespace Randomizer.Shared.Models {
         public long Id { get; set; }
         public TrackerState? TrackerState { get; set; }
         public HistoryEventType Type { get; set; }
-        public int? LocationId { get; set; }
+        public LocationId? LocationId { get; set; }
         public string? LocationName { get; set; }
         public string ObjectName { get; set; } = string.Empty;
         public bool IsImportant { get; set; }

--- a/src/Randomizer.Shared/Models/TrackerLocationState.cs
+++ b/src/Randomizer.Shared/Models/TrackerLocationState.cs
@@ -11,7 +11,7 @@ namespace Randomizer.Shared.Models
         [Key]
         public long Id { get; set; }
         public TrackerState? TrackerState { get; set; }
-        public int LocationId { get; init; }
+        public LocationId LocationId { get; init; }
         public ItemType Item { get; init; }
         public ItemType? MarkedItem { get; set; }
         public bool Cleared { get; set; }

--- a/src/Randomizer.Shared/Multiplayer/MultiplayerLocationState.cs
+++ b/src/Randomizer.Shared/Multiplayer/MultiplayerLocationState.cs
@@ -15,7 +15,7 @@ public class MultiplayerLocationState
     [JsonIgnore] public virtual MultiplayerGameState Game { get; init; } = null!;
     public long PlayerId { get; set; }
     [JsonIgnore] public virtual MultiplayerPlayerState Player { get; init; } = null!;
-    public int LocationId { get; init; }
+    public LocationId LocationId { get; init; }
     public bool Tracked { get; set; }
     public DateTimeOffset? TrackedTime { get; set; }
 }

--- a/src/Randomizer.Shared/Multiplayer/MultiplayerPlayerGenerationData.cs
+++ b/src/Randomizer.Shared/Multiplayer/MultiplayerPlayerGenerationData.cs
@@ -84,14 +84,14 @@ public class MultiplayerPlayerGenerationData
 
 public class PlayerGenerationLocationData
 {
-    public PlayerGenerationLocationData(int id, int itemWorldId, ItemType item)
+    public PlayerGenerationLocationData(LocationId id, int itemWorldId, ItemType item)
     {
         Id = id;
         ItemWorldId = itemWorldId;
         Item = item;
     }
 
-    public int Id { get; }
+    public LocationId Id { get; }
     public int ItemWorldId { get; }
     public ItemType Item { get; }
 }

--- a/src/Randomizer.Shared/Multiplayer/MultiplayerPlayerState.cs
+++ b/src/Randomizer.Shared/Multiplayer/MultiplayerPlayerState.cs
@@ -34,7 +34,7 @@ public class MultiplayerPlayerState
     public string? AdditionalData { get; set; }
     [JsonIgnore] public string? GenerationData { get; set; }
 
-    public MultiplayerLocationState? GetLocation(int id) => Locations?.FirstOrDefault(x => x.LocationId == id);
+    public MultiplayerLocationState? GetLocation(LocationId id) => Locations?.FirstOrDefault(x => x.LocationId == id);
     public MultiplayerItemState? GetItem(ItemType type) => Items?.FirstOrDefault(x => x.Item == type);
     public MultiplayerBossState? GetBoss(BossType type) => Bosses?.FirstOrDefault(x => x.Boss == type);
     public MultiplayerDungeonState? GetDungeon(string name) => Dungeons?.FirstOrDefault(x => x.Dungeon == name);
@@ -44,7 +44,7 @@ public class MultiplayerPlayerState
     /// Marks a location as accessed
     /// </summary>
     /// <param name="locationId"></param>
-    public MultiplayerLocationState? TrackLocation(int locationId)
+    public MultiplayerLocationState? TrackLocation(LocationId locationId)
     {
         var location = GetLocation(locationId);
         if (location != null)

--- a/src/Randomizer.Shared/Multiplayer/MultiplayerVersion.cs
+++ b/src/Randomizer.Shared/Multiplayer/MultiplayerVersion.cs
@@ -2,5 +2,5 @@
 
 public static class MultiplayerVersion
 {
-    public const int Id = 3;
+    public const int Id = 4;
 }

--- a/src/Randomizer.Shared/Multiplayer/MultiplayerWorldState.cs
+++ b/src/Randomizer.Shared/Multiplayer/MultiplayerWorldState.cs
@@ -5,7 +5,7 @@ namespace Randomizer.Shared.Multiplayer;
 
 public class MultiplayerWorldState
 {
-    public MultiplayerWorldState(Dictionary<int, bool> locations, Dictionary<ItemType, int> items,
+    public MultiplayerWorldState(Dictionary<LocationId, bool> locations, Dictionary<ItemType, int> items,
         Dictionary<BossType, bool> bosses, Dictionary<string, bool> dungeons)
     {
         Locations = locations;
@@ -14,7 +14,7 @@ public class MultiplayerWorldState
         Dungeons = dungeons;
     }
 
-    public Dictionary<int, bool> Locations { get; set; }
+    public Dictionary<LocationId, bool> Locations { get; set; }
     public Dictionary<ItemType, int> Items { get; set; }
     public Dictionary<BossType, bool> Bosses { get; set; }
     public Dictionary<string, bool> Dungeons { get; set; }

--- a/src/Randomizer.Shared/Multiplayer/TrackLocationRequest.cs
+++ b/src/Randomizer.Shared/Multiplayer/TrackLocationRequest.cs
@@ -2,12 +2,12 @@
 
 public class TrackLocationRequest
 {
-    public TrackLocationRequest(string playerGuid, int locationId)
+    public TrackLocationRequest(string playerGuid, LocationId locationId)
     {
         PlayerGuid = playerGuid;
         LocationId = locationId;
     }
 
     public string PlayerGuid { get; }
-    public int LocationId { get; }
+    public LocationId LocationId { get; }
 }

--- a/src/Randomizer.Shared/Multiplayer/TrackLocationResponse.cs
+++ b/src/Randomizer.Shared/Multiplayer/TrackLocationResponse.cs
@@ -2,12 +2,12 @@
 
 public class TrackLocationResponse
 {
-    public TrackLocationResponse(string playerGuid, int locationId)
+    public TrackLocationResponse(string playerGuid, LocationId locationId)
     {
         PlayerGuid = playerGuid;
         LocationId = locationId;
     }
 
     public string PlayerGuid { get; init; }
-    public int LocationId { get; init; }
+    public LocationId LocationId { get; init; }
 }

--- a/tests/Randomizer.SMZ3.Tests/LocationIdTests.cs
+++ b/tests/Randomizer.SMZ3.Tests/LocationIdTests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Randomizer.Data.Options;
+using Randomizer.Data.WorldData;
+using Randomizer.Shared;
+using Xunit;
+
+namespace Randomizer.SMZ3.Tests
+{
+    public class LocationIdTests
+    {
+        public LocationIdTests()
+        {
+            World = new World(new Config(), "", 0, "");
+        }
+
+        protected World World { get; }
+
+        [Fact]
+        public void EachLocationIdValueIsUsedExactlyOnce()
+        {
+            var allLocationIds = Enum.GetValues<LocationId>().ToImmutableSortedSet();
+            var usedLocationIds = World.Locations.Select(x => x.Id);
+
+            // Every value was used
+            Assert.Empty(allLocationIds.Except(usedLocationIds));
+            // No value was repeated
+            Assert.Equal(allLocationIds.Count, usedLocationIds.Count());
+        }
+    }
+}

--- a/tests/Randomizer.SMZ3.Tests/LogicTests/RandomizerTests.cs
+++ b/tests/Randomizer.SMZ3.Tests/LogicTests/RandomizerTests.cs
@@ -25,7 +25,7 @@ namespace Randomizer.SMZ3.Tests.LogicTests
     {
         // If this test breaks, update Smz3Randomizer.Version
         [Theory]
-        [InlineData("test", -420637834)] // Smz3Randomizer v4.0
+        [InlineData("test", 766814496)] // Smz3Randomizer v4.0
         public void StandardFillerWithSameSeedGeneratesSameWorld(string seed, int expectedHash)
         {
             var filler = new StandardFiller(GetLogger<StandardFiller>());

--- a/tests/Randomizer.SMZ3.Tests/LogicTests/RandomizerTests.cs
+++ b/tests/Randomizer.SMZ3.Tests/LogicTests/RandomizerTests.cs
@@ -25,7 +25,7 @@ namespace Randomizer.SMZ3.Tests.LogicTests
     {
         // If this test breaks, update Smz3Randomizer.Version
         [Theory]
-        [InlineData("test", 766814496)] // Smz3Randomizer v4.0
+        [InlineData("test", -2044032863)] // Smz3Randomizer v4.0
         public void StandardFillerWithSameSeedGeneratesSameWorld(string seed, int expectedHash)
         {
             var filler = new StandardFiller(GetLogger<StandardFiller>());


### PR DESCRIPTION
Continuing work on #341, this takes a lot of `int` parameters and switches them to use `LocationId`. It looks worse than it is and it doesn't appear to affect saved Tracker data, because all the underlying ID's remained the same, but it did mean we needed to bump the multiplayer version up so things wouldn't get screwy there.