### PR TITLE
Moved all locations in rooms from individual properties into `Room.Locations`

### DIFF
--- a/src/Randomizer.App/ViewModels/TrackerViewModel.cs
+++ b/src/Randomizer.App/ViewModels/TrackerViewModel.cs
@@ -103,7 +103,7 @@ namespace Randomizer.App.ViewModels
 
             item = new Item(ItemType.XRay, world, "Bow");
             yield return new MarkedLocationViewModel(
-                _syncer.World.LightWorldNorthEast.ZorasDomain.Zora,
+                _syncer.World.FindLocation(LocationId.KingZora),
                 item,
                 null,
                 _syncer);

--- a/src/Randomizer.App/Windows/GenerateRomWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/GenerateRomWindow.xaml.cs
@@ -459,10 +459,10 @@ namespace Randomizer.App.Windows
 
             stats.Increment("Successfully generated");
 
-            if (IsScam(world.World.InnerMaridia.SpringBall.ShaktoolItem.Item.Type))
+            if (IsScam(world.World.FindLocation(LocationId.InnerMaridiaSpringBall).Item.Type))
                 stats.Increment("Shaktool betrays you");
 
-            if (IsScam(world.World.LightWorldNorthEast.ZorasDomain.Zora.Item.Type))
+            if (IsScam(world.World.FindLocation(LocationId.KingZora).Item.Type))
                 stats.Increment("Zora is a scam");
 
             if (IsScam(world.World.DarkWorldNorthEast.Catfish.Item.Type))
@@ -471,7 +471,7 @@ namespace Randomizer.App.Windows
             if (IsScam(world.World.DarkWorldNorthWest.PegWorld.Item.Type))
                 stats.Increment("\"I want to go on something more thrilling than Peg World.\"");
 
-            if (world.World.BlueBrinstar.BlueBrinstarMorphBall.MorphBall.Item.Type == ItemType.Morph)
+            if (world.World.FindLocation(LocationId.BlueBrinstarMorphBallRight).Item.Type == ItemType.Morph)
                 stats.Increment("The Morph Ball is in its original location");
 
             if (world.World.GanonsTower.MoldormChest.Item.Type.IsInCategory(ItemCategory.Metroid))

--- a/src/Randomizer.Data/WorldData/Regions/Region.cs
+++ b/src/Randomizer.Data/WorldData/Regions/Region.cs
@@ -49,7 +49,7 @@ namespace Randomizer.Data.WorldData.Regions
         /// Gets a collection of every location in the region.
         /// </summary>
         public IEnumerable<Location> Locations => GetStandaloneLocations()
-            .Concat(GetRooms().SelectMany(x => x.GetLocations()));
+            .Concat(GetRooms().SelectMany(x => x.Locations));
 
         /// <summary>
         /// Gets a collection of every room in the region.

--- a/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Brinstar/BlueBrinstar.cs
+++ b/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Brinstar/BlueBrinstar.cs
@@ -3,6 +3,7 @@ using Randomizer.Shared;
 using Randomizer.Data.Options;
 using Randomizer.Data.Services;
 using Randomizer.Shared.Models;
+using System.Collections.Generic;
 
 namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
 {
@@ -35,27 +36,26 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
             public BlueBrinstarMorphBallRoom(BlueBrinstar region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Blue Brinstar Morph Ball Room", metadata, "Morph Ball Room")
             {
-                MorphBall = new Location(this, LocationId.BlueBrinstarMorphBallRight, 0x8F86EC, LocationType.Visible,
-                    name: "Morphing Ball",
-                    vanillaItem: ItemType.Morph,
-                    memoryAddress: 0x3,
-                    memoryFlag: 0x4,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.BlueBrinstarMorphBallRight, 0x8F86EC, LocationType.Visible,
+                        name: "Morphing Ball",
+                        vanillaItem: ItemType.Morph,
+                        memoryAddress: 0x3,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState),
 
-                PowerBomb = new Location(this, LocationId.BlueBrinstarMorphBallLeft, 0x8F874C, LocationType.Visible,
-                    name: "Power Bomb (blue Brinstar)",
-                    vanillaItem: ItemType.PowerBomb,
-                    access: items => Logic.CanUsePowerBombs(items),
-                    memoryAddress: 0x3,
-                    memoryFlag: 0x8,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                    new Location(this, LocationId.BlueBrinstarMorphBallLeft, 0x8F874C, LocationType.Visible,
+                        name: "Power Bomb (blue Brinstar)",
+                        vanillaItem: ItemType.PowerBomb,
+                        access: items => Logic.CanUsePowerBombs(items),
+                        memoryAddress: 0x3,
+                        memoryFlag: 0x8,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location MorphBall { get; }
-
-            public Location PowerBomb { get; }
         }
 
         public class BlueBrinstarFirstMissileRoom : Room
@@ -63,17 +63,18 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
             public BlueBrinstarFirstMissileRoom(BlueBrinstar region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Blue Brinstar First Missile Room", metadata)
             {
-                MiddleMissile = new Location(this, LocationId.BlueBrinstarFirstMissile, 0x8F8798, LocationType.Visible,
-                    name: "Missile (blue Brinstar middle)",
-                    vanillaItem: ItemType.Missile,
-                    access: items => items.CardBrinstarL1 && items.Morph,
-                    memoryAddress: 0x3,
-                    memoryFlag: 0x10,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.BlueBrinstarFirstMissile, 0x8F8798, LocationType.Visible,
+                        name: "Missile (blue Brinstar middle)",
+                        vanillaItem: ItemType.Missile,
+                        access: items => items.CardBrinstarL1 && items.Morph,
+                        memoryAddress: 0x3,
+                        memoryFlag: 0x10,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location MiddleMissile { get; }
         }
 
         public class BlueBrinstarEnergyTankRoom : Room
@@ -81,28 +82,27 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
             public BlueBrinstarEnergyTankRoom(BlueBrinstar region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Blue Brinstar Energy Tank Room", metadata)
             {
-                Ceiling = new Location(this, LocationId.BlueBrinstarEnergyTankCeiling, 0x8F879E, LocationType.Hidden,
-                    name: "Energy Tank, Brinstar Ceiling",
-                    vanillaItem: ItemType.ETank,
-                    access: items => items.CardBrinstarL1 && (Logic.CanFly(items) || items.HiJump || items.SpeedBooster || items.Ice),
-                    memoryAddress: 0x3,
-                    memoryFlag: 0x20,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.BlueBrinstarEnergyTankCeiling, 0x8F879E, LocationType.Hidden,
+                        name: "Energy Tank, Brinstar Ceiling",
+                        vanillaItem: ItemType.ETank,
+                        access: items => items.CardBrinstarL1 && (Logic.CanFly(items) || items.HiJump || items.SpeedBooster || items.Ice),
+                        memoryAddress: 0x3,
+                        memoryFlag: 0x20,
+                        metadata: metadata,
+                        trackerState: trackerState),
 
-                BottomMissile = new Location(this, LocationId.BlueBrinstarEnergyTankRight, 0x8F8802, LocationType.Chozo,
-                    name: "Missile (blue Brinstar bottom)",
-                    vanillaItem: ItemType.Missile,
-                    access: items => items.Morph,
-                    memoryAddress: 0x4,
-                    memoryFlag: 0x4,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                    new Location(this, LocationId.BlueBrinstarEnergyTankRight, 0x8F8802, LocationType.Chozo,
+                        name: "Missile (blue Brinstar bottom)",
+                        vanillaItem: ItemType.Missile,
+                        access: items => items.Morph,
+                        memoryAddress: 0x4,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location Ceiling { get; }
-
-            public Location BottomMissile { get; }
         }
 
         public class BlueBrinstarTopRoom : Room
@@ -110,28 +110,26 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
             public BlueBrinstarTopRoom(BlueBrinstar region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Blue Brinstar Top", metadata, "Billy Mays Room")
             {
-                MainItem = new Location(this, LocationId.BlueBrinstarDoubleMissileVisible, 0x8F8836, LocationType.Visible,
-                    name: "Main Item",
-                    vanillaItem: ItemType.Missile,
-                    access: CanEnter,
-                    memoryAddress: 0x4,
-                    memoryFlag: 0x10,
-                    metadata: metadata,
-                    trackerState: trackerState);
-
-                HiddenItem = new Location(this, LocationId.BlueBrinstarDoubleMissileHidden, 0x8F883C, LocationType.Hidden,
-                    name: "Hidden Item",
-                    vanillaItem: ItemType.Missile,
-                    access: CanEnter,
-                    memoryAddress: 0x4,
-                    memoryFlag: 0x20,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.BlueBrinstarDoubleMissileVisible, 0x8F8836, LocationType.Visible,
+                        name: "Main Item",
+                        vanillaItem: ItemType.Missile,
+                        access: CanEnter,
+                        memoryAddress: 0x4,
+                        memoryFlag: 0x10,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.BlueBrinstarDoubleMissileHidden, 0x8F883C, LocationType.Hidden,
+                        name: "Hidden Item",
+                        vanillaItem: ItemType.Missile,
+                        access: CanEnter,
+                        memoryAddress: 0x4,
+                        memoryFlag: 0x20,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location MainItem { get; }
-
-            public Location HiddenItem { get; }
 
             public bool CanEnter(Progression items)
             {

--- a/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Brinstar/GreenBrinstar.cs
+++ b/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Brinstar/GreenBrinstar.cs
@@ -3,6 +3,7 @@ using Randomizer.Shared;
 using Randomizer.Data.Options;
 using Randomizer.Data.Services;
 using Randomizer.Shared.Models;
+using System.Collections.Generic;
 
 namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
 {
@@ -44,17 +45,18 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
             public GreenBrinstarMainShaftRoom(GreenBrinstar region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Green Brinstar Main Shaft", metadata)
             {
-                PowerBomb = new Location(this, LocationId.GreenBrinstarMainShaft, 0x8F84AC, LocationType.Chozo,
-                    name: "Power Bomb (green Brinstar bottom)",
-                    access: items => items.CardBrinstarL2 && Logic.CanUsePowerBombs(items)
-                                  && (Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items)),
-                    memoryAddress: 0x1,
-                    memoryFlag: 0x20,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.GreenBrinstarMainShaft, 0x8F84AC, LocationType.Chozo,
+                        name: "Power Bomb (green Brinstar bottom)",
+                        access: items => items.CardBrinstarL2 && Logic.CanUsePowerBombs(items)
+                                      && (Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items)),
+                        memoryAddress: 0x1,
+                        memoryFlag: 0x20,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location PowerBomb { get; }
         }
 
         public class EtecoonEnergyTankRoom : Room
@@ -62,18 +64,19 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
             public EtecoonEnergyTankRoom(GreenBrinstar region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Etecoon Energy Tank Room", metadata)
             {
-                ETank = new Location(this, LocationId.GreenBrinstarEtecoonEnergyTank, 0x8F87C2, LocationType.Visible,
-                    name: "Energy Tank, Etecoons",
-                    vanillaItem: ItemType.ETank,
-                    access: items => items.CardBrinstarL2 && Logic.CanUsePowerBombs(items)
-                                  && (Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items)),
-                    memoryAddress: 0x3,
-                    memoryFlag: 0x40,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.GreenBrinstarEtecoonEnergyTank, 0x8F87C2, LocationType.Visible,
+                        name: "Energy Tank, Etecoons",
+                        vanillaItem: ItemType.ETank,
+                        access: items => items.CardBrinstarL2 && Logic.CanUsePowerBombs(items)
+                                      && (Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items)),
+                        memoryAddress: 0x3,
+                        memoryFlag: 0x40,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location ETank { get; }
         }
 
         public class EtecoonSuperRoom : Room
@@ -81,18 +84,19 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
             public EtecoonSuperRoom(GreenBrinstar region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Etecon Super Room", metadata)
             {
-                BottomSuperMissile = new Location(this, LocationId.GreenBrinstarEtecoonSuper, 0x8F87D0, LocationType.Visible,
-                    name: "Super Missile (green Brinstar bottom)",
-                    vanillaItem: ItemType.Super,
-                    access: items => items.CardBrinstarL2 && Logic.CanUsePowerBombs(items) && items.Super
-                                  && (Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items)),
-                    memoryAddress: 0x3,
-                    memoryFlag: 0x80,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.GreenBrinstarEtecoonSuper, 0x8F87D0, LocationType.Visible,
+                        name: "Super Missile (green Brinstar bottom)",
+                        vanillaItem: ItemType.Super,
+                        access: items => items.CardBrinstarL2 && Logic.CanUsePowerBombs(items) && items.Super
+                                      && (Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items)),
+                        memoryAddress: 0x3,
+                        memoryFlag: 0x80,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location BottomSuperMissile { get; }
         }
 
         public class MockballHallRoom : Room
@@ -100,28 +104,27 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
             public MockballHallRoom(GreenBrinstar region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Mockball Hall", metadata, "Early Supers Room")
             {
-                MissileBelowSuperMissile = new Location(this, LocationId.GreenBrinstarEarlySupersBottom, 0x8F8518, LocationType.Visible,
-                    name: "Missile (green Brinstar below super missile)",
-                    vanillaItem: ItemType.Missile,
-                    access: items => Logic.CanPassBombPassages(items) && Logic.CanOpenRedDoors(items),
-                    memoryAddress: 0x1,
-                    memoryFlag: 0x80,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.GreenBrinstarEarlySupersBottom, 0x8F8518, LocationType.Visible,
+                        name: "Missile (green Brinstar below super missile)",
+                        vanillaItem: ItemType.Missile,
+                        access: items => Logic.CanPassBombPassages(items) && Logic.CanOpenRedDoors(items),
+                        memoryAddress: 0x1,
+                        memoryFlag: 0x80,
+                        metadata: metadata,
+                        trackerState: trackerState),
 
-                TopSuperMissile = new Location(this, LocationId.GreenBrinstarEarlySupersTop, 0x8F851E, LocationType.Visible,
-                    name: "Super Missile (green Brinstar top)",
-                    vanillaItem: ItemType.Super,
-                    access: items => Logic.CanOpenRedDoors(items) && Logic.CanMoveAtHighSpeeds(items),
-                    memoryAddress: 0x2,
-                    memoryFlag: 0x1,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                    new Location(this, LocationId.GreenBrinstarEarlySupersTop, 0x8F851E, LocationType.Visible,
+                        name: "Super Missile (green Brinstar top)",
+                        vanillaItem: ItemType.Super,
+                        access: items => Logic.CanOpenRedDoors(items) && Logic.CanMoveAtHighSpeeds(items),
+                        memoryAddress: 0x2,
+                        memoryFlag: 0x1,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location MissileBelowSuperMissile { get; }
-
-            public Location TopSuperMissile { get; }
         }
 
         public class MockballHallHiddenRoom : Room
@@ -129,39 +132,36 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
             public MockballHallHiddenRoom(GreenBrinstar region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Mockball Hall Hidden Room", metadata, "Brinstar Reserve Tank Room")
             {
-                ReserveTank = new Location(this, LocationId.GreenBrinstarReserveTankChozo, 0x8F852C, LocationType.Chozo,
-                    name: "Reserve Tank, Brinstar",
-                    vanillaItem: ItemType.ReserveTank,
-                    access: CanEnter,
-                    memoryAddress: 0x2,
-                    memoryFlag: 0x2,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.GreenBrinstarReserveTankChozo, 0x8F852C, LocationType.Chozo,
+                        name: "Reserve Tank, Brinstar",
+                        vanillaItem: ItemType.ReserveTank,
+                        access: CanEnter,
+                        memoryAddress: 0x2,
+                        memoryFlag: 0x2,
+                        metadata: metadata,
+                        trackerState: trackerState),
 
-                HiddenItem = new Location(this, LocationId.GreenBrinstarReserveTankHidden, 0x8F8532, LocationType.Hidden,
-                    name: "Hidden Item",
-                    vanillaItem: ItemType.Missile,
-                    access: items => CanEnter(items) && Logic.CanPassBombPassages(items),
-                    memoryAddress: 0x2,
-                    memoryFlag: 0x4,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                    new Location(this, LocationId.GreenBrinstarReserveTankHidden, 0x8F8532, LocationType.Hidden,
+                        name: "Hidden Item",
+                        vanillaItem: ItemType.Missile,
+                        access: items => CanEnter(items) && Logic.CanPassBombPassages(items),
+                        memoryAddress: 0x2,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState),
 
-                MainItem = new Location(this, LocationId.GreenBrinstarReserveTankVisible, 0x8F8538, LocationType.Visible,
-                    name: "Main Item",
-                    vanillaItem: ItemType.Missile,
-                    access: items => CanEnter(items) && items.Morph,
-                    memoryAddress: 0x2,
-                    memoryFlag: 0x8,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                    new Location(this, LocationId.GreenBrinstarReserveTankVisible, 0x8F8538, LocationType.Visible,
+                        name: "Main Item",
+                        vanillaItem: ItemType.Missile,
+                        access: items => CanEnter(items) && items.Morph,
+                        memoryAddress: 0x2,
+                        memoryFlag: 0x8,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location ReserveTank { get; }
-
-            public Location MainItem { get; }
-
-            public Location HiddenItem { get; }
 
             public bool CanEnter(Progression items)
             {
@@ -169,5 +169,4 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
             }
         }
     }
-
 }

--- a/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Brinstar/KraidsLair.cs
+++ b/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Brinstar/KraidsLair.cs
@@ -53,7 +53,9 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
             public WarehouseEnergyTankRoom(KraidsLair region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Warehouse Energy Tank Room", metadata)
             {
-                    ETank = new Location(this, LocationId.KraidsLairEnergyTank, 0x8F899C, LocationType.Hidden,
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.KraidsLairEnergyTank, 0x8F899C, LocationType.Hidden,
                         name: "Energy Tank, Kraid",
                         vanillaItem: ItemType.ETank,
                         access: items => items.Kraid,
@@ -61,10 +63,9 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
                         memoryAddress: 0x5,
                         memoryFlag: 0x8,
                         metadata: metadata,
-                        trackerState: trackerState);
+                        trackerState: trackerState)
+                };
             }
-
-            public Location ETank { get; }
         }
 
         public class WarehouseKihunterRoom : Room
@@ -72,17 +73,18 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
             public WarehouseKihunterRoom(KraidsLair region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Warehouse Kihunter Room", metadata)
             {
-                MissileBeforeKraid = new Location(this, LocationId.KraidsLairKihunter, 0x8F89EC, LocationType.Hidden,
-                    name: "Missile (Kraid)",
-                    vanillaItem: ItemType.Missile,
-                    access: items => Logic.CanUsePowerBombs(items),
-                    memoryAddress: 0x5,
-                    memoryFlag: 0x10,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.KraidsLairKihunter, 0x8F89EC, LocationType.Hidden,
+                        name: "Missile (Kraid)",
+                        vanillaItem: ItemType.Missile,
+                        access: items => Logic.CanUsePowerBombs(items),
+                        memoryAddress: 0x5,
+                        memoryFlag: 0x10,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location MissileBeforeKraid { get; }
         }
 
         public class VariaSuitRoom : Room
@@ -90,18 +92,19 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
             public VariaSuitRoom(KraidsLair region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Varia Suit Room", metadata)
             {
-                KraidsItem = new Location(this, LocationId.KraidsLairVariaSuit, 0x8F8ACA, LocationType.Chozo,
-                    name: "Varia Suit",
-                    vanillaItem: ItemType.Varia,
-                    access: items => items.Kraid,
-                    relevanceRequirement: items => region.CanBeatBoss(items),
-                    memoryAddress: 0x6,
-                    memoryFlag: 0x1,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.KraidsLairVariaSuit, 0x8F8ACA, LocationType.Chozo,
+                        name: "Varia Suit",
+                        vanillaItem: ItemType.Varia,
+                        access: items => items.Kraid,
+                        relevanceRequirement: items => region.CanBeatBoss(items),
+                        memoryAddress: 0x6,
+                        memoryFlag: 0x1,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location KraidsItem { get; }
         }
     }
 }

--- a/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Brinstar/PinkBrinstar.cs
+++ b/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Brinstar/PinkBrinstar.cs
@@ -3,6 +3,7 @@ using Randomizer.Shared;
 using Randomizer.Data.Options;
 using Randomizer.Data.Services;
 using Randomizer.Shared.Models;
+using System.Collections.Generic;
 
 namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
 {
@@ -48,36 +49,33 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
             public BigPinkRoom(PinkBrinstar region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Big Pink", metadata)
             {
-                PinkShaftTop = new Location(this, LocationId.PinkBrinstarPinkShaftTop, 0x8F8608, LocationType.Visible,
-                    name: "Missile (pink Brinstar top)",
-                    vanillaItem: ItemType.Missile,
-                    access: items => items.Grapple || Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items),
-                    memoryAddress: 0x2,
-                    memoryFlag: 0x20,
-                    metadata: metadata,
-                    trackerState: trackerState);
-                PinkShaftBottom = new Location(this, LocationId.PinkBrinstarPinkShaftBottom, 0x8F860E, LocationType.Visible,
-                    name: "Missile (pink Brinstar bottom)",
-                    vanillaItem: ItemType.Missile,
-                    memoryAddress: 0x2,
-                    memoryFlag: 0x40,
-                    metadata: metadata,
-                    trackerState: trackerState);
-                PinkShaftChozo = new Location(this, LocationId.PinkBrinstarPinkShaftChozo, 0x8F8614, LocationType.Chozo,
-                    name: "Charge Beam",
-                    vanillaItem: ItemType.Charge,
-                    access: items => Logic.CanPassBombPassages(items),
-                    memoryAddress: 0x2,
-                    memoryFlag: 0x80,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.PinkBrinstarPinkShaftTop, 0x8F8608, LocationType.Visible,
+                        name: "Missile (pink Brinstar top)",
+                        vanillaItem: ItemType.Missile,
+                        access: items => items.Grapple || Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items),
+                        memoryAddress: 0x2,
+                        memoryFlag: 0x20,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.PinkBrinstarPinkShaftBottom, 0x8F860E, LocationType.Visible,
+                        name: "Missile (pink Brinstar bottom)",
+                        vanillaItem: ItemType.Missile,
+                        memoryAddress: 0x2,
+                        memoryFlag: 0x40,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.PinkBrinstarPinkShaftChozo, 0x8F8614, LocationType.Chozo,
+                        name: "Charge Beam",
+                        vanillaItem: ItemType.Charge,
+                        access: items => Logic.CanPassBombPassages(items),
+                        memoryAddress: 0x2,
+                        memoryFlag: 0x80,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location PinkShaftTop { get; }
-
-            public Location PinkShaftBottom { get; }
-
-            public Location PinkShaftChozo { get; }
         }
 
         public class PinkBrinstarPowerBombRoom : Room
@@ -85,18 +83,19 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
             public PinkBrinstarPowerBombRoom(PinkBrinstar region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Pink Brinstar Power Bomb Room", metadata)
             {
-                MissionImpossible = new Location(this, LocationId.PinkBrinstarPowerBomb, 0x8F865C, LocationType.Visible,
-                    name: "Power Bomb (pink Brinstar)",
-                    vanillaItem: ItemType.PowerBomb,
-                    access: items => Logic.CanUsePowerBombs(items) && items.Super && Logic.HasEnergyReserves(items, 1)
-                                  && (items.Grapple || Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items)),
-                    memoryAddress: 0x3,
-                    memoryFlag: 0x1,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.PinkBrinstarPowerBomb, 0x8F865C, LocationType.Visible,
+                        name: "Power Bomb (pink Brinstar)",
+                        vanillaItem: ItemType.PowerBomb,
+                        access: items => Logic.CanUsePowerBombs(items) && items.Super && Logic.HasEnergyReserves(items, 1)
+                                      && (items.Grapple || Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items)),
+                        memoryAddress: 0x3,
+                        memoryFlag: 0x1,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location MissionImpossible { get; }
         }
 
         public class HoptankRoom : Room
@@ -104,19 +103,20 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
             public HoptankRoom(PinkBrinstar region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Hoptank Room", metadata)
             {
-                WaveBeamGlitchRoom = new Location(this, LocationId.PinkBrinstarHoptank, 0x8F8824, LocationType.Visible,
-                    name: "Energy Tank, Brinstar Gate",
-                    vanillaItem: ItemType.ETank,
-                    access: items => items.CardBrinstarL2 && Logic.CanUsePowerBombs(items)
-                                  && items.Wave && Logic.HasEnergyReserves(items, 1)
-                                  && (items.Grapple || Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items)),
-                    memoryAddress: 0x4,
-                    memoryFlag: 0x8,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.PinkBrinstarHoptank, 0x8F8824, LocationType.Visible,
+                        name: "Energy Tank, Brinstar Gate",
+                        vanillaItem: ItemType.ETank,
+                        access: items => items.CardBrinstarL2 && Logic.CanUsePowerBombs(items)
+                                      && items.Wave && Logic.HasEnergyReserves(items, 1)
+                                      && (items.Grapple || Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items)),
+                        memoryAddress: 0x4,
+                        memoryFlag: 0x8,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location WaveBeamGlitchRoom { get; }
         }
 
         public class SporeSpawnSuperRoom : Room
@@ -124,17 +124,18 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
             public SporeSpawnSuperRoom(PinkBrinstar region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Spore Spawn Super Room", metadata)
             {
-                SporeSpawnReward = new Location(this, LocationId.PinkBrinstarSporeSpawnSuper, 0x8F84E4, LocationType.Chozo,
-                    name: "Super Missile (pink Brinstar)",
-                    vanillaItem: ItemType.Super,
-                    access: items => items.CardBrinstarBoss && Logic.CanPassBombPassages(items) && items.Super,
-                    memoryAddress: 0x1,
-                    memoryFlag: 0x40,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.PinkBrinstarSporeSpawnSuper, 0x8F84E4, LocationType.Chozo,
+                        name: "Super Missile (pink Brinstar)",
+                        vanillaItem: ItemType.Super,
+                        access: items => items.CardBrinstarBoss && Logic.CanPassBombPassages(items) && items.Super,
+                        memoryAddress: 0x1,
+                        memoryFlag: 0x40,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location SporeSpawnReward { get; }
         }
 
         public class WaterwayEnergyTankRoom : Room
@@ -142,18 +143,19 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
             public WaterwayEnergyTankRoom(PinkBrinstar region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Waterway Energy Tank Room", metadata)
             {
-                Waterway = new Location(this, LocationId.PinkBrinstarWaterwayEnergyTank, 0x8F87FA, LocationType.Visible,
-                    name: "Energy Tank, Waterway",
-                    vanillaItem: ItemType.ETank,
-                    access: items => Logic.CanUsePowerBombs(items) && Logic.CanOpenRedDoors(items) && items.SpeedBooster &&
-                            ((Logic.HasEnergyReserves(items, 1) && !World.Config.LogicConfig.WaterwayNeedsGravitySuit) || items.Gravity),
-                    memoryAddress: 0x4,
-                    memoryFlag: 0x2,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.PinkBrinstarWaterwayEnergyTank, 0x8F87FA, LocationType.Visible,
+                        name: "Energy Tank, Waterway",
+                        vanillaItem: ItemType.ETank,
+                        access: items => Logic.CanUsePowerBombs(items) && Logic.CanOpenRedDoors(items) && items.SpeedBooster &&
+                                ((Logic.HasEnergyReserves(items, 1) && !World.Config.LogicConfig.WaterwayNeedsGravitySuit) || items.Gravity),
+                        memoryAddress: 0x4,
+                        memoryFlag: 0x2,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location Waterway { get; }
         }
 
         public class GreenHillZoneRoom : Room
@@ -161,19 +163,20 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
             public GreenHillZoneRoom(PinkBrinstar region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Green Hill Zone", metadata)
             {
-                GreenHillZone = new Location(this, LocationId.GreenBrinstarGreenHillZone, 0x8F8676, LocationType.Visible,
-                    name: "Missile (green Brinstar pipe)",
-                    vanillaItem: ItemType.Missile,
-                    access: items => items.Morph
-                                  && (items.PowerBomb || items.Super || Logic.CanAccessNorfairUpperPortal(items))
-                                  && (items.HiJump || Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items)),
-                    memoryAddress: 0x3,
-                    memoryFlag: 0x2,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.GreenBrinstarGreenHillZone, 0x8F8676, LocationType.Visible,
+                        name: "Missile (green Brinstar pipe)",
+                        vanillaItem: ItemType.Missile,
+                        access: items => items.Morph
+                                      && (items.PowerBomb || items.Super || Logic.CanAccessNorfairUpperPortal(items))
+                                      && (items.HiJump || Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items)),
+                        memoryAddress: 0x3,
+                        memoryFlag: 0x2,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location GreenHillZone { get; }
         }
     }
 }

--- a/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Brinstar/RedBrinstar.cs
+++ b/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Brinstar/RedBrinstar.cs
@@ -3,6 +3,7 @@ using Randomizer.Shared;
 using Randomizer.Data.Options;
 using Randomizer.Data.Services;
 using Randomizer.Shared.Models;
+using System.Collections.Generic;
 
 namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
 {
@@ -43,17 +44,18 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
             public XRayScopeRoom(RedBrinstar region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "X-Ray Scope Room", metadata)
             {
-                XRayScope = new Location(this, LocationId.RedBrinstarXRayScope, 0x8F8876, LocationType.Chozo,
-                    name: "X-Ray Scope",
-                    vanillaItem: ItemType.XRay,
-                    access: items => Logic.CanUsePowerBombs(items) && Logic.CanOpenRedDoors(items) && (items.Grapple || items.SpaceJump),
-                    memoryAddress: 0x4,
-                    memoryFlag: 0x40,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.RedBrinstarXRayScope, 0x8F8876, LocationType.Chozo,
+                        name: "X-Ray Scope",
+                        vanillaItem: ItemType.XRay,
+                        access: items => Logic.CanUsePowerBombs(items) && Logic.CanOpenRedDoors(items) && (items.Grapple || items.SpaceJump),
+                        memoryAddress: 0x4,
+                        memoryFlag: 0x40,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location XRayScope { get; }
         }
 
         public class BetaPowerBombRoom : Room
@@ -61,17 +63,18 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
             public BetaPowerBombRoom(RedBrinstar region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Beta Power Bomb Room", metadata)
             {
-                PowerBomb = new Location(this, LocationId.RedBrinstarBetaPowerBomb, 0x8F88CA, LocationType.Visible,
-                    name: "Power Bomb (red Brinstar sidehopper room)",
-                    vanillaItem: ItemType.PowerBomb,
-                    access: items => Logic.CanUsePowerBombs(items) && items.Super,
-                    memoryAddress: 0x4,
-                    memoryFlag: 0x80,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.RedBrinstarBetaPowerBomb, 0x8F88CA, LocationType.Visible,
+                        name: "Power Bomb (red Brinstar sidehopper room)",
+                        vanillaItem: ItemType.PowerBomb,
+                        access: items => Logic.CanUsePowerBombs(items) && items.Super,
+                        memoryAddress: 0x4,
+                        memoryFlag: 0x80,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location PowerBomb { get; }
         }
 
         public class AlphaPowerBombRoom : Room
@@ -79,27 +82,26 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
             public AlphaPowerBombRoom(RedBrinstar region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Alpha Power Bomb Room", metadata)
             {
-                PowerBomb = new Location(this, LocationId.RedBrinstarAlphaPowerBombRight, 0x8F890E, LocationType.Chozo,
-                    name: "Power Bomb (red Brinstar spike room)",
-                    vanillaItem: ItemType.PowerBomb,
-                    access: items => (Logic.CanUsePowerBombs(items) || items.Ice) && items.Super,
-                    memoryAddress: 0x5,
-                    memoryFlag: 0x1,
-                    metadata: metadata,
-                    trackerState: trackerState);
-                AlphaPowerBombRoomWall = new Location(this, LocationId.RedBrinstarAlphaPowerBombLeft, 0x8F8914, LocationType.Visible,
-                    name: "Missile (red Brinstar spike room)",
-                    vanillaItem: ItemType.Missile,
-                    access: items => Logic.CanUsePowerBombs(items) && items.Super,
-                    memoryAddress: 0x5,
-                    memoryFlag: 0x2,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.RedBrinstarAlphaPowerBombRight, 0x8F890E, LocationType.Chozo,
+                        name: "Power Bomb (red Brinstar spike room)",
+                        vanillaItem: ItemType.PowerBomb,
+                        access: items => (Logic.CanUsePowerBombs(items) || items.Ice) && items.Super,
+                        memoryAddress: 0x5,
+                        memoryFlag: 0x1,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.RedBrinstarAlphaPowerBombLeft, 0x8F8914, LocationType.Visible,
+                        name: "Missile (red Brinstar spike room)",
+                        vanillaItem: ItemType.Missile,
+                        access: items => Logic.CanUsePowerBombs(items) && items.Super,
+                        memoryAddress: 0x5,
+                        memoryFlag: 0x2,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location PowerBomb { get; }
-
-            public Location AlphaPowerBombRoomWall { get; }
         }
 
         public class SpazerRoom : Room
@@ -107,18 +109,19 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Brinstar
             public SpazerRoom(RedBrinstar region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Spazer Room", metadata)
             {
-                Spazer = new Location(this, LocationId.RedBrinstarSpazer, 0x8F896E, LocationType.Chozo,
-                    name: "Spazer",
-                    vanillaItem: ItemType.Spazer,
-                    access: items => Logic.CanPassBombPassages(items) && items.Super
-                                  && (items.HiJump || Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items)),
-                    memoryAddress: 0x5,
-                    memoryFlag: 0x4,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.RedBrinstarSpazer, 0x8F896E, LocationType.Chozo,
+                        name: "Spazer",
+                        vanillaItem: ItemType.Spazer,
+                        access: items => Logic.CanPassBombPassages(items) && items.Super
+                                      && (items.HiJump || Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items)),
+                        memoryAddress: 0x5,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location Spazer { get; }
         }
     }
 }

--- a/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Crateria/CentralCrateria.cs
+++ b/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Crateria/CentralCrateria.cs
@@ -3,6 +3,7 @@ using Randomizer.Shared;
 using Randomizer.Data.Options;
 using Randomizer.Data.Services;
 using Randomizer.Shared.Models;
+using System.Collections.Generic;
 
 namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Crateria
 {
@@ -41,17 +42,18 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Crateria
             public PowerBombRoom(CentralCrateria region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Crateria Power Bomb Room", metadata)
             {
-                PowerBomb = new Location(this, LocationId.CrateriaPowerBomb, 0x8F81CC, LocationType.Visible,
-                    name: "Power Bomb (Crateria surface)",
-                    vanillaItem: ItemType.PowerBomb,
-                    access: items => (Config.MetroidKeysanity ? items.CardCrateriaL1 : Logic.CanUsePowerBombs(items)) && (items.SpeedBooster || Logic.CanFly(items)),
-                    memoryAddress: 0x0,
-                    memoryFlag: 0x1,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.CrateriaPowerBomb, 0x8F81CC, LocationType.Visible,
+                        name: "Power Bomb (Crateria surface)",
+                        vanillaItem: ItemType.PowerBomb,
+                        access: items => (Config.MetroidKeysanity ? items.CardCrateriaL1 : Logic.CanUsePowerBombs(items)) && (items.SpeedBooster || Logic.CanFly(items)),
+                        memoryAddress: 0x0,
+                        memoryFlag: 0x1,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location PowerBomb { get; }
         }
 
         public class TheFinalMissileRoom : Room
@@ -59,17 +61,18 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Crateria
             public TheFinalMissileRoom(CentralCrateria region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "The Final Missile Room", metadata)
             {
-                FinalMissileBombWay = new Location(this, LocationId.CrateriaFinalMissile, 0x8F8486, LocationType.Visible,
-                    name: "Missile (Crateria middle)",
-                    vanillaItem: ItemType.Missile,
-                    access: items => Logic.CanPassBombPassages(items),
-                    memoryAddress: 0x1,
-                    memoryFlag: 0x10,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.CrateriaFinalMissile, 0x8F8486, LocationType.Visible,
+                        name: "Missile (Crateria middle)",
+                        vanillaItem: ItemType.Missile,
+                        access: items => Logic.CanPassBombPassages(items),
+                        memoryAddress: 0x1,
+                        memoryFlag: 0x10,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location FinalMissileBombWay { get; }
         }
 
         public class PitRoom : Room
@@ -77,17 +80,18 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Crateria
             public PitRoom(CentralCrateria region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Pit Room", metadata)
             {
-                MotherBrainTreasure = new Location(this, LocationId.CrateriaPit, 0x8F83EE, LocationType.Visible,
-                    name: "Missile (Crateria bottom)",
-                    vanillaItem: ItemType.Missile,
-                    access: items => Logic.CanDestroyBombWalls(items),
-                    memoryAddress: 0x0,
-                    memoryFlag: 0x40,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.CrateriaPit, 0x8F83EE, LocationType.Visible,
+                        name: "Missile (Crateria bottom)",
+                        vanillaItem: ItemType.Missile,
+                        access: items => Logic.CanDestroyBombWalls(items),
+                        memoryAddress: 0x0,
+                        memoryFlag: 0x40,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location MotherBrainTreasure { get; }
         }
 
         public class CrateriaSuperRoom : Room
@@ -95,17 +99,18 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Crateria
             public CrateriaSuperRoom(CentralCrateria region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Crateria Super Room", metadata)
             {
-                SuperMissile = new Location(this, LocationId.CrateriaSuper, 0x8F8478, LocationType.Visible,
-                    name: "Super Missile (Crateria)",
-                    vanillaItem: ItemType.Super,
-                    access: items => Logic.CanUsePowerBombs(items) && Logic.HasEnergyReserves(items, 2) && items.SpeedBooster && (!World.Config.LogicConfig.LaunchPadRequiresIceBeam || items.Ice),
-                    memoryAddress: 0x1,
-                    memoryFlag: 0x8,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.CrateriaSuper, 0x8F8478, LocationType.Visible,
+                        name: "Super Missile (Crateria)",
+                        vanillaItem: ItemType.Super,
+                        access: items => Logic.CanUsePowerBombs(items) && Logic.HasEnergyReserves(items, 2) && items.SpeedBooster && (!World.Config.LogicConfig.LaunchPadRequiresIceBeam || items.Ice),
+                        memoryAddress: 0x1,
+                        memoryFlag: 0x8,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location SuperMissile { get; }
         }
 
         public class BombTorizoRoom : Room
@@ -113,18 +118,19 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Crateria
             public BombTorizoRoom(CentralCrateria region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Bomb Torizo Room", metadata)
             {
-                BombTorizo = new Location(this, LocationId.CrateriaBombTorizo, 0x8F8404, LocationType.Chozo,
-                    name: "Bombs",
-                    vanillaItem: ItemType.Bombs,
-                    access: items => (Config.MetroidKeysanity ? items.CardCrateriaBoss : Logic.CanOpenRedDoors(items))
-                                     && (Logic.CanPassBombPassages(items) || Logic.CanWallJump(WallJumpDifficulty.Hard)),
-                    memoryAddress: 0x0,
-                    memoryFlag: 0x80,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.CrateriaBombTorizo, 0x8F8404, LocationType.Chozo,
+                        name: "Bombs",
+                        vanillaItem: ItemType.Bombs,
+                        access: items => (Config.MetroidKeysanity ? items.CardCrateriaBoss : Logic.CanOpenRedDoors(items))
+                                         && (Logic.CanPassBombPassages(items) || Logic.CanWallJump(WallJumpDifficulty.Hard)),
+                        memoryAddress: 0x0,
+                        memoryFlag: 0x80,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location BombTorizo { get; }
         }
     }
 }

--- a/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Crateria/EastCrateria.cs
+++ b/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Crateria/EastCrateria.cs
@@ -3,6 +3,7 @@ using Randomizer.Shared;
 using Randomizer.Data.Options;
 using Randomizer.Data.Services;
 using Randomizer.Shared.Models;
+using System.Collections.Generic;
 
 namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Crateria
 {
@@ -37,7 +38,7 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Crateria
                         /* Oasis -> Forgotten Highway */
                         (items.CardMaridiaL2 && Logic.CanDestroyBombWalls(items)) ||
                         /* Draygon -> Cactus Alley -> Forgotten Highway */
-                        World.InnerMaridia.SpaceJump.DraygonTreasure.IsAvailable(items))) ||
+                        World.FindLocation(LocationId.InnerMaridiaSpaceJump).IsAvailable(items))) ||
                     /*Through Maridia from Pipe*/
                     (Logic.CanUsePowerBombs(items) && items.Super && items.Gravity);
         }
@@ -47,40 +48,37 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Crateria
             public WestOceanRoom(EastCrateria region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "West Ocean", metadata)
             {
-                FloodedCavernUnderWater = new Location(this, LocationId.CrateriaWestOceanFloodedCavern, 0x8F81E8, LocationType.Visible,
-                    name: "Missile (outside Wrecked Ship bottom)",
-                    vanillaItem: ItemType.Missile,
-                    access: items => CanAccessFloodedCavernUnderWater(items, true),
-                    relevanceRequirement: items => CanAccessFloodedCavernUnderWater(items, false),
-                    memoryAddress: 0x0,
-                    memoryFlag: 0x2,
-                    metadata: metadata,
-                    trackerState: trackerState);
-                SkyMissile = new Location(this, LocationId.CrateriaWestOceanSky, 0x8F81EE, LocationType.Hidden,
-                    name: "Missile (outside Wrecked Ship top)",
-                    vanillaItem: ItemType.Missile,
-                    access: items => CanAccessSkyItem(items, true),
-                    relevanceRequirement: items => CanAccessSkyItem(items, false),
-                    memoryAddress: 0x0,
-                    memoryFlag: 0x4,
-                    metadata: metadata,
-                    trackerState: trackerState);
-                MorphBallMaze = new Location(this, LocationId.CrateriaWestOceanMorphBallMaze, 0x8F81F4, LocationType.Visible,
-                    name: "Missile (outside Wrecked Ship middle)",
-                    vanillaItem: ItemType.Missile,
-                    access: items => CanPassThroughWreckedShip(items, true),
-                    relevanceRequirement: items => CanPassThroughWreckedShip(items, false),
-                    memoryAddress: 0x0,
-                    memoryFlag: 0x8,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.CrateriaWestOceanFloodedCavern, 0x8F81E8, LocationType.Visible,
+                        name: "Missile (outside Wrecked Ship bottom)",
+                        vanillaItem: ItemType.Missile,
+                        access: items => CanAccessFloodedCavernUnderWater(items, true),
+                        relevanceRequirement: items => CanAccessFloodedCavernUnderWater(items, false),
+                        memoryAddress: 0x0,
+                        memoryFlag: 0x2,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.CrateriaWestOceanSky, 0x8F81EE, LocationType.Hidden,
+                        name: "Missile (outside Wrecked Ship top)",
+                        vanillaItem: ItemType.Missile,
+                        access: items => CanAccessSkyItem(items, true),
+                        relevanceRequirement: items => CanAccessSkyItem(items, false),
+                        memoryAddress: 0x0,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.CrateriaWestOceanMorphBallMaze, 0x8F81F4, LocationType.Visible,
+                        name: "Missile (outside Wrecked Ship middle)",
+                        vanillaItem: ItemType.Missile,
+                        access: items => CanPassThroughWreckedShip(items, true),
+                        relevanceRequirement: items => CanPassThroughWreckedShip(items, false),
+                        memoryAddress: 0x0,
+                        memoryFlag: 0x8,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location FloodedCavernUnderWater { get; }
-
-            public Location SkyMissile { get; }
-
-            public Location MorphBallMaze { get; }
 
             private bool CanAccessFloodedCavernUnderWater(Progression items, bool requireRewards)
                 => items.Morph && (
@@ -102,16 +100,17 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Crateria
             public TheMoatRoom(EastCrateria region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "The Moat", metadata)
             {
-                Moat = new Location(this, LocationId.CrateriaMoat, 0x8F8248, LocationType.Visible,
-                    name: "Missile (Crateria moat)",
-                    vanillaItem: ItemType.Missile,
-                    memoryAddress: 0x0,
-                    memoryFlag: 0x10,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.CrateriaMoat, 0x8F8248, LocationType.Visible,
+                        name: "Missile (Crateria moat)",
+                        vanillaItem: ItemType.Missile,
+                        memoryAddress: 0x0,
+                        memoryFlag: 0x10,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location Moat { get; }
         }
     }
 }

--- a/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Crateria/WestCrateria.cs
+++ b/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Crateria/WestCrateria.cs
@@ -3,6 +3,7 @@ using Randomizer.Shared;
 using Randomizer.Data.Options;
 using Randomizer.Data.Services;
 using Randomizer.Shared.Models;
+using System.Collections.Generic;
 
 namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Crateria
 {
@@ -46,28 +47,26 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Crateria
             public GauntletShaftRoom(WestCrateria region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Gauntlet Shaft", metadata)
             {
-                GauntletRight = new Location(this, LocationId.CrateriaGauntletShaftRight, 0x8F8464, LocationType.Visible,
-                    name: "Right",
-                    vanillaItem: ItemType.Missile,
-                    access: items => region.CanEnterAndLeaveGauntlet(items) && Logic.CanPassBombPassages(items) && Logic.HasEnergyReserves(items, 2),
-                    memoryAddress: 0x1,
-                    memoryFlag: 0x2,
-                    metadata: metadata,
-                    trackerState: trackerState);
-
-                GauntletLeft = new Location(this, LocationId.CrateriaGauntletShaftLeft, 0x8F846A, LocationType.Visible,
-                    name: "Left",
-                    vanillaItem: ItemType.Missile,
-                    access: items => region.CanEnterAndLeaveGauntlet(items) && Logic.CanPassBombPassages(items) && Logic.HasEnergyReserves(items, 2),
-                    memoryAddress: 0x1,
-                    memoryFlag: 0x4,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.CrateriaGauntletShaftRight, 0x8F8464, LocationType.Visible,
+                        name: "Right",
+                        vanillaItem: ItemType.Missile,
+                        access: items => region.CanEnterAndLeaveGauntlet(items) && Logic.CanPassBombPassages(items) && Logic.HasEnergyReserves(items, 2),
+                        memoryAddress: 0x1,
+                        memoryFlag: 0x2,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.CrateriaGauntletShaftLeft, 0x8F846A, LocationType.Visible,
+                        name: "Left",
+                        vanillaItem: ItemType.Missile,
+                        access: items => region.CanEnterAndLeaveGauntlet(items) && Logic.CanPassBombPassages(items) && Logic.HasEnergyReserves(items, 2),
+                        memoryAddress: 0x1,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location GauntletRight { get; }
-
-            public Location GauntletLeft { get; }
         }
 
         public class GauntletEnergyTankRoom : Room
@@ -75,17 +74,18 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Crateria
             public GauntletEnergyTankRoom(WestCrateria region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Gauntlet Energy Tank Room", metadata)
             {
-                Gauntlet = new Location(this, LocationId.CrateriaGauntletEnergyTank, 0x8F8264, LocationType.Visible,
-                    name: "Energy Tank, Gauntlet",
-                    vanillaItem: ItemType.ETank,
-                    access: items => region.CanEnterAndLeaveGauntlet(items) && Logic.HasEnergyReserves(items, 1),
-                    memoryAddress: 0x0,
-                    memoryFlag: 0x20,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.CrateriaGauntletEnergyTank, 0x8F8264, LocationType.Visible,
+                        name: "Energy Tank, Gauntlet",
+                        vanillaItem: ItemType.ETank,
+                        access: items => region.CanEnterAndLeaveGauntlet(items) && Logic.HasEnergyReserves(items, 1),
+                        memoryAddress: 0x0,
+                        memoryFlag: 0x20,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location Gauntlet { get; }
         }
 
         public class TerminatorRoom : Room
@@ -93,16 +93,17 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Crateria
             public TerminatorRoom(WestCrateria region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Terminator Room", metadata)
             {
-                Terminator = new Location(this, LocationId.CrateriaTerminator, 0x8F8432, LocationType.Visible,
-                    name: "Energy Tank, Terminator",
-                    vanillaItem: ItemType.ETank,
-                    memoryAddress: 0x1,
-                    memoryFlag: 0x1,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.CrateriaTerminator, 0x8F8432, LocationType.Visible,
+                        name: "Energy Tank, Terminator",
+                        vanillaItem: ItemType.ETank,
+                        memoryAddress: 0x1,
+                        memoryFlag: 0x1,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location Terminator { get; }
         }
     }
 }

--- a/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Maridia/InnerMaridia.cs
+++ b/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Maridia/InnerMaridia.cs
@@ -4,6 +4,7 @@ using Randomizer.Shared;
 using Randomizer.Data.Options;
 using Randomizer.Data.Services;
 using Randomizer.Shared.Models;
+using System.Collections.Generic;
 
 namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Maridia
 {
@@ -101,30 +102,29 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Maridia
             public WateringHoleRoom(InnerMaridia region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Watering Hole", metadata)
             {
-                Left = new Location(this, LocationId.InnerMaridiaWateringHoleLeft, 0x8FC4AF, LocationType.Visible,
-                    name: "Left",
-                    vanillaItem: ItemType.Super,
-                    access: items => items.CardMaridiaL1 && Logic.CanPassBombPassages(items) && region.CanPassPipeCrossroads(items) && CanReachAqueduct(items, Logic, true),
-                    relevanceRequirement: items => items.CardMaridiaL1 && Logic.CanPassBombPassages(items) && region.CanPassPipeCrossroads(items) && CanReachAqueduct(items, Logic, false),
-                    memoryAddress: 0x11,
-                    memoryFlag: 0x10,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.InnerMaridiaWateringHoleLeft, 0x8FC4AF, LocationType.Visible,
+                        name: "Left",
+                        vanillaItem: ItemType.Super,
+                        access: items => items.CardMaridiaL1 && Logic.CanPassBombPassages(items) && region.CanPassPipeCrossroads(items) && CanReachAqueduct(items, Logic, true),
+                        relevanceRequirement: items => items.CardMaridiaL1 && Logic.CanPassBombPassages(items) && region.CanPassPipeCrossroads(items) && CanReachAqueduct(items, Logic, false),
+                        memoryAddress: 0x11,
+                        memoryFlag: 0x10,
+                        metadata: metadata,
+                        trackerState: trackerState),
 
-                Right = new Location(this, LocationId.InnerMaridiaWateringHoleRight, 0x8FC4B5, LocationType.Visible,
-                    name: "Right",
-                    vanillaItem: ItemType.Missile,
-                    access: items => items.CardMaridiaL1 && Logic.CanPassBombPassages(items) && region.CanPassPipeCrossroads(items) && CanReachAqueduct(items, Logic, true),
-                    relevanceRequirement: items => items.CardMaridiaL1 && Logic.CanPassBombPassages(items) && region.CanPassPipeCrossroads(items) && CanReachAqueduct(items, Logic, false),
-                    memoryAddress: 0x11,
-                    memoryFlag: 0x20,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                    new Location(this, LocationId.InnerMaridiaWateringHoleRight, 0x8FC4B5, LocationType.Visible,
+                        name: "Right",
+                        vanillaItem: ItemType.Missile,
+                        access: items => items.CardMaridiaL1 && Logic.CanPassBombPassages(items) && region.CanPassPipeCrossroads(items) && CanReachAqueduct(items, Logic, true),
+                        relevanceRequirement: items => items.CardMaridiaL1 && Logic.CanPassBombPassages(items) && region.CanPassPipeCrossroads(items) && CanReachAqueduct(items, Logic, false),
+                        memoryAddress: 0x11,
+                        memoryFlag: 0x20,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location Left { get; }
-
-            public Location Right { get; }
         }
 
         public class PseudoPlasmaSparkRoom : Room
@@ -132,18 +132,19 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Maridia
             public PseudoPlasmaSparkRoom(InnerMaridia region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Pseudo Plasma Spark Room", metadata)
             {
-                PseudoSparkRoom = new Location(this, LocationId.InnerMaridiaPseudoPlasmaSpark, 0x8FC533, LocationType.Visible,
-                    name: "Missile (yellow Maridia false wall)",
-                    vanillaItem: ItemType.Missile,
-                    access: items => items.CardMaridiaL1 && Logic.CanPassBombPassages(items) && region.CanPassPipeCrossroads(items) && CanReachAqueduct(items, Logic, true),
-                    relevanceRequirement: items => items.CardMaridiaL1 && Logic.CanPassBombPassages(items) && region.CanPassPipeCrossroads(items) && CanReachAqueduct(items, Logic, false),
-                    memoryAddress: 0x11,
-                    memoryFlag: 0x40,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.InnerMaridiaPseudoPlasmaSpark, 0x8FC533, LocationType.Visible,
+                        name: "Missile (yellow Maridia false wall)",
+                        vanillaItem: ItemType.Missile,
+                        access: items => items.CardMaridiaL1 && Logic.CanPassBombPassages(items) && region.CanPassPipeCrossroads(items) && CanReachAqueduct(items, Logic, true),
+                        relevanceRequirement: items => items.CardMaridiaL1 && Logic.CanPassBombPassages(items) && region.CanPassPipeCrossroads(items) && CanReachAqueduct(items, Logic, false),
+                        memoryAddress: 0x11,
+                        memoryFlag: 0x40,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location PseudoSparkRoom { get; }
         }
 
         public class PlasmaRoom : Room
@@ -151,18 +152,19 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Maridia
             public PlasmaRoom(InnerMaridia region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Plasma Room", metadata, "Plasma Beam Room")
             {
-                PlasmaBeam = new Location(this, LocationId.InnerMaridiaPlasma, 0x8FC559, LocationType.Chozo,
-                    name: "Plasma Beam",
-                    vanillaItem: ItemType.Plasma,
-                    access: items => region.CanAccessPlasmaBeamRoom(items, requireRewards: true),
-                    relevanceRequirement: items => region.CanAccessPlasmaBeamRoom(items, requireRewards: false),
-                    memoryAddress: 0x11,
-                    memoryFlag: 0x80,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.InnerMaridiaPlasma, 0x8FC559, LocationType.Chozo,
+                        name: "Plasma Beam",
+                        vanillaItem: ItemType.Plasma,
+                        access: items => region.CanAccessPlasmaBeamRoom(items, requireRewards: true),
+                        relevanceRequirement: items => region.CanAccessPlasmaBeamRoom(items, requireRewards: false),
+                        memoryAddress: 0x11,
+                        memoryFlag: 0x80,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location PlasmaBeam { get; }
         }
 
         public class LeftSandPitRoom : Room
@@ -170,30 +172,28 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Maridia
             public LeftSandPitRoom(InnerMaridia region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Left Sand Pit", metadata, "West Sand Hole")
             {
-                Left = new Location(this, LocationId.InnerMaridiaWestSandHoleLeft, 0x8FC5DD, LocationType.Visible,
-                    name: "Left",
-                    vanillaItem: ItemType.Missile,
-                    access: items => CanEnter(items, true) && Logic.CanNavigateMaridiaLeftSandPit(items),
-                    relevanceRequirement: items => CanEnter(items, false) && Logic.CanNavigateMaridiaLeftSandPit(items),
-                    memoryAddress: 0x12,
-                    memoryFlag: 0x1,
-                    metadata: metadata,
-                    trackerState: trackerState);
-
-                Right = new Location(this, LocationId.InnerMaridiaWestSandHoleRight, 0x8FC5E3, LocationType.Chozo,
-                    name: "Right",
-                    vanillaItem: ItemType.ReserveTank,
-                    access: items => CanEnter(items, true) && Logic.CanNavigateMaridiaLeftSandPit(items),
-                    relevanceRequirement: items => CanEnter(items, false) && Logic.CanNavigateMaridiaLeftSandPit(items),
-                    memoryAddress: 0x12,
-                    memoryFlag: 0x2,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.InnerMaridiaWestSandHoleLeft, 0x8FC5DD, LocationType.Visible,
+                        name: "Left",
+                        vanillaItem: ItemType.Missile,
+                        access: items => CanEnter(items, true) && Logic.CanNavigateMaridiaLeftSandPit(items),
+                        relevanceRequirement: items => CanEnter(items, false) && Logic.CanNavigateMaridiaLeftSandPit(items),
+                        memoryAddress: 0x12,
+                        memoryFlag: 0x1,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.InnerMaridiaWestSandHoleRight, 0x8FC5E3, LocationType.Chozo,
+                        name: "Right",
+                        vanillaItem: ItemType.ReserveTank,
+                        access: items => CanEnter(items, true) && Logic.CanNavigateMaridiaLeftSandPit(items),
+                        relevanceRequirement: items => CanEnter(items, false) && Logic.CanNavigateMaridiaLeftSandPit(items),
+                        memoryAddress: 0x12,
+                        memoryFlag: 0x2,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location Left { get; }
-
-            public Location Right { get; }
 
             public bool CanEnter(Progression items, bool requireRewards)
                 => InnerMaridia.CanReachAqueduct(items, Logic, requireRewards) && items.Super && Logic.CanPassBombPassages(items);
@@ -204,29 +204,28 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Maridia
             public RightSandPitRoom(InnerMaridia region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Right Sand Pit", metadata, "East Sand Hole")
             {
-                Left = new Location(this, LocationId.InnerMaridiaEastSandHoleLeft, 0x8FC5EB, LocationType.Visible,
-                    name: "Missile (right Maridia sand pit room)",
-                    vanillaItem: ItemType.Missile,
-                    access: items => CanReachRightSandPit(items, true),
-                    relevanceRequirement: items => CanReachRightSandPit(items, false),
-                    memoryAddress: 0x12,
-                    memoryFlag: 0x4,
-                    metadata: metadata,
-                    trackerState: trackerState);
-                Right = new Location(this, LocationId.InnerMaridiaEastSandHoleRight, 0x8FC5F1, LocationType.Visible,
-                    name: "Power Bomb (right Maridia sand pit room)",
-                    vanillaItem: ItemType.PowerBomb,
-                    access: items => CanReachRightSandPit(items, true),
-                    relevanceRequirement: items => CanReachRightSandPit(items, false),
-                    memoryAddress: 0x12,
-                    memoryFlag: 0x8,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.InnerMaridiaEastSandHoleLeft, 0x8FC5EB, LocationType.Visible,
+                        name: "Missile (right Maridia sand pit room)",
+                        vanillaItem: ItemType.Missile,
+                        access: items => CanReachRightSandPit(items, true),
+                        relevanceRequirement: items => CanReachRightSandPit(items, false),
+                        memoryAddress: 0x12,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.InnerMaridiaEastSandHoleRight, 0x8FC5F1, LocationType.Visible,
+                        name: "Power Bomb (right Maridia sand pit room)",
+                        vanillaItem: ItemType.PowerBomb,
+                        access: items => CanReachRightSandPit(items, true),
+                        relevanceRequirement: items => CanReachRightSandPit(items, false),
+                        memoryAddress: 0x12,
+                        memoryFlag: 0x8,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location Left { get; }
-
-            public Location Right { get; }
 
             private bool CanReachRightSandPit(Progression items, bool requireRewards)
                 => CanReachAqueduct(items, Logic, requireRewards) && items.Super && (Logic.CanWallJump(WallJumpDifficulty.Easy) || items.HiJump || items.SpaceJump);
@@ -237,29 +236,28 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Maridia
             public AqueductRoom(InnerMaridia region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Aqueduct", metadata)
             {
-                AqueductLeft = new Location(this, LocationId.InnerMaridiaAqueductLeft, 0x8FC603, LocationType.Visible,
-                    name: "Missile (pink Maridia)",
-                    vanillaItem: ItemType.Missile,
-                    access: items => CanReachAqueduct(items, Logic, true) && items.SpeedBooster,
-                    relevanceRequirement: items => CanReachAqueduct(items, Logic, false) && items.SpeedBooster,
-                    memoryAddress: 0x12,
-                    memoryFlag: 0x10,
-                    metadata: metadata,
-                    trackerState: trackerState);
-                AqueductRight = new Location(this, LocationId.InnerMaridiaAqueductRight, 0x8FC609, LocationType.Visible,
-                    name: "Super Missile (pink Maridia)",
-                    vanillaItem: ItemType.Super,
-                    access: items => CanReachAqueduct(items, Logic, true) && items.SpeedBooster,
-                    relevanceRequirement: items => CanReachAqueduct(items, Logic, false) && items.SpeedBooster,
-                    memoryAddress: 0x12,
-                    memoryFlag: 0x20,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.InnerMaridiaAqueductLeft, 0x8FC603, LocationType.Visible,
+                        name: "Missile (pink Maridia)",
+                        vanillaItem: ItemType.Missile,
+                        access: items => CanReachAqueduct(items, Logic, true) && items.SpeedBooster,
+                        relevanceRequirement: items => CanReachAqueduct(items, Logic, false) && items.SpeedBooster,
+                        memoryAddress: 0x12,
+                        memoryFlag: 0x10,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.InnerMaridiaAqueductRight, 0x8FC609, LocationType.Visible,
+                        name: "Super Missile (pink Maridia)",
+                        vanillaItem: ItemType.Super,
+                        access: items => CanReachAqueduct(items, Logic, true) && items.SpeedBooster,
+                        relevanceRequirement: items => CanReachAqueduct(items, Logic, false) && items.SpeedBooster,
+                        memoryAddress: 0x12,
+                        memoryFlag: 0x20,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location AqueductLeft { get; }
-
-            public Location AqueductRight { get; }
         }
 
         public class SpringBallRoom : Room
@@ -267,19 +265,20 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Maridia
             public SpringBallRoom(InnerMaridia region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Spring Ball Room", metadata)
             {
-                ShaktoolItem = new Location(this, LocationId.InnerMaridiaSpringBall, 0x8FC6E5, LocationType.Chozo,
-                    name: "Spring Ball",
-                    vanillaItem: ItemType.SpringBall,
-                    access: items => items.Super && Logic.CanUsePowerBombs(items) && items.Grapple
-                                  && (items.SpaceJump || (items.HiJump && Logic.CanWallJump(WallJumpDifficulty.Medium)))
-                                  && (Logic.CanWallJump(WallJumpDifficulty.Medium) || items.SpringBall || items.SpaceJump), // Leaving again
-                    memoryAddress: 0x12,
-                    memoryFlag: 0x40,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.InnerMaridiaSpringBall, 0x8FC6E5, LocationType.Chozo,
+                        name: "Spring Ball",
+                        vanillaItem: ItemType.SpringBall,
+                        access: items => items.Super && Logic.CanUsePowerBombs(items) && items.Grapple
+                                      && (items.SpaceJump || (items.HiJump && Logic.CanWallJump(WallJumpDifficulty.Medium)))
+                                      && (Logic.CanWallJump(WallJumpDifficulty.Medium) || items.SpringBall || items.SpaceJump), // Leaving again
+                        memoryAddress: 0x12,
+                        memoryFlag: 0x40,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location ShaktoolItem { get; }
         }
 
         public class ThePreciousRoom : Room
@@ -287,18 +286,19 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Maridia
             public ThePreciousRoom(InnerMaridia region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "The Precious Room", metadata)
             {
-                PreDraygonRoom = new Location(this, LocationId.InnerMaridiaPreciousRoom, 0x8FC74D, LocationType.Hidden,
-                    name: "Missile (Draygon)",
-                    vanillaItem: ItemType.Missile,
-                    access: items => region.CanAccessPreciousRoom(items, true),
-                    relevanceRequirement: items => region.CanAccessPreciousRoom(items, false),
-                    memoryAddress: 0x12,
-                    memoryFlag: 0x80,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.InnerMaridiaPreciousRoom, 0x8FC74D, LocationType.Hidden,
+                        name: "Missile (Draygon)",
+                        vanillaItem: ItemType.Missile,
+                        access: items => region.CanAccessPreciousRoom(items, true),
+                        relevanceRequirement: items => region.CanAccessPreciousRoom(items, false),
+                        memoryAddress: 0x12,
+                        memoryFlag: 0x80,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location PreDraygonRoom { get; }
         }
 
         public class BotwoonsRoom : Room
@@ -306,20 +306,21 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Maridia
             public BotwoonsRoom(InnerMaridia region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Botwoon's Room", metadata)
             {
-                Botwoon = new Location(this, LocationId.InnerMaridiaBotwoon, 0x8FC755, LocationType.Visible,
-                    name: "Energy Tank, Botwoon",
-                    vanillaItem: ItemType.ETank,
-                    access: items => (items.CardMaridiaL1 && items.CardMaridiaL2 && region.CanDefeatBotwoon(items, true))
-                                      || (Logic.CanAccessMaridiaPortal(items, requireRewards: true) && items.CardMaridiaL2),
-                    relevanceRequirement: items => (items.CardMaridiaL1 && items.CardMaridiaL2 && region.CanDefeatBotwoon(items, false))
-                                      || (Logic.CanAccessMaridiaPortal(items, requireRewards: false) && items.CardMaridiaL2),
-                    memoryAddress: 0x13,
-                    memoryFlag: 0x1,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.InnerMaridiaBotwoon, 0x8FC755, LocationType.Visible,
+                        name: "Energy Tank, Botwoon",
+                        vanillaItem: ItemType.ETank,
+                        access: items => (items.CardMaridiaL1 && items.CardMaridiaL2 && region.CanDefeatBotwoon(items, true))
+                                          || (Logic.CanAccessMaridiaPortal(items, requireRewards: true) && items.CardMaridiaL2),
+                        relevanceRequirement: items => (items.CardMaridiaL1 && items.CardMaridiaL2 && region.CanDefeatBotwoon(items, false))
+                                          || (Logic.CanAccessMaridiaPortal(items, requireRewards: false) && items.CardMaridiaL2),
+                        memoryAddress: 0x13,
+                        memoryFlag: 0x1,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location Botwoon { get; }
         }
 
         public class SpaceJumpRoom : Room
@@ -327,18 +328,19 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Maridia
             public SpaceJumpRoom(InnerMaridia region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Space Jump Room", metadata)
             {
-                DraygonTreasure = new Location(this, LocationId.InnerMaridiaSpaceJump, 0x8FC7A7, LocationType.Chozo,
-                    name: "Space Jump",
-                    vanillaItem: ItemType.SpaceJump,
-                    access: items => items.Draygon,
-                    relevanceRequirement: items => region.CanDefeatDraygon(items, false),
-                    memoryAddress: 0x13,
-                    memoryFlag: 0x4,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.InnerMaridiaSpaceJump, 0x8FC7A7, LocationType.Chozo,
+                        name: "Space Jump",
+                        vanillaItem: ItemType.SpaceJump,
+                        access: items => items.Draygon,
+                        relevanceRequirement: items => region.CanDefeatDraygon(items, false),
+                        memoryAddress: 0x13,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location DraygonTreasure { get; }
         }
     }
 }

--- a/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Maridia/OuterMaridia.cs
+++ b/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Maridia/OuterMaridia.cs
@@ -3,6 +3,7 @@ using Randomizer.Shared;
 using Randomizer.Data.Options;
 using Randomizer.Data.Services;
 using Randomizer.Shared.Models;
+using System.Collections.Generic;
 
 namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Maridia
 {
@@ -45,29 +46,28 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Maridia
             public MainStreetRoom(OuterMaridia region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Main Street Room", metadata, "Main Street")
             {
-                MainStreetCeiling = new Location(this, LocationId.OuterMaridiaMainStreetBottom, 0x8FC437, LocationType.Visible,
-                    name: "Missile (green Maridia shinespark)",
-                    vanillaItem: ItemType.Missile,
-                    access: items => items.SpeedBooster,
-                    memoryAddress: 0x11,
-                    memoryFlag: 0x1,
-                    metadata: metadata,
-                    trackerState: trackerState);
-                MainStreetCrabSupers = new Location(this, LocationId.OuterMaridiaMainStreetTop, 0x8FC43D, LocationType.Visible,
-                    name: "Super Missile (green Maridia)",
-                    vanillaItem: ItemType.Super,
-                    access: items => Logic.CanWallJump(WallJumpDifficulty.Medium)
-                                  || (Logic.CanWallJump(WallJumpDifficulty.Easy) && items.Ice)
-                                  || items.HiJump || Logic.CanFly(items),
-                    memoryAddress: 0x11,
-                    memoryFlag: 0x2,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.OuterMaridiaMainStreetBottom, 0x8FC437, LocationType.Visible,
+                        name: "Missile (green Maridia shinespark)",
+                        vanillaItem: ItemType.Missile,
+                        access: items => items.SpeedBooster,
+                        memoryAddress: 0x11,
+                        memoryFlag: 0x1,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.OuterMaridiaMainStreetTop, 0x8FC43D, LocationType.Visible,
+                        name: "Super Missile (green Maridia)",
+                        vanillaItem: ItemType.Super,
+                        access: items => Logic.CanWallJump(WallJumpDifficulty.Medium)
+                                      || (Logic.CanWallJump(WallJumpDifficulty.Easy) && items.Ice)
+                                      || items.HiJump || Logic.CanFly(items),
+                        memoryAddress: 0x11,
+                        memoryFlag: 0x2,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location MainStreetCeiling { get; }
-
-            public Location MainStreetCrabSupers { get; }
         }
 
         public class MamaTurtleRoom : Room
@@ -75,34 +75,33 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Maridia
             public MamaTurtleRoom(OuterMaridia region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Mama Turtle Room", metadata)
             {
-                EnergyTank = new Location(this, LocationId.OuterMaridiaMamaTurtleVisible, 0x8FC47D, LocationType.Visible,
-                    name: "Energy Tank, Mama turtle",
-                    vanillaItem: ItemType.ETank,
-                    access: items => region.CanReachTurtleRoom(items)
-                                  && (Logic.CanFly(items)
-                                      || items.SpeedBooster
-                                      || items.Grapple), // Reaching the item
-                    memoryAddress: 0x11,
-                    memoryFlag: 0x4,
-                    metadata: metadata,
-                    trackerState: trackerState);
-                MamaTurtleWallItem = new Location(this, LocationId.OuterMaridiaMamaTurtleHidden, 0x8FC483, LocationType.Hidden,
-                    name: "Missile (green Maridia tatori)",
-                    vanillaItem: ItemType.Missile,
-                    access: items => region.CanReachTurtleRoom(items)
-                                  && (Logic.CanWallJump(WallJumpDifficulty.Easy)
-                                      || items.SpeedBooster
-                                      || (items.Grapple && items.HiJump)
-                                      || Logic.CanFly(items)), // Reaching the item
-                    memoryAddress: 0x11,
-                    memoryFlag: 0x8,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.OuterMaridiaMamaTurtleVisible, 0x8FC47D, LocationType.Visible,
+                        name: "Energy Tank, Mama turtle",
+                        vanillaItem: ItemType.ETank,
+                        access: items => region.CanReachTurtleRoom(items)
+                                      && (Logic.CanFly(items)
+                                          || items.SpeedBooster
+                                          || items.Grapple), // Reaching the item
+                        memoryAddress: 0x11,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.OuterMaridiaMamaTurtleHidden, 0x8FC483, LocationType.Hidden,
+                        name: "Missile (green Maridia tatori)",
+                        vanillaItem: ItemType.Missile,
+                        access: items => region.CanReachTurtleRoom(items)
+                                      && (Logic.CanWallJump(WallJumpDifficulty.Easy)
+                                          || items.SpeedBooster
+                                          || (items.Grapple && items.HiJump)
+                                          || Logic.CanFly(items)), // Reaching the item
+                        memoryAddress: 0x11,
+                        memoryFlag: 0x8,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location EnergyTank { get; }
-
-            public Location MamaTurtleWallItem { get; }
         }
     }
 }

--- a/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Norfair/LowerNorfairEast.cs
+++ b/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Norfair/LowerNorfairEast.cs
@@ -3,6 +3,7 @@ using Randomizer.Shared;
 using Randomizer.Data.Options;
 using Randomizer.Data.Services;
 using Randomizer.Shared.Models;
+using System.Collections.Generic;
 
 namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
 {
@@ -66,17 +67,18 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
             public SpringBallMazeRoom(LowerNorfairEast region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Spring Ball Maze Room", metadata)
             {
-                SpringBallMaze = new Location(this, LocationId.LowerNorfairSpringBallMaze, 0x8F8FCA, LocationType.Visible,
-                    name: "Missile (lower Norfair above fire flea room)",
-                    vanillaItem: ItemType.Missile,
-                    access: items => region.CanExit(items),
-                    memoryAddress: 0x9,
-                    memoryFlag: 0x4,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.LowerNorfairSpringBallMaze, 0x8F8FCA, LocationType.Visible,
+                        name: "Missile (lower Norfair above fire flea room)",
+                        vanillaItem: ItemType.Missile,
+                        access: items => region.CanExit(items),
+                        memoryAddress: 0x9,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location SpringBallMaze { get; }
         }
 
         public class EscapePowerBombRoom : Room
@@ -84,17 +86,18 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
             public EscapePowerBombRoom(LowerNorfairEast region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Escape Power Bomb Room", metadata)
             {
-                PowerBomb = new Location(this, LocationId.LowerNorfairEscapePowerBomb, 0x8F8FD2, LocationType.Visible,
-                    name: "Power Bomb (lower Norfair above fire flea room)",
-                    vanillaItem: ItemType.PowerBomb,
-                    access: items => region.CanExit(items),
-                    memoryAddress: 0x9,
-                    memoryFlag: 0x8,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.LowerNorfairEscapePowerBomb, 0x8F8FD2, LocationType.Visible,
+                        name: "Power Bomb (lower Norfair above fire flea room)",
+                        vanillaItem: ItemType.PowerBomb,
+                        access: items => region.CanExit(items),
+                        memoryAddress: 0x9,
+                        memoryFlag: 0x8,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location PowerBomb { get; }
         }
 
         public class WastelandRoom : Room
@@ -102,17 +105,18 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
             public WastelandRoom(LowerNorfairEast region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Wasteland", metadata, "Power Bomb of Shame Room")
             {
-                PowerBombOfShame = new Location(this, LocationId.LowerNorfairWasteland, 0x8F90C0, LocationType.Visible,
-                    name: "Power Bomb (Power Bombs of shame)",
-                    vanillaItem: ItemType.PowerBomb,
-                    access: items => region.CanExit(items) && Logic.CanUsePowerBombs(items),
-                    memoryAddress: 0x9,
-                    memoryFlag: 0x10,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.LowerNorfairWasteland, 0x8F90C0, LocationType.Visible,
+                        name: "Power Bomb (Power Bombs of shame)",
+                        vanillaItem: ItemType.PowerBomb,
+                        access: items => region.CanExit(items) && Logic.CanUsePowerBombs(items),
+                        memoryAddress: 0x9,
+                        memoryFlag: 0x10,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location PowerBombOfShame { get; }
         }
 
         public class ThreeMusketeersRoom : Room
@@ -120,17 +124,18 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
             public ThreeMusketeersRoom(LowerNorfairEast region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Three Musketeers' Room", metadata)
             {
-                Missile = new Location(this, LocationId.LowerNorfairThreeMusketeers, 0x8F9100, LocationType.Visible,
-                    name: "Missile (lower Norfair near Wave Beam)",
-                    vanillaItem: ItemType.Missile,
-                    access: region.CanExit,
-                    memoryAddress: 0x9,
-                    memoryFlag: 0x20,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.LowerNorfairThreeMusketeers, 0x8F9100, LocationType.Visible,
+                        name: "Missile (lower Norfair near Wave Beam)",
+                        vanillaItem: ItemType.Missile,
+                        access: region.CanExit,
+                        memoryAddress: 0x9,
+                        memoryFlag: 0x20,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location Missile { get; }
         }
 
         public class RidleyTankRoom : Room
@@ -138,18 +143,19 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
             public RidleyTankRoom(LowerNorfairEast region, IMetadataService? metadata, TrackerState? trackerState)
                : base(region, "Ridley Tank Room", metadata)
            {
-                RidleyTreasure = new Location(this, LocationId.LowerNorfairRidleyTank, 0x8F9108, LocationType.Hidden,
-                    name: "Energy Tank, Ridley",
-                    vanillaItem: ItemType.ETank,
-                    access: items => items.Ridley,
-                    relevanceRequirement: region.CanBeatBoss,
-                    memoryAddress: 0x9,
-                    memoryFlag: 0x40,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.LowerNorfairRidleyTank, 0x8F9108, LocationType.Hidden,
+                        name: "Energy Tank, Ridley",
+                        vanillaItem: ItemType.ETank,
+                        access: items => items.Ridley,
+                        relevanceRequirement: region.CanBeatBoss,
+                        memoryAddress: 0x9,
+                        memoryFlag: 0x40,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
            }
-
-            public Location RidleyTreasure { get; }
         }
 
         public class FirefleaRoom : Room
@@ -157,17 +163,18 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
             public FirefleaRoom(LowerNorfairEast region, IMetadataService? metadata, TrackerState? trackerState)
                : base(region, "Lower Norfair Fireflea Room", metadata)
             {
-                EnergyTank = new Location(this, LocationId.LowerNorfairFireflea, 0x8F9184, LocationType.Visible,
-                    name: "Energy Tank, Firefleas",
-                    vanillaItem: ItemType.ETank,
-                    access: region.CanExit,
-                    memoryAddress: 0xA,
-                    memoryFlag: 0x1,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.LowerNorfairFireflea, 0x8F9184, LocationType.Visible,
+                        name: "Energy Tank, Firefleas",
+                        vanillaItem: ItemType.ETank,
+                        access: region.CanExit,
+                        memoryAddress: 0xA,
+                        memoryFlag: 0x1,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location EnergyTank { get; }
         }
     }
 }

--- a/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Norfair/LowerNorfairWest.cs
+++ b/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Norfair/LowerNorfairWest.cs
@@ -3,6 +3,7 @@ using Randomizer.Shared;
 using Randomizer.Data.Options;
 using Randomizer.Data.Services;
 using Randomizer.Shared.Models;
+using System.Collections.Generic;
 
 namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
 {
@@ -46,30 +47,29 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
             public GoldenTorizosRoom(LowerNorfairWest region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Golden Torizo's Room", metadata)
             {
-                BeforeGoldTorizo = new Location(this, LocationId.LowerNorfairGoldenTorizoVisible, 0x8F8E6E, LocationType.Visible,
-                    name: "Missile (Gold Torizo)",
-                    vanillaItem: ItemType.Missile,
-                    access: items => Logic.CanUsePowerBombs(items) && items.SpaceJump && items.Super,
-                    memoryAddress: 0x8,
-                    memoryFlag: 0x40,
-                    metadata: metadata,
-                    trackerState: trackerState);
-                GoldTorizoCeiling = new Location(this, LocationId.LowerNorfairGoldenTorizoHidden, 0x8F8E74, LocationType.Hidden,
-                    name: "Super Missile (Gold Torizo)",
-                    vanillaItem: ItemType.Super,
-                    access: items => Logic.CanDestroyBombWalls(items)
-                                     && (items.Super || items.Charge)
-                                     && (Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items))
-                                     && (Logic.CanAccessNorfairLowerPortal(items) || (items.SpaceJump && Logic.CanUsePowerBombs(items))),
-                    memoryAddress: 0x8,
-                    memoryFlag: 0x80,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.LowerNorfairGoldenTorizoVisible, 0x8F8E6E, LocationType.Visible,
+                        name: "Missile (Gold Torizo)",
+                        vanillaItem: ItemType.Missile,
+                        access: items => Logic.CanUsePowerBombs(items) && items.SpaceJump && items.Super,
+                        memoryAddress: 0x8,
+                        memoryFlag: 0x40,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.LowerNorfairGoldenTorizoHidden, 0x8F8E74, LocationType.Hidden,
+                        name: "Super Missile (Gold Torizo)",
+                        vanillaItem: ItemType.Super,
+                        access: items => Logic.CanDestroyBombWalls(items)
+                                         && (items.Super || items.Charge)
+                                         && (Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items))
+                                         && (Logic.CanAccessNorfairLowerPortal(items) || (items.SpaceJump && Logic.CanUsePowerBombs(items))),
+                        memoryAddress: 0x8,
+                        memoryFlag: 0x80,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location BeforeGoldTorizo { get; }
-
-            public Location GoldTorizoCeiling { get; }
         }
 
         public class MickeyMouseRoom : Room
@@ -77,26 +77,27 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
             public MickeyMouseRoom(LowerNorfairWest region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Mickey Mouse Room", metadata, "Mickey Mouse Clubhouse")
             {
-                MickeyMouseClubhouse = new Location(this, LocationId.LowerNorfairMickeyMouse, 0x8F8F30, LocationType.Visible,
-                    name: "Missile (Mickey Mouse room)",
-                    vanillaItem: ItemType.Missile,
-                    access: items => items.Morph && items.Super && (
-                                Logic.CanWallJump(WallJumpDifficulty.Insane) ||
-                                (items.HiJump && Logic.CanWallJump(WallJumpDifficulty.Hard)) ||
-                                Logic.CanFly(items)
-                            ) &&
-                            /*Exit to Upper Norfair*/
-                            (((items.CardLowerNorfairL1 || items.Gravity /*Vanilla or Reverse Lava Dive*/) && items.CardNorfairL2) /*Bubble Mountain*/ ||
-                            (items.Gravity && items.Wave /* Volcano Room and Blue Gate */ && (items.Grapple || items.SpaceJump)) /*Spikey Acid Snakes and Croc Escape*/ ||
-                            /*Exit via GT fight and Portal*/
-                            (Logic.CanUsePowerBombs(items) && items.SpaceJump && (items.Super || items.Charge))),
-                    memoryAddress: 0x9,
-                    memoryFlag: 0x2,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.LowerNorfairMickeyMouse, 0x8F8F30, LocationType.Visible,
+                        name: "Missile (Mickey Mouse room)",
+                        vanillaItem: ItemType.Missile,
+                        access: items => items.Morph && items.Super && (
+                                    Logic.CanWallJump(WallJumpDifficulty.Insane) ||
+                                    (items.HiJump && Logic.CanWallJump(WallJumpDifficulty.Hard)) ||
+                                    Logic.CanFly(items)
+                                ) &&
+                                /*Exit to Upper Norfair*/
+                                (((items.CardLowerNorfairL1 || items.Gravity /*Vanilla or Reverse Lava Dive*/) && items.CardNorfairL2) /*Bubble Mountain*/ ||
+                                (items.Gravity && items.Wave /* Volcano Room and Blue Gate */ && (items.Grapple || items.SpaceJump)) /*Spikey Acid Snakes and Croc Escape*/ ||
+                                /*Exit via GT fight and Portal*/
+                                (Logic.CanUsePowerBombs(items) && items.SpaceJump && (items.Super || items.Charge))),
+                        memoryAddress: 0x9,
+                        memoryFlag: 0x2,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location MickeyMouseClubhouse { get; }
         }
 
         public class ScrewAttackRoom : Room
@@ -104,16 +105,17 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
             public ScrewAttackRoom(LowerNorfairWest region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Screw Attack Room", metadata)
             {
-                ScrewAttack = new Location(this, LocationId.LowerNorfairScrewAttack, 0x8F9110, LocationType.Chozo,
-                    name: "Screw Attack",
-                    access: items => (Logic.CanDestroyBombWalls(items) || items.ScrewAttack) && (items.SpaceJump && Logic.CanUsePowerBombs(items) || Logic.CanAccessNorfairLowerPortal(items)),
-                    memoryAddress: 0x9,
-                    memoryFlag: 0x80,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.LowerNorfairScrewAttack, 0x8F9110, LocationType.Chozo,
+                        name: "Screw Attack",
+                        access: items => (Logic.CanDestroyBombWalls(items) || items.ScrewAttack) && (items.SpaceJump && Logic.CanUsePowerBombs(items) || Logic.CanAccessNorfairLowerPortal(items)),
+                        memoryAddress: 0x9,
+                        memoryFlag: 0x80,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location ScrewAttack { get; }
         }
     }
 }

--- a/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Norfair/UpperNorfairCrocomire.cs
+++ b/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Norfair/UpperNorfairCrocomire.cs
@@ -3,6 +3,7 @@ using Randomizer.Shared;
 using Randomizer.Data.Options;
 using Randomizer.Data.Services;
 using Randomizer.Shared.Models;
+using System.Collections.Generic;
 
 namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
 {
@@ -67,17 +68,18 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
             public CrocomiresRoom(UpperNorfairCrocomire region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Crocomire's Room", metadata)
             {
-                Crocomire = new Location(this, LocationId.UpperNorfairCrocomire, 0x8F8BA4, LocationType.Visible,
-                    name: "Energy Tank, Crocomire",
-                    vanillaItem: ItemType.ETank,
-                    access: items => region.CanAccessCrocomire(items) && ((Logic.HasEnergyReserves(items, 1) && Logic.CanWallJump(WallJumpDifficulty.Easy)) || items.SpaceJump || items.Grapple),
-                    memoryAddress: 0x6,
-                    memoryFlag: 0x10,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.UpperNorfairCrocomire, 0x8F8BA4, LocationType.Visible,
+                        name: "Energy Tank, Crocomire",
+                        vanillaItem: ItemType.ETank,
+                        access: items => region.CanAccessCrocomire(items) && ((Logic.HasEnergyReserves(items, 1) && Logic.CanWallJump(WallJumpDifficulty.Easy)) || items.SpaceJump || items.Grapple),
+                        memoryAddress: 0x6,
+                        memoryFlag: 0x10,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location Crocomire { get; }
         }
 
         public class CrocomireEscapeRoom : Room
@@ -85,17 +87,18 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
             public CrocomireEscapeRoom(UpperNorfairCrocomire region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Crocomire Escape", metadata)
             {
-                CrocomireEscape = new Location(this, LocationId.UpperNorfairCrocomireEscape, 0x8F8BC0, LocationType.Visible,
-                    name: "Missile (above Crocomire)",
-                    vanillaItem: ItemType.Missile,
-                    access: items => Logic.CanFly(items) || items.Grapple || (items.HiJump && items.SpeedBooster && Logic.CanWallJump(WallJumpDifficulty.Hard)),
-                    memoryAddress: 0x6,
-                    memoryFlag: 0x40,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.UpperNorfairCrocomireEscape, 0x8F8BC0, LocationType.Visible,
+                        name: "Missile (above Crocomire)",
+                        vanillaItem: ItemType.Missile,
+                        access: items => Logic.CanFly(items) || items.Grapple || (items.HiJump && items.SpeedBooster && Logic.CanWallJump(WallJumpDifficulty.Hard)),
+                        memoryAddress: 0x6,
+                        memoryFlag: 0x40,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location CrocomireEscape { get; }
         }
 
         public class PostCrocomirePowerBombRoom : Room
@@ -103,17 +106,18 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
             public PostCrocomirePowerBombRoom(UpperNorfairCrocomire region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Post Crocomire Power Bomb Room", metadata)
             {
-                PostCrocPowerBombRoom = new Location(this, LocationId.UpperNorfairPostCrocomirePowerBomb, 0x8F8C04, LocationType.Visible,
-                    name: "Power Bomb (Crocomire)",
-                    vanillaItem: ItemType.PowerBomb,
-                    access: items => region.CanAccessCrocomire(items) && (Logic.CanFly(items) || items.HiJump || items.Grapple),
-                    memoryAddress: 0x7,
-                    memoryFlag: 0x2,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.UpperNorfairPostCrocomirePowerBomb, 0x8F8C04, LocationType.Visible,
+                        name: "Power Bomb (Crocomire)",
+                        vanillaItem: ItemType.PowerBomb,
+                        access: items => region.CanAccessCrocomire(items) && (Logic.CanFly(items) || items.HiJump || items.Grapple),
+                        memoryAddress: 0x7,
+                        memoryFlag: 0x2,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location PostCrocPowerBombRoom { get; }
         }
 
         public class PostCrocomireMissileRoom : Room
@@ -121,21 +125,22 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
             public PostCrocomireMissileRoom(UpperNorfairCrocomire region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Post Crocomire Missile Room", metadata, "Cosine Room")
             {
-                CosineRoom = new Location(this, LocationId.UpperNorfairPostCrocomireMissile, 0x8F8C14, LocationType.Visible,
-                    name: "Missile (below Crocomire)",
-                    vanillaItem: ItemType.Missile,
-                    access: items =>
-                        // Can access item
-                        region.CanAccessCrocomire(items) && items.Morph &&
-                        // Can return
-                        (Logic.CanFly(items) || Logic.CanWallJump(WallJumpDifficulty.Medium) || (items.SpeedBooster && Logic.CanUsePowerBombs(items) && items.HiJump && items.Grapple)),
-                    memoryAddress: 0x7,
-                    memoryFlag: 0x4,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.UpperNorfairPostCrocomireMissile, 0x8F8C14, LocationType.Visible,
+                        name: "Missile (below Crocomire)",
+                        vanillaItem: ItemType.Missile,
+                        access: items =>
+                            // Can access item
+                            region.CanAccessCrocomire(items) && items.Morph &&
+                            // Can return
+                            (Logic.CanFly(items) || Logic.CanWallJump(WallJumpDifficulty.Medium) || (items.SpeedBooster && Logic.CanUsePowerBombs(items) && items.HiJump && items.Grapple)),
+                        memoryAddress: 0x7,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location CosineRoom { get; }
         }
 
         public class PostCrocomireJumpRoom : Room
@@ -143,21 +148,22 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
             public PostCrocomireJumpRoom(UpperNorfairCrocomire region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Post Crocomire Jump Room", metadata, "Indiana Jones Room", "Pantry")
             {
-                IndianaJonesRoom = new Location(this, LocationId.UpperNorfairPostCrocomireJump, 0x8F8C2A, LocationType.Visible,
-                    name: "Missile (Grappling Beam)",
-                    vanillaItem: ItemType.Missile,
-                    access: items =>
-                        // Can access item
-                        region.CanAccessCrocomire(items) && items.Morph && (Logic.CanFly(items) || (items.SpeedBooster && Logic.CanUsePowerBombs(items))) &&
-                        // Can return
-                        (Logic.CanFly(items) || Logic.CanWallJump(WallJumpDifficulty.Medium) || (items.HiJump && items.Grapple)),
-                    memoryAddress: 0x7,
-                    memoryFlag: 0x8,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.UpperNorfairPostCrocomireJump, 0x8F8C2A, LocationType.Visible,
+                        name: "Missile (Grappling Beam)",
+                        vanillaItem: ItemType.Missile,
+                        access: items =>
+                            // Can access item
+                            region.CanAccessCrocomire(items) && items.Morph && (Logic.CanFly(items) || (items.SpeedBooster && Logic.CanUsePowerBombs(items))) &&
+                            // Can return
+                            (Logic.CanFly(items) || Logic.CanWallJump(WallJumpDifficulty.Medium) || (items.HiJump && items.Grapple)),
+                        memoryAddress: 0x7,
+                        memoryFlag: 0x8,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location IndianaJonesRoom { get; }
         }
 
         public class GrappleBeamRoom : Room
@@ -165,21 +171,22 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
             public GrappleBeamRoom(UpperNorfairCrocomire region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Grapple Beam Room", metadata)
             {
-                GrappleBeam = new Location(this, LocationId.UpperNorfairGrappleBeam, 0x8F8C36, LocationType.Chozo,
-                    name: "Grappling Beam",
-                    vanillaItem: ItemType.Grapple,
-                    access: items =>
-                        // Can access item
-                        region.CanAccessCrocomire(items) && items.Morph && (Logic.CanFly(items) || (items.SpeedBooster && Logic.CanUsePowerBombs(items))) &&
-                        // Can return
-                        (Logic.CanFly(items) || Logic.CanWallJump(WallJumpDifficulty.Medium) || (items.HiJump && items.Grapple)),
-                    memoryAddress: 0x7,
-                    memoryFlag: 0x10,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.UpperNorfairGrappleBeam, 0x8F8C36, LocationType.Chozo,
+                        name: "Grappling Beam",
+                        vanillaItem: ItemType.Grapple,
+                        access: items =>
+                            // Can access item
+                            region.CanAccessCrocomire(items) && items.Morph && (Logic.CanFly(items) || (items.SpeedBooster && Logic.CanUsePowerBombs(items))) &&
+                            // Can return
+                            (Logic.CanFly(items) || Logic.CanWallJump(WallJumpDifficulty.Medium) || (items.HiJump && items.Grapple)),
+                        memoryAddress: 0x7,
+                        memoryFlag: 0x10,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location GrappleBeam { get; }
         }
     }
 }

--- a/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Norfair/UpperNorfairEast.cs
+++ b/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Norfair/UpperNorfairEast.cs
@@ -3,6 +3,7 @@ using Randomizer.Shared;
 using Randomizer.Data.Options;
 using Randomizer.Data.Services;
 using Randomizer.Shared.Models;
+using System.Collections.Generic;
 
 namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
 {
@@ -75,28 +76,26 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
             public BubbleMountainHiddenHallRoom(UpperNorfairEast region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Bubble Mountain Hidden Hall", metadata, "Norfair Reserve Tank")
             {
-                MainItem = new Location(this, LocationId.UpperNorfairReserveTankChozo, 0x8F8C3E, LocationType.Chozo,
-                    name: "Main Item",
-                    vanillaItem: ItemType.ReserveTank,
-                    access: items => items.CardNorfairL2 && items.Morph && region.CanReachBubbleMountainLeftSide(items),
-                    memoryAddress: 0x7,
-                    memoryFlag: 0x20,
-                    metadata: metadata,
-                    trackerState: trackerState);
-
-                HiddenItem = new Location(this, LocationId.UpperNorfairReserveTankHidden, 0x8F8C44, LocationType.Hidden,
-                    name: "Hidden Item",
-                    vanillaItem: ItemType.Missile,
-                    access: items => items.CardNorfairL2 && items.Morph && region.CanReachBubbleMountainLeftSide(items),
-                    memoryAddress: 0x7,
-                    memoryFlag: 0x40,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.UpperNorfairReserveTankChozo, 0x8F8C3E, LocationType.Chozo,
+                        name: "Main Item",
+                        vanillaItem: ItemType.ReserveTank,
+                        access: items => items.CardNorfairL2 && items.Morph && region.CanReachBubbleMountainLeftSide(items),
+                        memoryAddress: 0x7,
+                        memoryFlag: 0x20,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.UpperNorfairReserveTankHidden, 0x8F8C44, LocationType.Hidden,
+                        name: "Hidden Item",
+                        vanillaItem: ItemType.Missile,
+                        access: items => items.CardNorfairL2 && items.Morph && region.CanReachBubbleMountainLeftSide(items),
+                        memoryAddress: 0x7,
+                        memoryFlag: 0x40,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location MainItem { get; }
-
-            public Location HiddenItem { get; }
         }
 
         public class GreenBubblesMissileRoom : Room
@@ -104,17 +103,18 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
             public GreenBubblesMissileRoom(UpperNorfairEast region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Green Bubbles Missile Room", metadata)
             {
-                BubbleMountainMissileRoom = new Location(this, LocationId.UpperNorfairGreenBubblesMissile, 0x8F8C52, LocationType.Visible,
-                    name: "Missile (bubble Norfair green door)",
-                    vanillaItem: ItemType.Missile,
-                    access: items => items.CardNorfairL2 && region.CanReachBubbleMountainLeftSide(items),
-                    memoryAddress: 0x7,
-                    memoryFlag: 0x80,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.UpperNorfairGreenBubblesMissile, 0x8F8C52, LocationType.Visible,
+                        name: "Missile (bubble Norfair green door)",
+                        vanillaItem: ItemType.Missile,
+                        access: items => items.CardNorfairL2 && region.CanReachBubbleMountainLeftSide(items),
+                        memoryAddress: 0x7,
+                        memoryFlag: 0x80,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location BubbleMountainMissileRoom { get; }
         }
 
         public class BubbleMountainRoom : Room
@@ -122,17 +122,18 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
             public BubbleMountainRoom(UpperNorfairEast region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Bubbles Mountain", metadata)
             {
-                BubbleMountain = new Location(this, LocationId.UpperNorfairBubbleMountain, 0x8F8C66, LocationType.Visible,
-                    name: "Missile (bubble Norfair)",
-                    vanillaItem: ItemType.Missile,
-                    access: items => items.CardNorfairL2,
-                    memoryAddress: 0x8,
-                    memoryFlag: 0x1,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.UpperNorfairBubbleMountain, 0x8F8C66, LocationType.Visible,
+                        name: "Missile (bubble Norfair)",
+                        vanillaItem: ItemType.Missile,
+                        access: items => items.CardNorfairL2,
+                        memoryAddress: 0x8,
+                        memoryFlag: 0x1,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location BubbleMountain { get; }
         }
 
         public class SpeedBoosterHallRoom : Room
@@ -140,18 +141,19 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
             public SpeedBoosterHallRoom(UpperNorfairEast region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Speed Booster Hall", metadata)
             {
-                SpeedBoosterHallCeiling = new Location(this, LocationId.UpperNorfairSpeedBoosterHall, 0x8F8C74, LocationType.Hidden,
-                    name: "Missile (Speed Booster)",
-                    vanillaItem: ItemType.Missile,
-                    access: items => items.CardNorfairL2 && region.CanReachBubbleMountainRightSide(items)
-                                     && (Logic.CanWallJump(WallJumpDifficulty.Easy) || items.HiJump),
-                    memoryAddress: 0x8,
-                    memoryFlag: 0x2,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.UpperNorfairSpeedBoosterHall, 0x8F8C74, LocationType.Hidden,
+                        name: "Missile (Speed Booster)",
+                        vanillaItem: ItemType.Missile,
+                        access: items => items.CardNorfairL2 && region.CanReachBubbleMountainRightSide(items)
+                                         && (Logic.CanWallJump(WallJumpDifficulty.Easy) || items.HiJump),
+                        memoryAddress: 0x8,
+                        memoryFlag: 0x2,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location SpeedBoosterHallCeiling { get; }
         }
 
         public class SpeedBoosterRoom : Room
@@ -159,18 +161,19 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
             public SpeedBoosterRoom(UpperNorfairEast region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Speed Booster Room", metadata)
             {
-                SpeedBooster = new Location(this, LocationId.UpperNorfairSpeedBooster, 0x8F8C82, LocationType.Chozo,
-                    name: "Speed Booster",
-                    vanillaItem: ItemType.SpeedBooster,
-                    access: items => items.CardNorfairL2 && region.CanReachBubbleMountainRightSide(items)
-                                     && (Logic.CanWallJump(WallJumpDifficulty.Easy) || items.HiJump),
-                    memoryAddress: 0x8,
-                    memoryFlag: 0x4,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.UpperNorfairSpeedBooster, 0x8F8C82, LocationType.Chozo,
+                        name: "Speed Booster",
+                        vanillaItem: ItemType.SpeedBooster,
+                        access: items => items.CardNorfairL2 && region.CanReachBubbleMountainRightSide(items)
+                                         && (Logic.CanWallJump(WallJumpDifficulty.Easy) || items.HiJump),
+                        memoryAddress: 0x8,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location SpeedBooster { get; }
         }
 
         public class DoubleChamberRoom : Room
@@ -178,18 +181,19 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
             public DoubleChamberRoom(UpperNorfairEast region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Double Chamber Room", metadata)
             {
-                DoubleChamber = new Location(this, LocationId.UpperNorfairDoubleChamber, 0x8F8CBC, LocationType.Visible,
-                    name: "Missile (Wave Beam)",
-                    vanillaItem: ItemType.Missile,
-                    access: items => (items.CardNorfairL2 && region.CanReachBubbleMountainRightSide(items)) ||
-                        (items.SpeedBooster && items.Wave && items.Morph && items.Super),
-                    memoryAddress: 0x8,
-                    memoryFlag: 0x8,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.UpperNorfairDoubleChamber, 0x8F8CBC, LocationType.Visible,
+                        name: "Missile (Wave Beam)",
+                        vanillaItem: ItemType.Missile,
+                        access: items => (items.CardNorfairL2 && region.CanReachBubbleMountainRightSide(items)) ||
+                            (items.SpeedBooster && items.Wave && items.Morph && items.Super),
+                        memoryAddress: 0x8,
+                        memoryFlag: 0x8,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location DoubleChamber { get; }
         }
 
         public class WaveBeamRoom : Room
@@ -197,20 +201,21 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
             public WaveBeamRoom(UpperNorfairEast region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Wave Beam Room", metadata)
             {
-                WaveBeam = new Location(this, LocationId.UpperNorfairWaveBeam, 0x8F8CCA, LocationType.Chozo,
-                    name: "Wave Beam",
-                    vanillaItem: ItemType.Wave,
-                    access: items => items.Morph && (
-                            (items.CardNorfairL2 && region.CanReachBubbleMountainRightSide(items)) ||
-                            (items.SpeedBooster && items.Wave && items.Morph && items.Super)
-                        ),
-                    memoryAddress: 0x8,
-                    memoryFlag: 0x10,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.UpperNorfairWaveBeam, 0x8F8CCA, LocationType.Chozo,
+                        name: "Wave Beam",
+                        vanillaItem: ItemType.Wave,
+                        access: items => items.Morph && (
+                                (items.CardNorfairL2 && region.CanReachBubbleMountainRightSide(items)) ||
+                                (items.SpeedBooster && items.Wave && items.Morph && items.Super)
+                            ),
+                        memoryAddress: 0x8,
+                        memoryFlag: 0x10,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location WaveBeam { get; }
         }
     }
 }

--- a/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Norfair/UpperNorfairWest.cs
+++ b/src/Randomizer.Data/WorldData/Regions/SuperMetroid/Norfair/UpperNorfairWest.cs
@@ -3,6 +3,7 @@ using Randomizer.Shared;
 using Randomizer.Data.Options;
 using Randomizer.Data.Services;
 using Randomizer.Shared.Models;
+using System.Collections.Generic;
 
 namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
 {
@@ -43,20 +44,21 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
             public CathedralRoom(UpperNorfairWest region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Cathedral", metadata, "Lava Room")
             {
-                LavaRoom = new Location(this, LocationId.UpperNorfairCathedral, 0x8F8AE4, LocationType.Hidden,
-                    name: "Missile (lava room)",
-                    vanillaItem: ItemType.Missile,
-                    access: items => items.Varia && (
-                                (Logic.CanOpenRedDoors(items) && (Logic.CanFly(items) || items.HiJump || items.SpeedBooster)) ||
-                                (World.UpperNorfairEast.CanEnter(items, true) && items.CardNorfairL2)
-                            ) && items.Morph,
-                    memoryAddress: 0x6,
-                    memoryFlag: 0x2,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.UpperNorfairCathedral, 0x8F8AE4, LocationType.Hidden,
+                        name: "Missile (lava room)",
+                        vanillaItem: ItemType.Missile,
+                        access: items => items.Varia && (
+                                    (Logic.CanOpenRedDoors(items) && (Logic.CanFly(items) || items.HiJump || items.SpeedBooster)) ||
+                                    (World.UpperNorfairEast.CanEnter(items, true) && items.CardNorfairL2)
+                                ) && items.Morph,
+                        memoryAddress: 0x6,
+                        memoryFlag: 0x2,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location LavaRoom { get; }
         }
 
         public class IceBeamRoom : Room
@@ -64,18 +66,19 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
             public IceBeamRoom(UpperNorfairWest region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Ice Beam Room", metadata)
             {
-                IceBeam = new Location(this, LocationId.UpperNorfairIceBeam, 0x8F8B24, LocationType.Chozo,
-                    name: "Ice Beam",
-                    vanillaItem: ItemType.Ice,
-                    access: items => (Config.MetroidKeysanity ? items.CardNorfairL1 : items.Super)
-                                     && Logic.CanPassBombPassages(items) && items.Varia && Logic.CanMoveAtHighSpeeds(items),
-                    memoryAddress: 0x6,
-                    memoryFlag: 0x4,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.UpperNorfairIceBeam, 0x8F8B24, LocationType.Chozo,
+                        name: "Ice Beam",
+                        vanillaItem: ItemType.Ice,
+                        access: items => (Config.MetroidKeysanity ? items.CardNorfairL1 : items.Super)
+                                         && Logic.CanPassBombPassages(items) && items.Varia && Logic.CanMoveAtHighSpeeds(items),
+                        memoryAddress: 0x6,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location IceBeam { get; }
         }
 
         public class CrumbleShaftRoom : Room
@@ -83,19 +86,20 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
             public CrumbleShaftRoom(UpperNorfairWest region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Crumble Shaft Room", metadata)
             {
-                CrumbleShaft = new Location(this, LocationId.UpperNorfairCrumbleShaft, 0x8F8B46, LocationType.Hidden,
-                    name: "Missile (below Ice Beam)",
-                    vanillaItem: ItemType.Missile,
-                    access: items => (Config.MetroidKeysanity ? items.CardNorfairL1 : items.Super)
-                                     && Logic.CanUsePowerBombs(items) && items.Varia && Logic.CanMoveAtHighSpeeds(items)
-                                     && (Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items)),
-                    memoryAddress: 0x6,
-                    memoryFlag: 0x8,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.UpperNorfairCrumbleShaft, 0x8F8B46, LocationType.Hidden,
+                        name: "Missile (below Ice Beam)",
+                        vanillaItem: ItemType.Missile,
+                        access: items => (Config.MetroidKeysanity ? items.CardNorfairL1 : items.Super)
+                                         && Logic.CanUsePowerBombs(items) && items.Varia && Logic.CanMoveAtHighSpeeds(items)
+                                         && (Logic.CanWallJump(WallJumpDifficulty.Easy) || Logic.CanFly(items)),
+                        memoryAddress: 0x6,
+                        memoryFlag: 0x8,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location CrumbleShaft { get; }
         }
 
         public class HiJumpBootsRoom : Room
@@ -103,17 +107,18 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
             public HiJumpBootsRoom(UpperNorfairWest region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Hi-Jump Boots Room", metadata)
             {
-                HiJumpBoots = new Location(this, LocationId.UpperNorfairHiJumpBoots, 0x8F8BAC, LocationType.Chozo,
-                    name: "Hi-Jump Boots",
-                    vanillaItem: ItemType.HiJump,
-                    access: items => Logic.CanOpenRedDoors(items) && Logic.CanPassBombPassages(items),
-                    memoryAddress: 0x6,
-                    memoryFlag: 0x20,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.UpperNorfairHiJumpBoots, 0x8F8BAC, LocationType.Chozo,
+                        name: "Hi-Jump Boots",
+                        vanillaItem: ItemType.HiJump,
+                        access: items => Logic.CanOpenRedDoors(items) && Logic.CanPassBombPassages(items),
+                        memoryAddress: 0x6,
+                        memoryFlag: 0x20,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location HiJumpBoots { get; }
         }
 
         public class HiJumpEnergyTankRoom : Room
@@ -121,27 +126,26 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid.Norfair
             public HiJumpEnergyTankRoom(UpperNorfairWest region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Hi-Jump Energy Tank Room", metadata, "Hi-Jump Lobby")
             {
-                HiJumpLobbyBack = new Location(this, LocationId.UpperNorfairHiJumpEnergyTankLeft, 0x8F8BE6, LocationType.Visible,
-                    name: "Missile (Hi-Jump Boots)",
-                    vanillaItem: ItemType.Missile,
-                    access: items => Logic.CanOpenRedDoors(items) && items.Morph,
-                    memoryAddress: 0x6,
-                    memoryFlag: 0x80,
-                    metadata: metadata,
-                    trackerState: trackerState);
-                HiJumpLobbyEntrance = new Location(this, LocationId.UpperNorfairHiJumpEnergyTankRight, 0x8F8BEC, LocationType.Visible,
-                    name: "Energy Tank (Hi-Jump Boots)",
-                    vanillaItem: ItemType.ETank,
-                    access: items => Logic.CanOpenRedDoors(items),
-                    memoryAddress: 0x7,
-                    memoryFlag: 0x1,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.UpperNorfairHiJumpEnergyTankLeft, 0x8F8BE6, LocationType.Visible,
+                        name: "Missile (Hi-Jump Boots)",
+                        vanillaItem: ItemType.Missile,
+                        access: items => Logic.CanOpenRedDoors(items) && items.Morph,
+                        memoryAddress: 0x6,
+                        memoryFlag: 0x80,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.UpperNorfairHiJumpEnergyTankRight, 0x8F8BEC, LocationType.Visible,
+                        name: "Energy Tank (Hi-Jump Boots)",
+                        vanillaItem: ItemType.ETank,
+                        access: items => Logic.CanOpenRedDoors(items),
+                        memoryAddress: 0x7,
+                        memoryFlag: 0x1,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location HiJumpLobbyBack { get; }
-
-            public Location HiJumpLobbyEntrance { get; }
         }
     }
 }

--- a/src/Randomizer.Data/WorldData/Regions/SuperMetroid/WreckedShip.cs
+++ b/src/Randomizer.Data/WorldData/Regions/SuperMetroid/WreckedShip.cs
@@ -3,6 +3,7 @@ using Randomizer.Shared;
 using Randomizer.Data.Options;
 using Randomizer.Data.Services;
 using Randomizer.Shared.Models;
+using System.Collections.Generic;
 
 namespace Randomizer.Data.WorldData.Regions.SuperMetroid
 {
@@ -56,7 +57,7 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid
                         /* From Maridia portal -> Forgotten Highway */
                         (Logic.CanAccessMaridiaPortal(items, requireRewards) && CanPassReverseForgottenHighway(items) && (
                             (Logic.CanDestroyBombWalls(items) && items.CardMaridiaL2) ||
-                            World.InnerMaridia.SpaceJump.DraygonTreasure.IsAvailable(items)
+                            World.FindLocation(LocationId.InnerMaridiaSpaceJump).IsAvailable(items)
                         ))
                     );
         }
@@ -93,17 +94,18 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid
             public MainShaftRoom(WreckedShip region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Wrecked Ship Main Shaft", metadata)
             {
-                MainShaftSideRoom = new Location(this, LocationId.WreckedShipMainShaft, 0x8FC265, LocationType.Visible,
-                    name: "Missile (Wrecked Ship middle)",
-                    vanillaItem: ItemType.Missile,
-                    access: items => Logic.CanPassBombPassages(items),
-                    memoryAddress: 0x10,
-                    memoryFlag: 0x1,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.WreckedShipMainShaft, 0x8FC265, LocationType.Visible,
+                        name: "Missile (Wrecked Ship middle)",
+                        vanillaItem: ItemType.Missile,
+                        access: items => Logic.CanPassBombPassages(items),
+                        memoryAddress: 0x10,
+                        memoryFlag: 0x1,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location MainShaftSideRoom { get; }
         }
 
         public class BowlingAlleyRoom : Room
@@ -111,29 +113,28 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid
             public BowlingAlleyRoom(WreckedShip region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Bowling Alley", metadata, "Post Chozo Concert")
             {
-                PostChozoConcertSpeedBoosterItem = new Location(this, LocationId.WreckedShipBowlingAlleyTop, 0x8FC2E9, LocationType.Chozo,
-                    name: "Reserve Tank, Wrecked Ship",
-                    vanillaItem: ItemType.ReserveTank,
-                    access: items => region.CanViewConcert(items, requireRewards: true) && items.SpeedBooster && Logic.CanUsePowerBombs(items),
-                    relevanceRequirement: items => region.CanViewConcert(items, requireRewards: false) && items.SpeedBooster && Logic.CanUsePowerBombs(items),
-                    memoryAddress: 0x10,
-                    memoryFlag: 0x2,
-                    metadata: metadata,
-                    trackerState: trackerState);
-                PostChozoConcertBreakableChozo = new Location(this, LocationId.WreckedShipBowlingAlleyBottom, 0x8FC2EF, LocationType.Visible,
-                    name: "Missile (Gravity Suit)",
-                    vanillaItem: ItemType.Missile,
-                    access: items => region.CanViewConcert(items, requireRewards: true),
-                    relevanceRequirement: items => region.CanViewConcert(items, requireRewards: false),
-                    memoryAddress: 0x10,
-                    memoryFlag: 0x4,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.WreckedShipBowlingAlleyTop, 0x8FC2E9, LocationType.Chozo,
+                        name: "Reserve Tank, Wrecked Ship",
+                        vanillaItem: ItemType.ReserveTank,
+                        access: items => region.CanViewConcert(items, requireRewards: true) && items.SpeedBooster && Logic.CanUsePowerBombs(items),
+                        relevanceRequirement: items => region.CanViewConcert(items, requireRewards: false) && items.SpeedBooster && Logic.CanUsePowerBombs(items),
+                        memoryAddress: 0x10,
+                        memoryFlag: 0x2,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.WreckedShipBowlingAlleyBottom, 0x8FC2EF, LocationType.Visible,
+                        name: "Missile (Gravity Suit)",
+                        vanillaItem: ItemType.Missile,
+                        access: items => region.CanViewConcert(items, requireRewards: true),
+                        relevanceRequirement: items => region.CanViewConcert(items, requireRewards: false),
+                        memoryAddress: 0x10,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location PostChozoConcertSpeedBoosterItem { get; }
-
-            public Location PostChozoConcertBreakableChozo { get; }
         }
 
         public class AssemblyLineRoom : Room
@@ -141,18 +142,19 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid
             public AssemblyLineRoom(WreckedShip region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Assembly Line", metadata)
             {
-                AtticAssemblyLine = new Location(this, LocationId.WreckedShipAssemblyLine, 0x8FC319, LocationType.Visible,
-                    name: "Missile (Wrecked Ship top)",
-                    vanillaItem: ItemType.Missile,
-                    access: items => region.CanAccessShutDownRooms(items, requireRewards: true),
-                    relevanceRequirement: items => region.CanAccessShutDownRooms(items, requireRewards: false),
-                    memoryAddress: 0x10,
-                    memoryFlag: 0x8,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.WreckedShipAssemblyLine, 0x8FC319, LocationType.Visible,
+                        name: "Missile (Wrecked Ship top)",
+                        vanillaItem: ItemType.Missile,
+                        access: items => region.CanAccessShutDownRooms(items, requireRewards: true),
+                        relevanceRequirement: items => region.CanAccessShutDownRooms(items, requireRewards: false),
+                        memoryAddress: 0x10,
+                        memoryFlag: 0x8,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location AtticAssemblyLine { get; }
         }
 
         public class EnergyTankRoom : Room
@@ -160,18 +162,19 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid
             public EnergyTankRoom(WreckedShip region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Wrecked Ship Energy Tank Room", metadata, "Wrecked Pool")
             {
-                WreckedPool = new Location(this, LocationId.WreckedShipEnergyTank, 0x8FC337, LocationType.Visible,
-                    name: "Energy Tank, Wrecked Ship",
-                    vanillaItem: ItemType.ETank,
-                    access: items => region.CanAccessWreckedPool(items, requireRewards: true),
-                    relevanceRequirement: items => region.CanAccessWreckedPool(items, requireRewards: false),
-                    memoryAddress: 0x10,
-                    memoryFlag: 0x10,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.WreckedShipEnergyTank, 0x8FC337, LocationType.Visible,
+                        name: "Energy Tank, Wrecked Ship",
+                        vanillaItem: ItemType.ETank,
+                        access: items => region.CanAccessWreckedPool(items, requireRewards: true),
+                        relevanceRequirement: items => region.CanAccessWreckedPool(items, requireRewards: false),
+                        memoryAddress: 0x10,
+                        memoryFlag: 0x10,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location WreckedPool { get; }
         }
 
         public class WestSuperRoom : Room
@@ -179,18 +182,19 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid
             public WestSuperRoom(WreckedShip region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Wrecked Ship West Super Room", metadata)
             {
-                LeftSuperMissileChamber = new Location(this, LocationId.WreckedShipWestSuper, 0x8FC357, LocationType.Visible,
-                    name: "Super Missile (Wrecked Ship left)",
-                    vanillaItem: ItemType.Super,
-                    access: items => region.CanAccessShutDownRooms(items, requireRewards: true),
-                    relevanceRequirement: items => region.CanAccessShutDownRooms(items, requireRewards: false),
-                    memoryAddress: 0x10,
-                    memoryFlag: 0x20,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.WreckedShipWestSuper, 0x8FC357, LocationType.Visible,
+                        name: "Super Missile (Wrecked Ship left)",
+                        vanillaItem: ItemType.Super,
+                        access: items => region.CanAccessShutDownRooms(items, requireRewards: true),
+                        relevanceRequirement: items => region.CanAccessShutDownRooms(items, requireRewards: false),
+                        memoryAddress: 0x10,
+                        memoryFlag: 0x20,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location LeftSuperMissileChamber { get; }
         }
 
         public class EastSuperRoom : Room
@@ -198,18 +202,19 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid
             public EastSuperRoom(WreckedShip region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Wrecked Ship East Super Room", metadata)
             {
-                RightSuperMissileChamber = new Location(this, LocationId.WreckedShipEastSuper, 0x8FC365, LocationType.Visible,
-                    name: "Right Super, Wrecked Ship",
-                    vanillaItem: ItemType.Super,
-                    access: items => region.CanAccessShutDownRooms(items, requireRewards: true),
-                    relevanceRequirement: items => region.CanAccessShutDownRooms(items, requireRewards: false),
-                    memoryAddress: 0x10,
-                    memoryFlag: 0x40,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.WreckedShipEastSuper, 0x8FC365, LocationType.Visible,
+                        name: "Right Super, Wrecked Ship",
+                        vanillaItem: ItemType.Super,
+                        access: items => region.CanAccessShutDownRooms(items, requireRewards: true),
+                        relevanceRequirement: items => region.CanAccessShutDownRooms(items, requireRewards: false),
+                        memoryAddress: 0x10,
+                        memoryFlag: 0x40,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location RightSuperMissileChamber { get; }
         }
 
         public class GravitySuitRoom : Room
@@ -217,18 +222,19 @@ namespace Randomizer.Data.WorldData.Regions.SuperMetroid
             public GravitySuitRoom(WreckedShip region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Gravity Suit Room", metadata)
             {
-                PostChozoConcertGravitySuitChamber = new Location(this, LocationId.WreckedShipGravitySuit, 0x8FC36D, LocationType.Chozo,
-                    name: "Gravity Suit",
-                    vanillaItem: ItemType.Gravity,
-                    access: items => region.CanViewConcert(items, requireRewards: true),
-                    relevanceRequirement: items => region.CanViewConcert(items, requireRewards: false),
-                    memoryAddress: 0x10,
-                    memoryFlag: 0x80,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.WreckedShipGravitySuit, 0x8FC36D, LocationType.Chozo,
+                        name: "Gravity Suit",
+                        vanillaItem: ItemType.Gravity,
+                        access: items => region.CanViewConcert(items, requireRewards: true),
+                        relevanceRequirement: items => region.CanViewConcert(items, requireRewards: false),
+                        memoryAddress: 0x10,
+                        memoryFlag: 0x80,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location PostChozoConcertGravitySuitChamber { get; }
         }
     }
 }

--- a/src/Randomizer.Data/WorldData/Regions/Zelda/CastleTower.cs
+++ b/src/Randomizer.Data/WorldData/Regions/Zelda/CastleTower.cs
@@ -59,15 +59,16 @@ namespace Randomizer.Data.WorldData.Regions.Zelda
             public FoyerRoom(Region region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Foyer", metadata)
             {
-                Chest = new Location(region, LocationId.CastleTowerFoyer, 0x1EAB5, LocationType.Regular,
-                    name: "Castle Tower - Foyer",
-                    memoryAddress: 0xE0,
-                    memoryFlag: 0x4,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(region, LocationId.CastleTowerFoyer, 0x1EAB5, LocationType.Regular,
+                        name: "Castle Tower - Foyer",
+                        memoryAddress: 0xE0,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location Chest { get; }
         }
 
         public class DarkMazeRoom : Room
@@ -75,16 +76,17 @@ namespace Randomizer.Data.WorldData.Regions.Zelda
             public DarkMazeRoom(Region region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Dark Maze", metadata)
             {
-                Chest = new Location(region, LocationId.CastleTowerDarkMaze, 0x1EAB2, LocationType.Regular,
-                    name: "Castle Tower - Dark Maze",
-                    access: items => items.Lamp && items.KeyCT >= 1,
-                    memoryAddress: 0xD0,
-                    memoryFlag: 0x4,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(region, LocationId.CastleTowerDarkMaze, 0x1EAB2, LocationType.Regular,
+                        name: "Castle Tower - Dark Maze",
+                        access: items => items.Lamp && items.KeyCT >= 1,
+                        memoryAddress: 0xD0,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location Chest { get; }
         }
     }
 }

--- a/src/Randomizer.Data/WorldData/Regions/Zelda/DarkWorld/DarkWorldMire.cs
+++ b/src/Randomizer.Data/WorldData/Regions/Zelda/DarkWorld/DarkWorldMire.cs
@@ -34,27 +34,26 @@ namespace Randomizer.Data.WorldData.Regions.Zelda.DarkWorld
             public MireShedRoom(Region region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Mire Shed", metadata)
             {
-                Left = new Location(this, LocationId.MireShedLeft, 0x1EA73, LocationType.Regular,
-                    name: "Mire Shed - Left",
-                    vanillaItem: ItemType.HeartPiece,
-                    access: items => items.MoonPearl,
-                    memoryAddress: 0x10D,
-                    memoryFlag: 0x4,
-                    metadata: metadata,
-                    trackerState: trackerState);
-                Right = new Location(this, LocationId.MireShedRight, 0x1EA76, LocationType.Regular,
-                    name: "Mire Shed - Right",
-                    vanillaItem: ItemType.TwentyRupees,
-                    access: items => items.MoonPearl,
-                    memoryAddress: 0x10D,
-                    memoryFlag: 0x5,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.MireShedLeft, 0x1EA73, LocationType.Regular,
+                        name: "Mire Shed - Left",
+                        vanillaItem: ItemType.HeartPiece,
+                        access: items => items.MoonPearl,
+                        memoryAddress: 0x10D,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.MireShedRight, 0x1EA76, LocationType.Regular,
+                        name: "Mire Shed - Right",
+                        vanillaItem: ItemType.TwentyRupees,
+                        access: items => items.MoonPearl,
+                        memoryAddress: 0x10D,
+                        memoryFlag: 0x5,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location Left { get; }
-
-            public Location Right { get; }
         }
     }
 }

--- a/src/Randomizer.Data/WorldData/Regions/Zelda/DarkWorld/DarkWorldNorthEast.cs
+++ b/src/Randomizer.Data/WorldData/Regions/Zelda/DarkWorld/DarkWorldNorthEast.cs
@@ -65,32 +65,30 @@ namespace Randomizer.Data.WorldData.Regions.Zelda.DarkWorld
             {
                 // Vanilla has torches instead of chests, but allows trading in
                 // Lv3 sword for Lv4 sword and bow & arrow for silvers.
-                Left = new Location(this, LocationId.PyramidFairyLeft, 0x1E980, LocationType.Regular,
-                    name: "Left",
-                    vanillaItem: ItemType.ProgressiveSword,
-                    access: items => CanAccessPyramidFairy(items, requireRewards: true),
-                    relevanceRequirement: items => CanAccessPyramidFairy(items, requireRewards: false),
-                    memoryAddress: 0x116,
-                    memoryFlag: 0x4,
-                    trackerLogic: items => region.CountReward(items, RewardType.CrystalRed) == 2,
-                    metadata: metadata,
-                    trackerState: trackerState);
-
-                Right = new Location(this, LocationId.PyramidFairyRight, 0x1E983, LocationType.Regular,
-                    name: "Right",
-                    vanillaItem: ItemType.SilverArrows,
-                    access: items => CanAccessPyramidFairy(items, requireRewards: true),
-                    relevanceRequirement: items => CanAccessPyramidFairy(items, requireRewards: false),
-                    memoryAddress: 0x116,
-                    memoryFlag: 0x5,
-                    trackerLogic: items => region.CountReward(items, RewardType.CrystalRed) == 2,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.PyramidFairyLeft, 0x1E980, LocationType.Regular,
+                        name: "Left",
+                        vanillaItem: ItemType.ProgressiveSword,
+                        access: items => CanAccessPyramidFairy(items, requireRewards: true),
+                        relevanceRequirement: items => CanAccessPyramidFairy(items, requireRewards: false),
+                        memoryAddress: 0x116,
+                        memoryFlag: 0x4,
+                        trackerLogic: items => region.CountReward(items, RewardType.CrystalRed) == 2,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.PyramidFairyRight, 0x1E983, LocationType.Regular,
+                        name: "Right",
+                        vanillaItem: ItemType.SilverArrows,
+                        access: items => CanAccessPyramidFairy(items, requireRewards: true),
+                        relevanceRequirement: items => CanAccessPyramidFairy(items, requireRewards: false),
+                        memoryAddress: 0x116,
+                        memoryFlag: 0x5,
+                        trackerLogic: items => region.CountReward(items, RewardType.CrystalRed) == 2,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location Left { get; }
-
-            public Location Right { get; }
 
             private bool CanAccessPyramidFairy(Progression items, bool requireRewards) =>
                 (items.BothRedCrystals || (!requireRewards && World.CanAquireAll(items, RewardType.CrystalRed))) &&

--- a/src/Randomizer.Data/WorldData/Regions/Zelda/DarkWorld/DarkWorldSouth.cs
+++ b/src/Randomizer.Data/WorldData/Regions/Zelda/DarkWorld/DarkWorldSouth.cs
@@ -62,57 +62,45 @@ namespace Randomizer.Data.WorldData.Regions.Zelda.DarkWorld
             public HypeCaveRoom(Region region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Hype Cave", metadata)
             {
-                Top = new Location(this, LocationId.HypeCaveTop, 0x1EB1E, LocationType.Regular,
-                    name: "Top",
-                    vanillaItem: ItemType.TwentyRupees,
-                    memoryAddress: 0x11E,
-                    memoryFlag: 0x4,
-                    metadata: metadata,
-                    trackerState: trackerState);
-
-                MiddleRight = new Location(this, LocationId.HypeCaveMiddleRight, 0x1EB21, LocationType.Regular,
-                    name: "Middle Right",
-                    vanillaItem: ItemType.TwentyRupees,
-                    memoryAddress: 0x11E,
-                    memoryFlag: 0x5,
-                    metadata: metadata,
-                    trackerState: trackerState);
-
-                MiddleLeft = new Location(this, LocationId.HypeCaveMiddleLeft, 0x1EB24, LocationType.Regular,
-                    name: "Middle Left",
-                    vanillaItem: ItemType.TwentyRupees,
-                    memoryAddress: 0x11E,
-                    memoryFlag: 0x6,
-                    metadata: metadata,
-                    trackerState: trackerState);
-
-                Bottom = new Location(this, LocationId.HypeCaveBottom, 0x1EB27, LocationType.Regular,
-                    name: "Bottom",
-                    vanillaItem: ItemType.TwentyRupees,
-                    memoryAddress: 0x11E,
-                    memoryFlag: 0x7,
-                    metadata: metadata,
-                    trackerState: trackerState);
-
-                Npc = new Location(this, LocationId.HypeCaveNpc, 0x308011, LocationType.Regular,
-                    name: "NPC",
-                    vanillaItem: ItemType.ThreeHundredRupees,
-                    memoryAddress: 0x11E,
-                    memoryFlag: 0xA,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.HypeCaveTop, 0x1EB1E, LocationType.Regular,
+                        name: "Top",
+                        vanillaItem: ItemType.TwentyRupees,
+                        memoryAddress: 0x11E,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.HypeCaveMiddleRight, 0x1EB21, LocationType.Regular,
+                        name: "Middle Right",
+                        vanillaItem: ItemType.TwentyRupees,
+                        memoryAddress: 0x11E,
+                        memoryFlag: 0x5,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.HypeCaveMiddleLeft, 0x1EB24, LocationType.Regular,
+                        name: "Middle Left",
+                        vanillaItem: ItemType.TwentyRupees,
+                        memoryAddress: 0x11E,
+                        memoryFlag: 0x6,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.HypeCaveBottom, 0x1EB27, LocationType.Regular,
+                        name: "Bottom",
+                        vanillaItem: ItemType.TwentyRupees,
+                        memoryAddress: 0x11E,
+                        memoryFlag: 0x7,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.HypeCaveNpc, 0x308011, LocationType.Regular,
+                        name: "NPC",
+                        vanillaItem: ItemType.ThreeHundredRupees,
+                        memoryAddress: 0x11E,
+                        memoryFlag: 0xA,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location Top { get; }
-
-            public Location MiddleRight { get; }
-
-            public Location MiddleLeft { get; }
-
-            public Location Bottom { get; }
-
-            public Location Npc { get; }
         }
     }
-
 }

--- a/src/Randomizer.Data/WorldData/Regions/Zelda/DarkWorld/DeathMountain/DarkWorldDeathMountainEast.cs
+++ b/src/Randomizer.Data/WorldData/Regions/Zelda/DarkWorld/DeathMountain/DarkWorldDeathMountainEast.cs
@@ -37,47 +37,42 @@ namespace Randomizer.Data.WorldData.Regions.Zelda.DarkWorld.DeathMountain
             public HookshotCaveRoom(Region region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Hookshot Cave", metadata)
             {
-                TopRight = new Location(this, LocationId.HookshotCaveTopRight, 0x1EB51, LocationType.Regular,
-                    name: "Hookshot Cave - Top Right",
-                    vanillaItem: ItemType.FiftyRupees,
-                    access: items => items.MoonPearl && items.Hookshot,
-                    memoryAddress: 0x3C,
-                    memoryFlag: 0x4,
-                    metadata: metadata,
-                    trackerState: trackerState);
-                TopLeft = new Location(this, LocationId.HookshotCaveTopLeft, 0x1EB54, LocationType.Regular,
-                    name: "Hookshot Cave - Top Left",
-                    vanillaItem: ItemType.FiftyRupees,
-                    access: items => items.MoonPearl && items.Hookshot,
-                    memoryAddress: 0x3C,
-                    memoryFlag: 0x5,
-                    metadata: metadata,
-                    trackerState: trackerState);
-                BottomLeft =new Location(this, LocationId.HookshotCaveBottomLeft, 0x1EB57, LocationType.Regular,
-                    name: "Hookshot Cave - Bottom Left",
-                    vanillaItem: ItemType.FiftyRupees,
-                    access: items => items.MoonPearl && items.Hookshot,
-                    memoryAddress: 0x3C,
-                    memoryFlag: 0x6,
-                    metadata: metadata,
-                    trackerState: trackerState);
-                BottomRight = new Location(this, LocationId.HookshotCaveBottomRight, 0x1EB5A, LocationType.Regular,
-                    name: "Hookshot Cave - Bottom Right",
-                    vanillaItem: ItemType.FiftyRupees,
-                    access: items => items.MoonPearl && (items.Hookshot || items.Boots),
-                    memoryAddress: 0x3C,
-                    memoryFlag: 0x7,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.HookshotCaveTopRight, 0x1EB51, LocationType.Regular,
+                        name: "Hookshot Cave - Top Right",
+                        vanillaItem: ItemType.FiftyRupees,
+                        access: items => items.MoonPearl && items.Hookshot,
+                        memoryAddress: 0x3C,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.HookshotCaveTopLeft, 0x1EB54, LocationType.Regular,
+                        name: "Hookshot Cave - Top Left",
+                        vanillaItem: ItemType.FiftyRupees,
+                        access: items => items.MoonPearl && items.Hookshot,
+                        memoryAddress: 0x3C,
+                        memoryFlag: 0x5,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.HookshotCaveBottomLeft, 0x1EB57, LocationType.Regular,
+                        name: "Hookshot Cave - Bottom Left",
+                        vanillaItem: ItemType.FiftyRupees,
+                        access: items => items.MoonPearl && items.Hookshot,
+                        memoryAddress: 0x3C,
+                        memoryFlag: 0x6,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.HookshotCaveBottomRight, 0x1EB5A, LocationType.Regular,
+                        name: "Hookshot Cave - Bottom Right",
+                        vanillaItem: ItemType.FiftyRupees,
+                        access: items => items.MoonPearl && (items.Hookshot || items.Boots),
+                        memoryAddress: 0x3C,
+                        memoryFlag: 0x7,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location TopRight { get; }
-
-            public Location TopLeft { get; }
-
-            public Location BottomLeft { get; }
-
-            public Location BottomRight { get; }
         }
 
         public class SuperbunnyCaveRoom : Room
@@ -85,26 +80,24 @@ namespace Randomizer.Data.WorldData.Regions.Zelda.DarkWorld.DeathMountain
             public SuperbunnyCaveRoom(Region region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Superbunny Cave", metadata)
             {
-                Top = new Location(this, LocationId.SuperbunnyCaveTop, 0x1EA7C, LocationType.Regular,
-                    name: "Superbunny Cave - Top",
-                    access: items => items.MoonPearl,
-                    memoryAddress: 0xF8,
-                    memoryFlag: 0x4,
-                    metadata: metadata,
-                    trackerState: trackerState);
-                Bottom = new Location(this, LocationId.SuperbunnyCaveBottom, 0x1EA7F, LocationType.Regular,
-                    name: "Superbunny Cave - Bottom",
-                    access: items => items.MoonPearl,
-                    memoryAddress: 0xF8,
-                    memoryFlag: 0x5,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.SuperbunnyCaveTop, 0x1EA7C, LocationType.Regular,
+                        name: "Superbunny Cave - Top",
+                        access: items => items.MoonPearl,
+                        memoryAddress: 0xF8,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.SuperbunnyCaveBottom, 0x1EA7F, LocationType.Regular,
+                        name: "Superbunny Cave - Bottom",
+                        access: items => items.MoonPearl,
+                        memoryAddress: 0xF8,
+                        memoryFlag: 0x5,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location Top { get; }
-
-            public Location Bottom { get; }
         }
     }
-
 }

--- a/src/Randomizer.Data/WorldData/Regions/Zelda/DarkWorld/DeathMountain/DarkWorldDeathMountainWest.cs
+++ b/src/Randomizer.Data/WorldData/Regions/Zelda/DarkWorld/DeathMountain/DarkWorldDeathMountainWest.cs
@@ -29,18 +29,19 @@ namespace Randomizer.Data.WorldData.Regions.Zelda.DarkWorld.DeathMountain
             public SpikeCaveRoom(Region region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Spike Cave", metadata)
             {
-                Chest = new Location(this, LocationId.SpikeCave, 0x1EA8B, LocationType.Regular,
-                    name: "Spike Cave",
-                    access: items => items.MoonPearl && items.Hammer && Logic.CanLiftLight(items) &&
-                        ((Logic.CanExtendMagic(items, 2) && items.Cape) || items.Byrna) &&
-                        World.LightWorldDeathMountainWest.CanEnter(items, true),
-                    memoryAddress: 0x117,
-                    memoryFlag: 0x4,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.SpikeCave, 0x1EA8B, LocationType.Regular,
+                        name: "Spike Cave",
+                        access: items => items.MoonPearl && items.Hammer && Logic.CanLiftLight(items) &&
+                            ((Logic.CanExtendMagic(items, 2) && items.Cape) || items.Byrna) &&
+                            World.LightWorldDeathMountainWest.CanEnter(items, true),
+                        memoryAddress: 0x117,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location Chest { get; }
         }
     }
 }

--- a/src/Randomizer.Data/WorldData/Regions/Zelda/GanonsTower.cs
+++ b/src/Randomizer.Data/WorldData/Regions/Zelda/GanonsTower.cs
@@ -43,11 +43,11 @@ namespace Randomizer.Data.WorldData.Regions.Zelda
                 name: "Firesnake Room",
                 vanillaItem: ItemType.KeyGT,
                 access: items => FiresnakeRoom != null && RandomizerRoom != null && items.Hammer && items.Hookshot && items.KeyGT >= (new[] {
-                        RandomizerRoom.TopRight,
-                        RandomizerRoom.TopLeft,
-                        RandomizerRoom.BottomLeft,
-                        RandomizerRoom.BottomRight
-                    }.Any(l => l.ItemIs(ItemType.BigKeyGT, World))
+                        LocationId.GanonsTowerRandomizerRoomTopRight,
+                        LocationId.GanonsTowerRandomizerRoomTopLeft,
+                        LocationId.GanonsTowerRandomizerRoomBottomLeft,
+                        LocationId.GanonsTowerRandomizerRoomBottomRight
+                    }.Any(l => world.FindLocation(l).ItemIs(ItemType.BigKeyGT, World))
                     || FiresnakeRoom.ItemIs(ItemType.KeyGT, World) ? 2 : 3),
                 memoryAddress: 0x7D,
                 memoryFlag: 0x4,
@@ -200,43 +200,38 @@ namespace Randomizer.Data.WorldData.Regions.Zelda
                 : base(region, "DMs Room", metadata)
             {
                 // "bombs, arrows, and Rupees" - but what?
-                TopLeft = new Location(this, LocationId.GanonsTowerDMsRoomTopLeft, 0x1EAB8, LocationType.Regular,
-                    name: "Top Left",
-                    access: items => items.Hammer && items.Hookshot,
-                    memoryAddress: 0x7B,
-                    memoryFlag: 0x4,
-                    metadata: metadata,
-                    trackerState: trackerState);
-                TopRight = new Location(this, LocationId.GanonsTowerDMsRoomTopRight, 0x1EABB, LocationType.Regular,
-                    name: "Top Right",
-                    access: items => items.Hammer && items.Hookshot,
-                    memoryAddress: 0x7B,
-                    memoryFlag: 0x5,
-                    metadata: metadata,
-                    trackerState: trackerState);
-                BottomLeft = new Location(this, LocationId.GanonsTowerDMsRoomBottomLeft, 0x1EABE, LocationType.Regular,
-                    name: "Bottom Left",
-                    access: items => items.Hammer && items.Hookshot,
-                    memoryAddress: 0x7B,
-                    memoryFlag: 0x6,
-                    metadata: metadata,
-                    trackerState: trackerState);
-                BottomRight = new Location(this, LocationId.GanonsTowerDMsRoomBottomRight, 0x1EAC1, LocationType.Regular,
-                    name: "Bottom Right",
-                    access: items => items.Hammer && items.Hookshot,
-                    memoryAddress: 0x7B,
-                    memoryFlag: 0x7,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.GanonsTowerDMsRoomTopLeft, 0x1EAB8, LocationType.Regular,
+                        name: "Top Left",
+                        access: items => items.Hammer && items.Hookshot,
+                        memoryAddress: 0x7B,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.GanonsTowerDMsRoomTopRight, 0x1EABB, LocationType.Regular,
+                        name: "Top Right",
+                        access: items => items.Hammer && items.Hookshot,
+                        memoryAddress: 0x7B,
+                        memoryFlag: 0x5,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.GanonsTowerDMsRoomBottomLeft, 0x1EABE, LocationType.Regular,
+                        name: "Bottom Left",
+                        access: items => items.Hammer && items.Hookshot,
+                        memoryAddress: 0x7B,
+                        memoryFlag: 0x6,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.GanonsTowerDMsRoomBottomRight, 0x1EAC1, LocationType.Regular,
+                        name: "Bottom Right",
+                        access: items => items.Hammer && items.Hookshot,
+                        memoryAddress: 0x7B,
+                        memoryFlag: 0x7,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location TopLeft { get; }
-
-            public Location TopRight { get; }
-
-            public Location BottomLeft { get; }
-
-            public Location BottomRight { get; }
         }
 
         public class RandomizerRoomRoom : Room
@@ -244,47 +239,42 @@ namespace Randomizer.Data.WorldData.Regions.Zelda
             public RandomizerRoomRoom(Region region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Randomizer Room", metadata) // The room with all the floor tiles
             {
-                TopLeft = new Location(this, LocationId.GanonsTowerRandomizerRoomTopLeft, 0x1EAC4, LocationType.Regular,
-                    name: "Top Left",
-                    access: items => LeftSide(items, new[] { TopRight, BottomLeft, BottomRight }),
-                    memoryAddress: 0x7C,
-                    memoryFlag: 0x4,
-                    metadata: metadata,
-                    trackerState: trackerState);
-                TopRight = new Location(this, LocationId.GanonsTowerRandomizerRoomTopRight, 0x1EAC7, LocationType.Regular,
-                    name: "Top Right",
-                    access: items => LeftSide(items, new[] { TopLeft, BottomLeft, BottomRight }),
-                    memoryAddress: 0x7C,
-                    memoryFlag: 0x5,
-                    metadata: metadata,
-                    trackerState: trackerState);
-                BottomLeft = new Location(this, LocationId.GanonsTowerRandomizerRoomBottomLeft, 0x1EACA, LocationType.Regular,
-                    name: "Bottom Left",
-                    access: items => LeftSide(items, new[] { TopRight, TopLeft, BottomRight }),
-                    memoryAddress: 0x7C,
-                    memoryFlag: 0x6,
-                    metadata: metadata,
-                    trackerState: trackerState);
-                BottomRight = new Location(this, LocationId.GanonsTowerRandomizerRoomBottomRight, 0x1EACD, LocationType.Regular,
-                    name: "Bottom Right",
-                    access: items => LeftSide(items, new[] { TopRight, TopLeft, BottomLeft }),
-                    memoryAddress: 0x7C,
-                    memoryFlag: 0x7,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.GanonsTowerRandomizerRoomTopLeft, 0x1EAC4, LocationType.Regular,
+                        name: "Top Left",
+                        access: items => LeftSide(items, LocationId.GanonsTowerRandomizerRoomTopLeft),
+                        memoryAddress: 0x7C,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.GanonsTowerRandomizerRoomTopRight, 0x1EAC7, LocationType.Regular,
+                        name: "Top Right",
+                        access: items => LeftSide(items, LocationId.GanonsTowerRandomizerRoomTopRight),
+                        memoryAddress: 0x7C,
+                        memoryFlag: 0x5,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.GanonsTowerRandomizerRoomBottomLeft, 0x1EACA, LocationType.Regular,
+                        name: "Bottom Left",
+                        access: items => LeftSide(items, LocationId.GanonsTowerRandomizerRoomBottomLeft),
+                        memoryAddress: 0x7C,
+                        memoryFlag: 0x6,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.GanonsTowerRandomizerRoomBottomRight, 0x1EACD, LocationType.Regular,
+                        name: "Bottom Right",
+                        access: items => LeftSide(items, LocationId.GanonsTowerRandomizerRoomBottomRight),
+                        memoryAddress: 0x7C,
+                        memoryFlag: 0x7,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
 
-            public Location TopLeft { get; }
-
-            public Location TopRight { get; }
-
-            public Location BottomLeft { get; }
-
-            public Location BottomRight { get; }
-
-            private bool LeftSide(Progression items, IList<Location?> locations)
+            private bool LeftSide(Progression items, LocationId except)
             {
-                return items.Hammer && items.Hookshot && items.KeyGT >= (locations.Any(l => l != null && l.ItemIs(ItemType.BigKeyGT, World)) ? 3 : 4);
+                return items.Hammer && items.Hookshot && items.KeyGT >= (Locations.Any(l => l.Id != except && l.ItemIs(ItemType.BigKeyGT, World)) ? 3 : 4);
             }
         }
 
@@ -293,26 +283,24 @@ namespace Randomizer.Data.WorldData.Regions.Zelda
             public HopeRoomRoom(Region region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Hope Room", metadata, "Right Side First Room")
             {
-                Left = new Location(this, LocationId.GanonsTowerHopeRoomLeft, 0x1EAD9, LocationType.Regular,
-                    name: "Left",
-                    vanillaItem: ItemType.TenArrows,
-                    memoryAddress: 0x8C,
-                    memoryFlag: 0x5,
-                    metadata: metadata,
-                    trackerState: trackerState);
-
-                Right = new Location(this, LocationId.GanonsTowerHopeRoomRight, 0x1EADC, LocationType.Regular,
-                    name: "Right",
-                    vanillaItem: ItemType.ThreeBombs,
-                    memoryAddress: 0x8C,
-                    memoryFlag: 0x6,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.GanonsTowerHopeRoomLeft, 0x1EAD9, LocationType.Regular,
+                        name: "Left",
+                        vanillaItem: ItemType.TenArrows,
+                        memoryAddress: 0x8C,
+                        memoryFlag: 0x5,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.GanonsTowerHopeRoomRight, 0x1EADC, LocationType.Regular,
+                        name: "Right",
+                        vanillaItem: ItemType.ThreeBombs,
+                        memoryAddress: 0x8C,
+                        memoryFlag: 0x6,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location Left { get; }
-
-            public Location Right { get; }
         }
 
         public class CompassRoomRoom : Room
@@ -320,51 +308,43 @@ namespace Randomizer.Data.WorldData.Regions.Zelda
             public CompassRoomRoom(Region region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Compass Room", metadata)
             {
-                TopLeft = new Location(this, LocationId.GanonsTowerCompassRoomTopLeft, 0x1EAE5, LocationType.Regular,
-                    name: "Top Left",
-                    vanillaItem: ItemType.CompassGT,
-                    access: items => RightSide(items, new[] { TopRight, BottomLeft, BottomRight }),
-                    memoryAddress: 0x9D,
-                    memoryFlag: 0x4,
-                    metadata: metadata,
-                    trackerState: trackerState);
-
-                TopRight = new Location(this, LocationId.GanonsTowerCompassRoomTopRight, 0x1EAE8, LocationType.Regular,
-                    name: "Top Right",
-                    access: items => RightSide(items, new[] { TopLeft, BottomLeft, BottomRight }),
-                    memoryAddress: 0x9D,
-                    memoryFlag: 0x5,
-                    metadata: metadata,
-                    trackerState: trackerState);
-
-                BottomLeft = new Location(this, LocationId.GanonsTowerCompassRoomBottomLeft, 0x1EAEB, LocationType.Regular,
-                    name: "Bottom Left",
-                    access: items => RightSide(items, new[] { TopRight, TopLeft, BottomRight }),
-                    memoryAddress: 0x9D,
-                    memoryFlag: 0x6,
-                    metadata: metadata,
-                    trackerState: trackerState);
-
-                BottomRight = new Location(this, LocationId.GanonsTowerCompassRoomBottomRight, 0x1EAEE, LocationType.Regular,
-                    name: "Bottom Right",
-                    access: items => RightSide(items, new[] { TopRight, TopLeft, BottomLeft }),
-                    memoryAddress: 0x9D,
-                    memoryFlag: 0x7,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.GanonsTowerCompassRoomTopLeft, 0x1EAE5, LocationType.Regular,
+                        name: "Top Left",
+                        vanillaItem: ItemType.CompassGT,
+                        access: items => RightSide(items, LocationId.GanonsTowerCompassRoomTopLeft),
+                        memoryAddress: 0x9D,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.GanonsTowerCompassRoomTopRight, 0x1EAE8, LocationType.Regular,
+                        name: "Top Right",
+                        access: items => RightSide(items, LocationId.GanonsTowerCompassRoomTopRight),
+                        memoryAddress: 0x9D,
+                        memoryFlag: 0x5,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.GanonsTowerCompassRoomBottomLeft, 0x1EAEB, LocationType.Regular,
+                        name: "Bottom Left",
+                        access: items => RightSide(items, LocationId.GanonsTowerCompassRoomBottomLeft),
+                        memoryAddress: 0x9D,
+                        memoryFlag: 0x6,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.GanonsTowerCompassRoomBottomRight, 0x1EAEE, LocationType.Regular,
+                        name: "Bottom Right",
+                        access: items => RightSide(items, LocationId.GanonsTowerCompassRoomBottomRight),
+                        memoryAddress: 0x9D,
+                        memoryFlag: 0x7,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
 
-            public Location TopLeft { get; }
-
-            public Location TopRight { get; }
-
-            public Location BottomLeft { get; }
-
-            public Location BottomRight { get; }
-
-            private bool RightSide(Progression items, IList<Location?> locations)
+            private bool RightSide(Progression items, LocationId except)
             {
-                return items.Somaria && items.FireRod && items.KeyGT >= (locations.Any(l => l != null && l.ItemIs(ItemType.BigKeyGT, World)) ? 3 : 4);
+                return items.Somaria && items.FireRod && items.KeyGT >= (Locations.Any(l => l.Id != except && l.ItemIs(ItemType.BigKeyGT, World)) ? 3 : 4);
             }
         }
 
@@ -373,39 +353,34 @@ namespace Randomizer.Data.WorldData.Regions.Zelda
             public BigKeyRoomRoom(Region region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Big Key Room", metadata)
             {
-                Bottom = new Location(this, LocationId.GanonsTowerBigKeyChest, 0x1EAF1, LocationType.Regular,
-                    name: "Bottom Big Key Chest",
-                    vanillaItem: ItemType.BigKeyGT,
-                    access: BigKeyRoom,
-                    memoryAddress: 0x1C,
-                    memoryFlag: 0x4,
-                    metadata: metadata,
-                    trackerState: trackerState);
-
-                Left = new Location(this, LocationId.GanonsTowerBigKeyRoomLeft, 0x1EAF4, LocationType.Regular,
-                    name: "Left",
-                    vanillaItem: ItemType.TenArrows,
-                    access: BigKeyRoom,
-                    memoryAddress: 0x1C,
-                    memoryFlag: 0x5,
-                    metadata: metadata,
-                    trackerState: trackerState);
-
-                Right = new Location(this, LocationId.GanonsTowerBigKeyRoomRight, 0x1EAF7, LocationType.Regular,
-                    name: "Right",
-                    vanillaItem: ItemType.ThreeBombs,
-                    access: BigKeyRoom,
-                    memoryAddress: 0x1C,
-                    memoryFlag: 0x6,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.GanonsTowerBigKeyChest, 0x1EAF1, LocationType.Regular,
+                        name: "Bottom Big Key Chest",
+                        vanillaItem: ItemType.BigKeyGT,
+                        access: BigKeyRoom,
+                        memoryAddress: 0x1C,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.GanonsTowerBigKeyRoomLeft, 0x1EAF4, LocationType.Regular,
+                        name: "Left",
+                        vanillaItem: ItemType.TenArrows,
+                        access: BigKeyRoom,
+                        memoryAddress: 0x1C,
+                        memoryFlag: 0x5,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.GanonsTowerBigKeyRoomRight, 0x1EAF7, LocationType.Regular,
+                        name: "Right",
+                        vanillaItem: ItemType.ThreeBombs,
+                        access: BigKeyRoom,
+                        memoryAddress: 0x1C,
+                        memoryFlag: 0x6,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location Bottom { get; }
-
-            public Location Left { get; }
-
-            public Location Right { get; }
 
             private bool BigKeyRoom(Progression items)
             {
@@ -427,30 +402,29 @@ namespace Randomizer.Data.WorldData.Regions.Zelda
                 : base(region, "Mini Helmasaur Room", metadata)
             {
                 var tower = (GanonsTower)region;
-                Left = new Location(this, LocationId.GanonsTowerMiniHelmasaurRoomLeft, 0x1EAFD, LocationType.Regular,
-                    name: "Left",
-                    vanillaItem: ItemType.ThreeBombs,
-                    access: tower.TowerAscend,
-                    memoryAddress: 0x3D,
-                    memoryFlag: 0x4,
-                    metadata: metadata,
-                    trackerState: trackerState)
-                    .Allow((item, items) => item.IsNot(ItemType.BigKeyGT, World));
 
-                Right = new Location(this, LocationId.GanonsTowerMiniHelmasaurRoomRight, 0x1EB00, LocationType.Regular,
-                    name: "Right",
-                    vanillaItem: ItemType.ThreeBombs,
-                    access: tower.TowerAscend,
-                    memoryAddress: 0x3D,
-                    memoryFlag: 0x5,
-                    metadata: metadata,
-                    trackerState: trackerState)
-                    .Allow((item, items) => item.IsNot(ItemType.BigKeyGT, World));
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.GanonsTowerMiniHelmasaurRoomLeft, 0x1EAFD, LocationType.Regular,
+                        name: "Left",
+                        vanillaItem: ItemType.ThreeBombs,
+                        access: tower.TowerAscend,
+                        memoryAddress: 0x3D,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                        .Allow((item, items) => item.IsNot(ItemType.BigKeyGT, World)),
+                    new Location(this, LocationId.GanonsTowerMiniHelmasaurRoomRight, 0x1EB00, LocationType.Regular,
+                        name: "Right",
+                        vanillaItem: ItemType.ThreeBombs,
+                        access: tower.TowerAscend,
+                        memoryAddress: 0x3D,
+                        memoryFlag: 0x5,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                        .Allow((item, items) => item.IsNot(ItemType.BigKeyGT, World))
+                };
             }
-
-            public Location Left { get; }
-
-            public Location Right { get; }
         }
     }
 }

--- a/src/Randomizer.Data/WorldData/Regions/Zelda/HyruleCastle.cs
+++ b/src/Randomizer.Data/WorldData/Regions/Zelda/HyruleCastle.cs
@@ -112,50 +112,42 @@ namespace Randomizer.Data.WorldData.Regions.Zelda
             public BackOfEscapeRoom(Region region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Sewers", metadata, "Back of Escape")
             {
-                SecretRoomLeft = new Location(this, LocationId.SewersSecretRoomLeft, 0x1EB5D, LocationType.Regular,
-                    name: "Secret Room - Left",
-                    vanillaItem: ItemType.ThreeBombs,
-                    access: items => Logic.CanLiftLight(items) || (Logic.CanPassFireRodDarkRooms(items) && items.KeyHC),
-                    memoryAddress: 0x11,
-                    memoryFlag: 0x4,
-                    metadata: metadata,
-                    trackerState: trackerState);
-
-                SecretRoomMiddle = new Location(this, LocationId.SewersSecretRoomMiddle, 0x1EB60, LocationType.Regular,
-                    name: "Secret Room - Middle",
-                    vanillaItem: ItemType.ThreeHundredRupees,
-                    access: items => Logic.CanLiftLight(items) || (Logic.CanPassFireRodDarkRooms(items) && items.KeyHC),
-                    memoryAddress: 0x11,
-                    memoryFlag: 0x5,
-                    metadata: metadata,
-                    trackerState: trackerState);
-
-                SecretRoomRight = new Location(this, LocationId.SewersSecretRoomRight, 0x1EB63, LocationType.Regular,
-                    name: "Secret Room - Right",
-                    vanillaItem: ItemType.TenArrows,
-                    access: items => Logic.CanLiftLight(items) || (Logic.CanPassFireRodDarkRooms(items) && items.KeyHC),
-                    memoryAddress: 0x11,
-                    memoryFlag: 0x6,
-                    metadata: metadata,
-                    trackerState: trackerState);
-
-                DarkCross = new Location(this, LocationId.SewersDarkCross, 0x1E96E, LocationType.Regular,
-                    name: "Dark Cross",
-                    vanillaItem: ItemType.KeyHC,
-                    access: items => Logic.CanPassFireRodDarkRooms(items),
-                    memoryAddress: 0x32,
-                    memoryFlag: 0x4,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.SewersSecretRoomLeft, 0x1EB5D, LocationType.Regular,
+                        name: "Secret Room - Left",
+                        vanillaItem: ItemType.ThreeBombs,
+                        access: items => Logic.CanLiftLight(items) || (Logic.CanPassFireRodDarkRooms(items) && items.KeyHC),
+                        memoryAddress: 0x11,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.SewersSecretRoomMiddle, 0x1EB60, LocationType.Regular,
+                        name: "Secret Room - Middle",
+                        vanillaItem: ItemType.ThreeHundredRupees,
+                        access: items => Logic.CanLiftLight(items) || (Logic.CanPassFireRodDarkRooms(items) && items.KeyHC),
+                        memoryAddress: 0x11,
+                        memoryFlag: 0x5,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.SewersSecretRoomRight, 0x1EB63, LocationType.Regular,
+                        name: "Secret Room - Right",
+                        vanillaItem: ItemType.TenArrows,
+                        access: items => Logic.CanLiftLight(items) || (Logic.CanPassFireRodDarkRooms(items) && items.KeyHC),
+                        memoryAddress: 0x11,
+                        memoryFlag: 0x6,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.SewersDarkCross, 0x1E96E, LocationType.Regular,
+                        name: "Dark Cross",
+                        vanillaItem: ItemType.KeyHC,
+                        access: items => Logic.CanPassFireRodDarkRooms(items),
+                        memoryAddress: 0x32,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location SecretRoomLeft { get; }
-
-            public Location SecretRoomMiddle { get; }
-
-            public Location SecretRoomRight { get; }
-
-            public Location DarkCross { get; }
         }
     }
 }

--- a/src/Randomizer.Data/WorldData/Regions/Zelda/LightWorld/DeathMountain/LightWorldDeathMountainEast.cs
+++ b/src/Randomizer.Data/WorldData/Regions/Zelda/LightWorld/DeathMountain/LightWorldDeathMountainEast.cs
@@ -72,77 +72,59 @@ namespace Randomizer.Data.WorldData.Regions.Zelda.LightWorld.DeathMountain
             public ParadoxCaveRoom(Region region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Paradox Cave", metadata)
             {
-                LowerLeft = new Location(this, LocationId.ParadoxCaveUpperLeft, 0x1EB39, LocationType.Regular,
-                    name: "Paradox Cave Upper - Left",
-                    vanillaItem: ItemType.ThreeBombs,
-                    memoryAddress: 0xFF,
-                    memoryFlag: 0x4,
-                    metadata: metadata,
-                    trackerState: trackerState);
-
-                LowerRight = new Location(this, LocationId.ParadoxCaveUpperRight, 0x1EB3C, LocationType.Regular,
-                    name: "Paradox Cave Upper - Right",
-                    vanillaItem: ItemType.TenArrows,
-                    memoryAddress: 0xFF,
-                    memoryFlag: 0x5,
-                    metadata: metadata,
-                    trackerState: trackerState);
-
-                UpperFarLeft = new Location(this, LocationId.ParadoxCaveLowerFarLeft, 0x1EB2A, LocationType.Regular,
-                    name: "Paradox Cave Lower - Far Left",
-                    vanillaItem: ItemType.TwentyRupees,
-                    memoryAddress: 0xEF,
-                    memoryFlag: 0x4,
-                    metadata: metadata,
-                    trackerState: trackerState);
-
-                UpperLeft = new Location(this, LocationId.ParadoxCaveLowerLeft, 0x1EB2D, LocationType.Regular,
-                    name: "Paradox Cave Lower - Left",
-                    vanillaItem: ItemType.TwentyRupees,
-                    memoryAddress: 0xEF,
-                    memoryFlag: 0x5,
-                    metadata: metadata,
-                    trackerState: trackerState);
-
-                UpperMiddle = new Location(this, LocationId.ParadoxCaveLowerMiddle, 0x1EB36, LocationType.Regular,
-                    name: "Paradox Cave Lower - Middle",
-                    vanillaItem: ItemType.TwentyRupees,
-                    memoryAddress: 0xEF,
-                    memoryFlag: 0x8,
-                    metadata: metadata,
-                    trackerState: trackerState);
-
-                UpperRight = new Location(this, LocationId.ParadoxCaveLowerRight, 0x1EB30, LocationType.Regular,
-                    name: "Paradox Cave Lower - Right",
-                    vanillaItem: ItemType.TwentyRupees,
-                    memoryAddress: 0xEF,
-                    memoryFlag: 0x6,
-                    metadata: metadata,
-                    trackerState: trackerState);
-
-                UpperFarRight = new Location(this, LocationId.ParadoxCaveLowerFarRight, 0x1EB33, LocationType.Regular,
-                    name: "Paradox Cave Lower - Far Right",
-                    vanillaItem: ItemType.TwentyRupees,
-                    memoryAddress: 0xEF,
-                    memoryFlag: 0x7,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.ParadoxCaveUpperLeft, 0x1EB39, LocationType.Regular,
+                        name: "Paradox Cave Upper - Left",
+                        vanillaItem: ItemType.ThreeBombs,
+                        memoryAddress: 0xFF,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.ParadoxCaveUpperRight, 0x1EB3C, LocationType.Regular,
+                        name: "Paradox Cave Upper - Right",
+                        vanillaItem: ItemType.TenArrows,
+                        memoryAddress: 0xFF,
+                        memoryFlag: 0x5,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.ParadoxCaveLowerFarLeft, 0x1EB2A, LocationType.Regular,
+                        name: "Paradox Cave Lower - Far Left",
+                        vanillaItem: ItemType.TwentyRupees,
+                        memoryAddress: 0xEF,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.ParadoxCaveLowerLeft, 0x1EB2D, LocationType.Regular,
+                        name: "Paradox Cave Lower - Left",
+                        vanillaItem: ItemType.TwentyRupees,
+                        memoryAddress: 0xEF,
+                        memoryFlag: 0x5,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.ParadoxCaveLowerMiddle, 0x1EB36, LocationType.Regular,
+                        name: "Paradox Cave Lower - Middle",
+                        vanillaItem: ItemType.TwentyRupees,
+                        memoryAddress: 0xEF,
+                        memoryFlag: 0x8,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.ParadoxCaveLowerRight, 0x1EB30, LocationType.Regular,
+                        name: "Paradox Cave Lower - Right",
+                        vanillaItem: ItemType.TwentyRupees,
+                        memoryAddress: 0xEF,
+                        memoryFlag: 0x6,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.ParadoxCaveLowerFarRight, 0x1EB33, LocationType.Regular,
+                        name: "Paradox Cave Lower - Far Right",
+                        vanillaItem: ItemType.TwentyRupees,
+                        memoryAddress: 0xEF,
+                        memoryFlag: 0x7,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location LowerLeft { get; }
-
-            public Location LowerRight { get; }
-
-            public Location UpperFarLeft { get; }
-
-            public Location UpperLeft { get; }
-
-            public Location UpperMiddle { get; }
-
-            public Location UpperRight { get; }
-
-            public Location UpperFarRight { get; }
         }
     }
-
 }

--- a/src/Randomizer.Data/WorldData/Regions/Zelda/LightWorld/LightWorldNorthEast.cs
+++ b/src/Randomizer.Data/WorldData/Regions/Zelda/LightWorld/LightWorldNorthEast.cs
@@ -48,53 +48,45 @@ namespace Randomizer.Data.WorldData.Regions.Zelda.LightWorld
             public SahasrahlasHideoutRoom(Region region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Sahasrahla's Hut", metadata)
             {
-                LeftChest = new Location(this, LocationId.SahasrahlasHutLeft, 0x1EA82, LocationType.Regular,
-                    name: "Left",
-                    vanillaItem: ItemType.FiftyRupees,
-                    memoryAddress: 0x105,
-                    memoryFlag: 0x4,
-                    metadata: metadata,
-                    trackerState: trackerState)
-                    .Weighted(SphereOne);
-
-                MiddleChest = new Location(this, LocationId.SahasrahlasHutMiddle, 0x1EA85, LocationType.Regular,
-                    name: "Middle",
-                    vanillaItem: ItemType.ThreeBombs,
-                    memoryAddress: 0x105,
-                    memoryFlag: 0x5,
-                    metadata: metadata,
-                    trackerState: trackerState)
-                    .Weighted(SphereOne);
-
-                RightChest = new Location(this, LocationId.SahasrahlasHutRight, 0x1EA88, LocationType.Regular,
-                    name: "Right",
-                    vanillaItem: ItemType.FiftyRupees,
-                    memoryAddress: 0x105,
-                    memoryFlag: 0x6,
-                    metadata: metadata,
-                    trackerState: trackerState)
-                    .Weighted(SphereOne);
-
-                Sahasrahla = new Location(this, LocationId.Sahasrahla, 0x5F1FC, LocationType.Regular,
-                    name: "Sahasrahla",
-                    vanillaItem: ItemType.Boots,
-                    access: items => items.GreenPendant,
-                    relevanceRequirement: items => World.CanAquire(items, RewardType.PendantGreen),
-                    memoryAddress: 0x190,
-                    memoryFlag: 0x10,
-                    memoryType: LocationMemoryType.ZeldaMisc,
-                    trackerLogic: items => region.CountReward(items, RewardType.PendantGreen) == 1,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.SahasrahlasHutLeft, 0x1EA82, LocationType.Regular,
+                        name: "Left",
+                        vanillaItem: ItemType.FiftyRupees,
+                        memoryAddress: 0x105,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                        .Weighted(SphereOne),
+                    new Location(this, LocationId.SahasrahlasHutMiddle, 0x1EA85, LocationType.Regular,
+                        name: "Middle",
+                        vanillaItem: ItemType.ThreeBombs,
+                        memoryAddress: 0x105,
+                        memoryFlag: 0x5,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                        .Weighted(SphereOne),
+                    new Location(this, LocationId.SahasrahlasHutRight, 0x1EA88, LocationType.Regular,
+                        name: "Right",
+                        vanillaItem: ItemType.FiftyRupees,
+                        memoryAddress: 0x105,
+                        memoryFlag: 0x6,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                        .Weighted(SphereOne),
+                    new Location(this, LocationId.Sahasrahla, 0x5F1FC, LocationType.Regular,
+                        name: "Sahasrahla",
+                        vanillaItem: ItemType.Boots,
+                        access: items => items.GreenPendant,
+                        relevanceRequirement: items => World.CanAquire(items, RewardType.PendantGreen),
+                        memoryAddress: 0x190,
+                        memoryFlag: 0x10,
+                        memoryType: LocationMemoryType.ZeldaMisc,
+                        trackerLogic: items => region.CountReward(items, RewardType.PendantGreen) == 1,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location LeftChest { get; }
-
-            public Location MiddleChest { get; }
-
-            public Location RightChest { get; }
-
-            public Location Sahasrahla { get; }
         }
 
         public class WaterfallFairyChamber : Room
@@ -102,25 +94,24 @@ namespace Randomizer.Data.WorldData.Regions.Zelda.LightWorld
             public WaterfallFairyChamber(Region region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Waterfall Fairy", metadata)
             {
-                Left = new Location(this, LocationId.WaterfallFairyLeft, 0x1E9B0, LocationType.Regular,
-                    name: "Left",
-                    access: items => items.Flippers || Logic.CanHyruleSouthFakeFlippers(items, true),
-                    memoryAddress: 0x114,
-                    memoryFlag: 0x4,
-                    metadata: metadata,
-                    trackerState: trackerState);
-                Right = new Location(this, LocationId.WaterfallFairyRight, 0x1E9D1, LocationType.Regular,
-                    name: "Right",
-                    access: items => items.Flippers || Logic.CanHyruleSouthFakeFlippers(items, true),
-                    memoryAddress: 0x114,
-                    memoryFlag: 0x5,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.WaterfallFairyLeft, 0x1E9B0, LocationType.Regular,
+                        name: "Left",
+                        access: items => items.Flippers || Logic.CanHyruleSouthFakeFlippers(items, true),
+                        memoryAddress: 0x114,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.WaterfallFairyRight, 0x1E9D1, LocationType.Regular,
+                        name: "Right",
+                        access: items => items.Flippers || Logic.CanHyruleSouthFakeFlippers(items, true),
+                        memoryAddress: 0x114,
+                        memoryFlag: 0x5,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location Left { get; }
-
-            public Location Right { get; }
         }
 
         public class ZorasDomainArea : Room
@@ -128,30 +119,28 @@ namespace Randomizer.Data.WorldData.Regions.Zelda.LightWorld
             public ZorasDomainArea(Region region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Zora's Domain", metadata)
             {
-                Zora = new Location(this, LocationId.KingZora, 0x1DE1C3, LocationType.Regular,
-                    name: "King Zora",
-                    vanillaItem: ItemType.Flippers,
-                    access: items => (Logic.CanLiftLight(items) || items.Flippers) && (!Config.LogicConfig.ZoraNeedsRupeeItems || items.Rupees >= 500),
-                    memoryAddress: 0x190,
-                    memoryFlag: 0x2,
-                    memoryType: LocationMemoryType.ZeldaMisc,
-                    metadata: metadata,
-                    trackerState: trackerState);
-
-                ZoraLedge = new Location(this, LocationId.ZorasLedge, 0x308149, LocationType.Regular,
-                    name: "Zora's Ledge",
-                    vanillaItem: ItemType.HeartPiece,
-                    access: items => items.Flippers,
-                    memoryAddress: 0x81,
-                    memoryFlag: 0x40,
-                    memoryType: LocationMemoryType.ZeldaMisc,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.KingZora, 0x1DE1C3, LocationType.Regular,
+                        name: "King Zora",
+                        vanillaItem: ItemType.Flippers,
+                        access: items => (Logic.CanLiftLight(items) || items.Flippers) && (!Config.LogicConfig.ZoraNeedsRupeeItems || items.Rupees >= 500),
+                        memoryAddress: 0x190,
+                        memoryFlag: 0x2,
+                        memoryType: LocationMemoryType.ZeldaMisc,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.ZorasLedge, 0x308149, LocationType.Regular,
+                        name: "Zora's Ledge",
+                        vanillaItem: ItemType.HeartPiece,
+                        access: items => items.Flippers,
+                        memoryAddress: 0x81,
+                        memoryFlag: 0x40,
+                        memoryType: LocationMemoryType.ZeldaMisc,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location Zora { get; }
-
-            public Location ZoraLedge { get; }
         }
     }
 }

--- a/src/Randomizer.Data/WorldData/Regions/Zelda/LightWorld/LightWorldNorthWest.cs
+++ b/src/Randomizer.Data/WorldData/Regions/Zelda/LightWorld/LightWorldNorthWest.cs
@@ -193,61 +193,50 @@ namespace Randomizer.Data.WorldData.Regions.Zelda.LightWorld
             public KakarikoWellArea(Region region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Kakariko Well", metadata)
             {
-                BackCave = new Location(this, LocationId.KakarikoWellTop, 0x1EA8E, LocationType.Regular,
-                    name: "Top",
-                    vanillaItem: ItemType.HeartPiece,
-                    memoryAddress: 0x2F,
-                    memoryFlag: 0x4,
-                    metadata: metadata,
-                    trackerState: trackerState)
-                    .Weighted(SphereOne);
-
-                Left = new Location(this, LocationId.KakarikoWellLeft, 0x1EA91, LocationType.Regular,
-                    name: "Left",
-                    vanillaItem: ItemType.TwentyRupees,
-                    memoryAddress: 0x2F,
-                    memoryFlag: 0x5,
-                    metadata: metadata,
-                    trackerState: trackerState)
-                    .Weighted(SphereOne);
-
-                Middle = new Location(this, LocationId.KakarikoWellMiddle, 0x1EA94, LocationType.Regular,
-                    name: "Middle",
-                    vanillaItem: ItemType.TwentyRupees,
-                    memoryAddress: 0x2F,
-                    memoryFlag: 0x6,
-                    metadata: metadata,
-                    trackerState: trackerState)
-                    .Weighted(SphereOne);
-
-                Right = new Location(this, LocationId.KakarikoWellRight, 0x1EA97, LocationType.Regular,
-                    name: "Right",
-                    vanillaItem: ItemType.TwentyRupees,
-                    memoryAddress: 0x2F,
-                    memoryFlag: 0x7,
-                    metadata: metadata,
-                    trackerState: trackerState)
-                    .Weighted(SphereOne);
-
-                Bottom = new Location(this, LocationId.KakarikoWellBottom, 0x1EA9A, LocationType.Regular,
-                    name: "Bottom",
-                    vanillaItem: ItemType.ThreeBombs,
-                    memoryAddress: 0x2F,
-                    memoryFlag: 0x8,
-                    metadata: metadata,
-                    trackerState: trackerState)
-                    .Weighted(SphereOne);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.KakarikoWellTop, 0x1EA8E, LocationType.Regular,
+                        name: "Top",
+                        vanillaItem: ItemType.HeartPiece,
+                        memoryAddress: 0x2F,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                        .Weighted(SphereOne),
+                    new Location(this, LocationId.KakarikoWellLeft, 0x1EA91, LocationType.Regular,
+                        name: "Left",
+                        vanillaItem: ItemType.TwentyRupees,
+                        memoryAddress: 0x2F,
+                        memoryFlag: 0x5,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                        .Weighted(SphereOne),
+                    new Location(this, LocationId.KakarikoWellMiddle, 0x1EA94, LocationType.Regular,
+                        name: "Middle",
+                        vanillaItem: ItemType.TwentyRupees,
+                        memoryAddress: 0x2F,
+                        memoryFlag: 0x6,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                        .Weighted(SphereOne),
+                    new Location(this, LocationId.KakarikoWellRight, 0x1EA97, LocationType.Regular,
+                        name: "Right",
+                        vanillaItem: ItemType.TwentyRupees,
+                        memoryAddress: 0x2F,
+                        memoryFlag: 0x7,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                        .Weighted(SphereOne),
+                    new Location(this, LocationId.KakarikoWellBottom, 0x1EA9A, LocationType.Regular,
+                        name: "Bottom",
+                        vanillaItem: ItemType.ThreeBombs,
+                        memoryAddress: 0x2F,
+                        memoryFlag: 0x8,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                        .Weighted(SphereOne)
+                };
             }
-
-            public Location BackCave { get; }
-
-            public Location Left { get; }
-
-            public Location Middle { get; }
-
-            public Location Right { get; }
-
-            public Location Bottom { get; }
         }
 
         public class BlindsHideoutRoom : Room
@@ -255,53 +244,45 @@ namespace Randomizer.Data.WorldData.Regions.Zelda.LightWorld
             public BlindsHideoutRoom(Region region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Blind's Hideout", metadata)
             {
-                BackRoom = new Location(this, LocationId.BlindsHideoutTop, 0x1EB0F, LocationType.Regular,
-                    name: "Top",
-                    memoryAddress: 0x11D,
-                    memoryFlag: 0x4,
-                    metadata: metadata,
-                    trackerState: trackerState)
-                    .Weighted(SphereOne);
-                FarLeft = new Location(this, LocationId.BlindsHideoutFarLeft, 0x1EB18, LocationType.Regular,
-                    name: "Far Left",
-                    memoryAddress: 0x11D,
-                    memoryFlag: 0x7,
-                    metadata: metadata,
-                    trackerState: trackerState)
-                    .Weighted(SphereOne);
-                Left = new Location(this, LocationId.BlindsHideoutLeft, 0x1EB12, LocationType.Regular,
-                    name: "Left",
-                    memoryAddress: 0x11D,
-                    memoryFlag: 0x5,
-                    metadata: metadata,
-                    trackerState: trackerState)
-                    .Weighted(SphereOne);
-                Right = new Location(this, LocationId.BlindsHideoutRight, 0x1EB15, LocationType.Regular,
-                    name: "Right",
-                    memoryAddress: 0x11D,
-                    memoryFlag: 0x6,
-                    metadata: metadata,
-                    trackerState: trackerState)
-                    .Weighted(SphereOne);
-                FarRight = new Location(this, LocationId.BlindsHideoutFarRight, 0x1EB1B, LocationType.Regular,
-                    name: "Far Right",
-                    memoryAddress: 0x11D,
-                    memoryFlag: 0x8,
-                    metadata: metadata,
-                    trackerState: trackerState)
-                    .Weighted(SphereOne);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.BlindsHideoutTop, 0x1EB0F, LocationType.Regular,
+                        name: "Top",
+                        memoryAddress: 0x11D,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                        .Weighted(SphereOne),
+                    new Location(this, LocationId.BlindsHideoutFarLeft, 0x1EB18, LocationType.Regular,
+                        name: "Far Left",
+                        memoryAddress: 0x11D,
+                        memoryFlag: 0x7,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                        .Weighted(SphereOne),
+                    new Location(this, LocationId.BlindsHideoutLeft, 0x1EB12, LocationType.Regular,
+                        name: "Left",
+                        memoryAddress: 0x11D,
+                        memoryFlag: 0x5,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                        .Weighted(SphereOne),
+                    new Location(this, LocationId.BlindsHideoutRight, 0x1EB15, LocationType.Regular,
+                        name: "Right",
+                        memoryAddress: 0x11D,
+                        memoryFlag: 0x6,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                        .Weighted(SphereOne),
+                    new Location(this, LocationId.BlindsHideoutFarRight, 0x1EB1B, LocationType.Regular,
+                        name: "Far Right",
+                        memoryAddress: 0x11D,
+                        memoryFlag: 0x8,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                        .Weighted(SphereOne)
+                };
             }
-
-            public Location BackRoom { get; }
-
-            public Location FarLeft { get; }
-
-            public Location Left { get; }
-
-            public Location Right { get; }
-
-            public Location FarRight { get; }
         }
-
     }
 }

--- a/src/Randomizer.Data/WorldData/Regions/Zelda/LightWorld/LightWorldSouth.cs
+++ b/src/Randomizer.Data/WorldData/Regions/Zelda/LightWorld/LightWorldSouth.cs
@@ -182,61 +182,50 @@ namespace Randomizer.Data.WorldData.Regions.Zelda.LightWorld
             public MiniMoldormCaveRoom(Region region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Mini Moldorm Cave", metadata)
             {
-                FarLeftChest = new Location(this, LocationId.MiniMoldormCaveFarLeft, 0x1EB42, LocationType.Regular,
-                    name: "Far Left",
-                    vanillaItem: ItemType.ThreeBombs,
-                    memoryAddress: 0x123,
-                    memoryFlag: 0x4,
-                    metadata: metadata,
-                    trackerState: trackerState)
-                    .Weighted(SphereOne);
-
-                LeftChest = new Location(this, LocationId.MiniMoldormCaveLeft, 0x1EB45, LocationType.Regular,
-                    name: "Left",
-                    vanillaItem: ItemType.TwentyRupees,
-                    memoryAddress: 0x123,
-                    memoryFlag: 0x5,
-                    metadata: metadata,
-                    trackerState: trackerState)
-                    .Weighted(SphereOne);
-
-                Npc = new Location(this, LocationId.MiniMoldormCaveNpc, 0x308010, LocationType.Regular,
-                    name: "NPC",
-                    vanillaItem: ItemType.ThreeHundredRupees,
-                    memoryAddress: 0x123,
-                    memoryFlag: 0xA,
-                    metadata: metadata,
-                    trackerState: trackerState)
-                    .Weighted(SphereOne);
-
-                RightChest = new Location(this, LocationId.MiniMoldormCaveRight, 0x1EB48, LocationType.Regular,
-                    name: "Right",
-                    vanillaItem: ItemType.TwentyRupees,
-                    memoryAddress: 0x123,
-                    memoryFlag: 0x6,
-                    metadata: metadata,
-                    trackerState: trackerState)
-                    .Weighted(SphereOne);
-
-                FarRightChest = new Location(this, LocationId.MiniMoldormCaveFarRight, 0x1EB4B, LocationType.Regular,
-                    name: "Far Right",
-                    vanillaItem: ItemType.TenArrows,
-                    memoryAddress: 0x123,
-                    memoryFlag: 0x7,
-                    metadata: metadata,
-                    trackerState: trackerState)
-                    .Weighted(SphereOne);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.MiniMoldormCaveFarLeft, 0x1EB42, LocationType.Regular,
+                        name: "Far Left",
+                        vanillaItem: ItemType.ThreeBombs,
+                        memoryAddress: 0x123,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                        .Weighted(SphereOne),
+                    new Location(this, LocationId.MiniMoldormCaveLeft, 0x1EB45, LocationType.Regular,
+                        name: "Left",
+                        vanillaItem: ItemType.TwentyRupees,
+                        memoryAddress: 0x123,
+                        memoryFlag: 0x5,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                        .Weighted(SphereOne),
+                    new Location(this, LocationId.MiniMoldormCaveNpc, 0x308010, LocationType.Regular,
+                        name: "NPC",
+                        vanillaItem: ItemType.ThreeHundredRupees,
+                        memoryAddress: 0x123,
+                        memoryFlag: 0xA,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                        .Weighted(SphereOne),
+                    new Location(this, LocationId.MiniMoldormCaveRight, 0x1EB48, LocationType.Regular,
+                        name: "Right",
+                        vanillaItem: ItemType.TwentyRupees,
+                        memoryAddress: 0x123,
+                        memoryFlag: 0x6,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                        .Weighted(SphereOne),
+                    new Location(this, LocationId.MiniMoldormCaveFarRight, 0x1EB4B, LocationType.Regular,
+                        name: "Far Right",
+                        vanillaItem: ItemType.TenArrows,
+                        memoryAddress: 0x123,
+                        memoryFlag: 0x7,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                        .Weighted(SphereOne)
+                };
             }
-
-            public Location FarLeftChest { get; }
-
-            public Location LeftChest { get; }
-
-            public Location RightChest { get; }
-
-            public Location FarRightChest { get; }
-
-            public Location Npc { get; }
         }
 
         public class SwampRuinsRoom : Room
@@ -244,31 +233,27 @@ namespace Randomizer.Data.WorldData.Regions.Zelda.LightWorld
             public SwampRuinsRoom(Region region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Swamp Ruins", metadata)
             {
-                FloodgateChest = new Location(this, LocationId.FloodgateChest, 0x1E98C, LocationType.Regular,
-                   name: "Floodgate Chest",
-                   vanillaItem: ItemType.ThreeBombs,
-                   memoryAddress: 0x10B,
-                   memoryFlag: 0x4,
-                   metadata: metadata,
-                   trackerState: trackerState)
-                   .Weighted(SphereOne);
-
-                SunkedTreasure = new Location(this, LocationId.SunkenTreasure, 0x308145, LocationType.Regular,
-                    name: "Sunken Treasure",
-                    vanillaItem: ItemType.HeartPiece,
-                    memoryAddress: 0x3B,
-                    memoryFlag: 0x40,
-                    memoryType: LocationMemoryType.ZeldaMisc,
-                    metadata: metadata,
-                    trackerState: trackerState)
-                    .Weighted(SphereOne);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.FloodgateChest, 0x1E98C, LocationType.Regular,
+                        name: "Floodgate Chest",
+                        vanillaItem: ItemType.ThreeBombs,
+                        memoryAddress: 0x10B,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                        .Weighted(SphereOne),
+                    new Location(this, LocationId.SunkenTreasure, 0x308145, LocationType.Regular,
+                        name: "Sunken Treasure",
+                        vanillaItem: ItemType.HeartPiece,
+                        memoryAddress: 0x3B,
+                        memoryFlag: 0x40,
+                        memoryType: LocationMemoryType.ZeldaMisc,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                        .Weighted(SphereOne)
+                };
             }
-
-            public Location FloodgateChest { get; }
-
-            public Location SunkedTreasure { get; }
-
         }
     }
-
 }

--- a/src/Randomizer.Data/WorldData/Regions/Zelda/PalaceOfDarkness.cs
+++ b/src/Randomizer.Data/WorldData/Regions/Zelda/PalaceOfDarkness.cs
@@ -177,28 +177,26 @@ namespace Randomizer.Data.WorldData.Regions.Zelda
             public DarkMazeRoom(Region region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Dark Maze", metadata)
             {
-                Top = new Location(this, LocationId.PalaceOfDarknessDarkMazeTop, 0x1EA55, LocationType.Regular,
-                    name: "Top",
-                    vanillaItem: ItemType.ThreeBombs,
-                    access: items => Logic.CanPassSwordOnlyDarkRooms(items) && items.KeyPD >= ((items.Hammer && items.Bow) || Config.ZeldaKeysanity ? 6 : 5),
-                    memoryAddress: 0x19,
-                    memoryFlag: 0x4,
-                    metadata: metadata,
-                    trackerState: trackerState);
-
-                Bottom = new Location(this, LocationId.PalaceOfDarknessDarkMazeBottom, 0x1EA58, LocationType.Regular,
-                    name: "Bottom",
-                    vanillaItem: ItemType.KeyPD,
-                    access: items => Logic.CanPassSwordOnlyDarkRooms(items) && items.KeyPD >= ((items.Hammer && items.Bow) || Config.ZeldaKeysanity ? 6 : 5),
-                    memoryAddress: 0x19,
-                    memoryFlag: 0x5,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.PalaceOfDarknessDarkMazeTop, 0x1EA55, LocationType.Regular,
+                        name: "Top",
+                        vanillaItem: ItemType.ThreeBombs,
+                        access: items => Logic.CanPassSwordOnlyDarkRooms(items) && items.KeyPD >= ((items.Hammer && items.Bow) || Config.ZeldaKeysanity ? 6 : 5),
+                        memoryAddress: 0x19,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.PalaceOfDarknessDarkMazeBottom, 0x1EA58, LocationType.Regular,
+                        name: "Bottom",
+                        vanillaItem: ItemType.KeyPD,
+                        access: items => Logic.CanPassSwordOnlyDarkRooms(items) && items.KeyPD >= ((items.Hammer && items.Bow) || Config.ZeldaKeysanity ? 6 : 5),
+                        memoryAddress: 0x19,
+                        memoryFlag: 0x5,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location Top { get; }
-
-            public Location Bottom { get; }
         }
 
         public class DarkBasementRoom : Room
@@ -206,28 +204,26 @@ namespace Randomizer.Data.WorldData.Regions.Zelda
             public DarkBasementRoom(Region region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Dark Basement", metadata)
             {
-                Left = new Location(this, LocationId.PalaceOfDarknessDarkBasementLeft, 0x1EA4C, LocationType.Regular,
-                    name: "Left",
-                    vanillaItem: ItemType.TenArrows,
-                    access: items => Logic.CanPassFireRodDarkRooms(items) && items.KeyPD >= ((items.Hammer && items.Bow) || Config.ZeldaKeysanity ? 4 : 3),
-                    memoryAddress: 0x6A,
-                    memoryFlag: 0x4,
-                    metadata: metadata,
-                    trackerState: trackerState);
-
-                Right = new Location(this, LocationId.PalaceOfDarknessDarkBasementRight, 0x1EA4F, LocationType.Regular,
-                    name: "Right",
-                    vanillaItem: ItemType.KeyPD,
-                    access: items => Logic.CanPassFireRodDarkRooms(items) && items.KeyPD >= ((items.Hammer && items.Bow) || Config.ZeldaKeysanity ? 4 : 3),
-                    memoryAddress: 0x6A,
-                    memoryFlag: 0x5,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.PalaceOfDarknessDarkBasementLeft, 0x1EA4C, LocationType.Regular,
+                        name: "Left",
+                        vanillaItem: ItemType.TenArrows,
+                        access: items => Logic.CanPassFireRodDarkRooms(items) && items.KeyPD >= ((items.Hammer && items.Bow) || Config.ZeldaKeysanity ? 4 : 3),
+                        memoryAddress: 0x6A,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.PalaceOfDarknessDarkBasementRight, 0x1EA4F, LocationType.Regular,
+                        name: "Right",
+                        vanillaItem: ItemType.KeyPD,
+                        access: items => Logic.CanPassFireRodDarkRooms(items) && items.KeyPD >= ((items.Hammer && items.Bow) || Config.ZeldaKeysanity ? 4 : 3),
+                        memoryAddress: 0x6A,
+                        memoryFlag: 0x5,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location Left { get; }
-
-            public Location Right { get; }
         }
     }
 }

--- a/src/Randomizer.Data/WorldData/Regions/Zelda/SwampPalace.cs
+++ b/src/Randomizer.Data/WorldData/Regions/Zelda/SwampPalace.cs
@@ -147,27 +147,26 @@ namespace Randomizer.Data.WorldData.Regions.Zelda
             public FloodedRoomRoom(Region region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Flooded Room", metadata)
             {
-                Left = new Location(this, LocationId.SwampPalaceFloodedRoomLeft, 0x1EAA9, LocationType.Regular,
-                    name: "Left",
-                    vanillaItem: ItemType.TwentyRupees,
-                    access: items => items.KeySP && items.Hammer && items.Hookshot,
-                    memoryAddress: 0x76,
-                    memoryFlag: 0x4,
-                    metadata: metadata,
-                    trackerState: trackerState);
-                Right = new Location(this, LocationId.SwampPalaceFloodedRoomRight, 0x1EAAC, LocationType.Regular,
-                    name: "Right",
-                    vanillaItem: ItemType.TwentyRupees,
-                    access: items => items.KeySP && items.Hammer && items.Hookshot,
-                    memoryAddress: 0x76,
-                    memoryFlag: 0x5,
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.SwampPalaceFloodedRoomLeft, 0x1EAA9, LocationType.Regular,
+                        name: "Left",
+                        vanillaItem: ItemType.TwentyRupees,
+                        access: items => items.KeySP && items.Hammer && items.Hookshot,
+                        memoryAddress: 0x76,
+                        memoryFlag: 0x4,
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.SwampPalaceFloodedRoomRight, 0x1EAAC, LocationType.Regular,
+                        name: "Right",
+                        vanillaItem: ItemType.TwentyRupees,
+                        access: items => items.KeySP && items.Hammer && items.Hookshot,
+                        memoryAddress: 0x76,
+                        memoryFlag: 0x5,
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location Left { get; }
-
-            public Location Right { get; }
         }
     }
 }

--- a/src/Randomizer.Data/WorldData/Regions/Zelda/TurtleRock.cs
+++ b/src/Randomizer.Data/WorldData/Regions/Zelda/TurtleRock.cs
@@ -148,29 +148,28 @@ namespace Randomizer.Data.WorldData.Regions.Zelda
             public RollerRoomRoom(Region region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Roller Room", metadata)
             {
-                Left = new Location(this, LocationId.TurtleRockRollerRoomLeft, 0x1EA1C, LocationType.Regular,
-                    name: "Left",
-                    vanillaItem: ItemType.MapTR,
-                    access: items => items.FireRod,
-                    memoryAddress: 0xB7,
-                    memoryFlag: 0x4,
-                    trackerLogic: items => items.HasMarkedMedallion(World.TurtleRock.DungeonState.MarkedMedallion),
-                    metadata: metadata,
-                    trackerState: trackerState);
-                Right = new Location(this, LocationId.TurtleRockRollerRoomRight, 0x1EA1F, LocationType.Regular,
-                    name: "Right",
-                    vanillaItem: ItemType.KeyTR,
-                    access: items => items.FireRod,
-                    memoryAddress: 0xB7,
-                    memoryFlag: 0x5,
-                    trackerLogic: items => items.HasMarkedMedallion(World.TurtleRock.DungeonState.MarkedMedallion),
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.TurtleRockRollerRoomLeft, 0x1EA1C, LocationType.Regular,
+                        name: "Left",
+                        vanillaItem: ItemType.MapTR,
+                        access: items => items.FireRod,
+                        memoryAddress: 0xB7,
+                        memoryFlag: 0x4,
+                        trackerLogic: items => items.HasMarkedMedallion(World.TurtleRock.DungeonState.MarkedMedallion),
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.TurtleRockRollerRoomRight, 0x1EA1F, LocationType.Regular,
+                        name: "Right",
+                        vanillaItem: ItemType.KeyTR,
+                        access: items => items.FireRod,
+                        memoryAddress: 0xB7,
+                        memoryFlag: 0x5,
+                        trackerLogic: items => items.HasMarkedMedallion(World.TurtleRock.DungeonState.MarkedMedallion),
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location Left { get; }
-
-            public Location Right { get; }
         }
 
         public class LaserBridgeRoom : Room
@@ -178,54 +177,46 @@ namespace Randomizer.Data.WorldData.Regions.Zelda
             public LaserBridgeRoom(Region region, IMetadataService? metadata, TrackerState? trackerState)
                 : base(region, "Eye Bridge", metadata, "Laser Bridge")
             {
-                TopRight = new Location(this, LocationId.TurtleRockEyeBridgeTopRight, 0x1EA28, LocationType.Regular,
-                    name: "Top Right",
-                    vanillaItem: ItemType.FiveRupees,
-                    access: CanAccess,
-                    memoryAddress: 0xD5,
-                    memoryFlag: 0x4,
-                    trackerLogic: items => items.HasMarkedMedallion(World.TurtleRock.DungeonState.MarkedMedallion),
-                    metadata: metadata,
-                    trackerState: trackerState);
-
-                TopLeft = new Location(this, LocationId.TurtleRockEyeBridgeTopLeft, 0x1EA2B, LocationType.Regular,
-                    name: "Top Left",
-                    vanillaItem: ItemType.FiveRupees,
-                    access: CanAccess,
-                    memoryAddress: 0xD5,
-                    memoryFlag: 0x5,
-                    trackerLogic: items => items.HasMarkedMedallion(World.TurtleRock.DungeonState.MarkedMedallion),
-                    metadata: metadata,
-                    trackerState: trackerState);
-
-                BottomRight = new Location(this, LocationId.TurtleRockEyeBridgeBottomRight, 0x1EA2E, LocationType.Regular,
-                    name: "Bottom Right",
-                    vanillaItem: ItemType.TwentyRupees,
-                    access: CanAccess,
-                    memoryAddress: 0xD5,
-                    memoryFlag: 0x6,
-                    trackerLogic: items => items.HasMarkedMedallion(World.TurtleRock.DungeonState.MarkedMedallion),
-                    metadata: metadata,
-                    trackerState: trackerState);
-
-                BottomLeft = new Location(this, LocationId.TurtleRockEyeBridgeBottomLeft, 0x1EA31, LocationType.Regular,
-                    name: "Bottom Left",
-                    vanillaItem: ItemType.KeyTR,
-                    access: CanAccess,
-                    memoryAddress: 0xD5,
-                    memoryFlag: 0x7,
-                    trackerLogic: items => items.HasMarkedMedallion(World.TurtleRock.DungeonState.MarkedMedallion),
-                    metadata: metadata,
-                    trackerState: trackerState);
+                Locations = new List<Location>
+                {
+                    new Location(this, LocationId.TurtleRockEyeBridgeTopRight, 0x1EA28, LocationType.Regular,
+                        name: "Top Right",
+                        vanillaItem: ItemType.FiveRupees,
+                        access: CanAccess,
+                        memoryAddress: 0xD5,
+                        memoryFlag: 0x4,
+                        trackerLogic: items => items.HasMarkedMedallion(World.TurtleRock.DungeonState.MarkedMedallion),
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.TurtleRockEyeBridgeTopLeft, 0x1EA2B, LocationType.Regular,
+                        name: "Top Left",
+                        vanillaItem: ItemType.FiveRupees,
+                        access: CanAccess,
+                        memoryAddress: 0xD5,
+                        memoryFlag: 0x5,
+                        trackerLogic: items => items.HasMarkedMedallion(World.TurtleRock.DungeonState.MarkedMedallion),
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.TurtleRockEyeBridgeBottomRight, 0x1EA2E, LocationType.Regular,
+                        name: "Bottom Right",
+                        vanillaItem: ItemType.TwentyRupees,
+                        access: CanAccess,
+                        memoryAddress: 0xD5,
+                        memoryFlag: 0x6,
+                        trackerLogic: items => items.HasMarkedMedallion(World.TurtleRock.DungeonState.MarkedMedallion),
+                        metadata: metadata,
+                        trackerState: trackerState),
+                    new Location(this, LocationId.TurtleRockEyeBridgeBottomLeft, 0x1EA31, LocationType.Regular,
+                        name: "Bottom Left",
+                        vanillaItem: ItemType.KeyTR,
+                        access: CanAccess,
+                        memoryAddress: 0xD5,
+                        memoryFlag: 0x7,
+                        trackerLogic: items => items.HasMarkedMedallion(World.TurtleRock.DungeonState.MarkedMedallion),
+                        metadata: metadata,
+                        trackerState: trackerState)
+                };
             }
-
-            public Location TopRight { get; }
-
-            public Location TopLeft { get; }
-
-            public Location BottomRight { get; }
-
-            public Location BottomLeft { get; }
 
             private bool CanAccess(Progression items)
             {

--- a/src/Randomizer.Data/WorldData/Room.cs
+++ b/src/Randomizer.Data/WorldData/Room.cs
@@ -16,18 +16,6 @@ namespace Randomizer.Data.WorldData
     public abstract class Room : IHasLocations
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="Room"/> class that has
-        /// no alternate names.
-        /// </summary>
-        /// <param name="region">The region the room is located in.</param>
-        /// <param name="name">The name of the room.</param>
-        /// <param name="metadata"></param>
-        public Room(Region region, string name, IMetadataService? metadata)
-            : this(region, name, metadata, Array.Empty<string>())
-        {
-        }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="Room"/> class with the
         /// specified alternate names.
         /// </summary>
@@ -41,6 +29,7 @@ namespace Randomizer.Data.WorldData
             Name = name;
             AlsoKnownAs = new ReadOnlyCollection<string>(alsoKnownAs);
             Metadata = metadata?.Room(this) ?? new RoomInfo(name);
+            Locations = new List<Location>();
         }
 
         /// <summary>
@@ -81,14 +70,7 @@ namespace Randomizer.Data.WorldData
         /// <summary>
         /// Gets all locations in the room.
         /// </summary>
-        public IEnumerable<Location> Locations => GetLocations();
-
-        /// <summary>
-        /// Returns all locations in this room.
-        /// </summary>
-        /// <returns>A collection of locations in the room.</returns>
-        public IEnumerable<Location> GetLocations()
-            => GetType().GetPropertyValues<Location>(this);
+        public IEnumerable<Location> Locations { get; protected set; }
 
         /// <summary>
         /// Returns a string that represents the room.

--- a/src/Randomizer.Data/WorldData/World.cs
+++ b/src/Randomizer.Data/WorldData/World.cs
@@ -167,6 +167,16 @@ namespace Randomizer.Data.WorldData
                 ?? Locations.FirstOrDefault(x => x.ToString().Equals(name, comparisonType));
         }
 
+        /// <summary>
+        /// Returns the Location object matching the given ID.
+        /// We can be confident this won't throw an exception because we have a
+        /// test that ensures every LocationId is used exactly once.
+        /// </summary>
+        public Location FindLocation(LocationId id)
+        {
+            return Locations.First(x => x.Id == id);
+        }
+
         public bool CanAquire(Progression items, RewardType reward)
         {
             var dungeonWithReward = Regions.OfType<IHasReward>().FirstOrDefault(x => reward == x.RewardType);

--- a/src/Randomizer.SMZ3.Tracking/Tracker.cs
+++ b/src/Randomizer.SMZ3.Tracking/Tracker.cs
@@ -2229,7 +2229,7 @@ namespace Randomizer.SMZ3.Tracking
         /// </returns>
         protected internal bool IsWorth(RewardType reward)
         {
-            var sahasrahlaItem = World.LightWorldNorthEast.SahasrahlasHideout.Sahasrahla.Item;
+            var sahasrahlaItem = World.FindLocation(LocationId.Sahasrahla).Item;
             if (sahasrahlaItem.Type != ItemType.Nothing && reward == RewardType.PendantGreen)
             {
                 _logger.LogDebug("{Reward} leads to {Item}...", reward, sahasrahlaItem);
@@ -2580,7 +2580,7 @@ namespace Randomizer.SMZ3.Tracking
                     .OrderByDescending(x => x.Count())
                     .ThenBy(x => x.Key.Name);
 
-                if (newlyAccessible.Contains(World.InnerMaridia.SpringBall.ShaktoolItem))
+                if (newlyAccessible.Contains(World.FindLocation(LocationId.InnerMaridiaSpringBall)))
                     Say(Responses.ShaktoolAvailable);
 
                 if (newlyAccessible.Contains(World.DarkWorldNorthWest.PegWorld))

--- a/src/Randomizer.SMZ3/FileData/Patcher.cs
+++ b/src/Randomizer.SMZ3/FileData/Patcher.cs
@@ -593,7 +593,7 @@ namespace Randomizer.SMZ3.FileData
                 var item = GetItemName(config, _myWorld.LightWorldNorthWest.BottleMerchant.Item);
                 _stringTable.SetBottleVendorText(Dialog.GetChoiceText(_gameLines.BottleMerchant?.Format(item) ?? "{NOTEXT}", _gameLines.ChoiceYes?.ToString() ?? string.Empty, _gameLines.ChoiceNo?.ToString() ?? string.Empty));
 
-                item = GetItemName(config, _myWorld.LightWorldNorthEast.ZorasDomain.Zora.Item);
+                item = GetItemName(config, _myWorld.FindLocation(LocationId.KingZora).Item);
                 _stringTable.SetZoraText(Dialog.GetChoiceText(_gameLines.KingZora?.Format(item) ?? "{NOTEXT}", _gameLines.ChoiceYes?.ToString() ?? string.Empty, _gameLines.ChoiceNo?.ToString() ?? string.Empty));
             }
 

--- a/tests/Randomizer.SMZ3.Tests/LogicTests/LocationLogicTests.cs
+++ b/tests/Randomizer.SMZ3.Tests/LogicTests/LocationLogicTests.cs
@@ -62,7 +62,7 @@ namespace Randomizer.SMZ3.Tests.LogicTests
         public void LocationWithTwoMissingItemsReturnsTwoMissingItems()
         {
             var emptyProgression = new Progression(World.ItemPools.Keycards, new List<Reward>(), new List<Boss>());
-            var missingItems = Logic.GetMissingRequiredItems(World.GreenBrinstar.GreenBrinstarMainShaft.PowerBomb, emptyProgression, out _);
+            var missingItems = Logic.GetMissingRequiredItems(World.FindLocation(LocationId.GreenBrinstarMainShaft), emptyProgression, out _);
             missingItems.Should().ContainEquivalentOf(new[] { ItemType.Morph, ItemType.PowerBomb });
         }
 
@@ -70,7 +70,7 @@ namespace Randomizer.SMZ3.Tests.LogicTests
         public void LocationWithMultipleOptionsReturnsAllOptions()
         {
             var emptyProgression = new Progression(World.ItemPools.Keycards, new List<Reward>(), new List<Boss>());
-            var missingItems = Logic.GetMissingRequiredItems(World.BlueBrinstar.BlueBrinstarEnergyTank.Ceiling, emptyProgression, out _);
+            var missingItems = Logic.GetMissingRequiredItems(World.FindLocation(LocationId.BlueBrinstarEnergyTankCeiling), emptyProgression, out _);
             missingItems.Should().ContainEquivalentOf(new[] { ItemType.SpaceJump })
                 .And.ContainEquivalentOf(new[] { ItemType.HiJump })
                 .And.ContainEquivalentOf(new[] { ItemType.SpeedBooster })
@@ -81,7 +81,7 @@ namespace Randomizer.SMZ3.Tests.LogicTests
         public void LocationWithThreeMissingItemsReturnsThreeMissingItems()
         {
             var emptyProgression = new Progression(World.ItemPools.Keycards, new List<Reward>(), new List<Boss>());
-            var missingItems = Logic.GetMissingRequiredItems(World.CentralCrateria.BombTorizo.BombTorizo, emptyProgression, out _);
+            var missingItems = Logic.GetMissingRequiredItems(World.FindLocation(LocationId.CrateriaBombTorizo), emptyProgression, out _);
             missingItems.Should().ContainEquivalentOf(new[] { ItemType.Morph, ItemType.Super, ItemType.PowerBomb });
         }
     }

--- a/tests/Randomizer.SMZ3.Tests/LogicTests/LogicConfigTests.cs
+++ b/tests/Randomizer.SMZ3.Tests/LogicTests/LogicConfigTests.cs
@@ -42,17 +42,17 @@ namespace Randomizer.SMZ3.Tests.LogicTests
             config.LogicConfig.PreventScrewAttackSoftLock = false;
             World tempWorld = new World(config, "", 0, "");
             var progression = new Progression(new[] { ItemType.ScrewAttack }, new List<RewardType>(), new List<BossType>());
-            var missingItems = Logic.GetMissingRequiredItems(tempWorld.WestCrateria.Terminator.Terminator, progression, out _);
+            var missingItems = Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.CrateriaTerminator), progression, out _);
             missingItems.Should().BeEmpty();
-            tempWorld.WestCrateria.Terminator.Terminator.IsAvailable(progression).Should().BeTrue();
+            tempWorld.FindLocation(LocationId.CrateriaTerminator).IsAvailable(progression).Should().BeTrue();
 
             config.LogicConfig.PreventScrewAttackSoftLock = true;
             tempWorld = new World(config, "", 0, "");
             progression = new Progression(new[] { ItemType.ScrewAttack }, new List<RewardType>(), new List<BossType>());
-            missingItems = Logic.GetMissingRequiredItems(tempWorld.WestCrateria.Terminator.Terminator, progression, out _);
+            missingItems = Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.CrateriaTerminator), progression, out _);
             missingItems.Should().HaveCount(1)
                 .And.ContainEquivalentOf(new[] { ItemType.Morph });
-            tempWorld.WestCrateria.Terminator.Terminator.IsAvailable(progression).Should().BeFalse();
+            tempWorld.FindLocation(LocationId.CrateriaTerminator).IsAvailable(progression).Should().BeFalse();
         }
 
         [Fact]
@@ -63,24 +63,24 @@ namespace Randomizer.SMZ3.Tests.LogicTests
             config.LogicConfig.PreventFivePowerBombSeed = false;
             World tempWorld = new World(config, "", 0, "");
             var progression = new Progression(new[] { ItemType.Morph, ItemType.PowerBomb }, new List<RewardType>(), new List<BossType>());
-            var missingItems = Logic.GetMissingRequiredItems(tempWorld.WestCrateria.Terminator.Terminator, progression, out _);
+            var missingItems = Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.CrateriaTerminator), progression, out _);
             missingItems.Should().BeEmpty();
-            tempWorld.WestCrateria.Terminator.Terminator.IsAvailable(progression).Should().BeTrue();
+            tempWorld.FindLocation(LocationId.CrateriaTerminator).IsAvailable(progression).Should().BeTrue();
 
             config.LogicConfig.PreventFivePowerBombSeed = true;
             tempWorld = new World(config, "", 0, "");
             progression = new Progression(new[] { ItemType.Morph, ItemType.PowerBomb }, new List<RewardType>(), new List<BossType>());
-            missingItems = Logic.GetMissingRequiredItems(tempWorld.WestCrateria.Terminator.Terminator, progression, out _);
+            missingItems = Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.CrateriaTerminator), progression, out _);
             missingItems.Should().HaveCount(3)
                 .And.ContainEquivalentOf(new[] { ItemType.Bombs })
                 .And.ContainEquivalentOf(new[] { ItemType.ScrewAttack })
                 .And.ContainEquivalentOf(new[] { ItemType.PowerBomb });
-            tempWorld.WestCrateria.Terminator.Terminator.IsAvailable(progression).Should().BeFalse();
+            tempWorld.FindLocation(LocationId.CrateriaTerminator).IsAvailable(progression).Should().BeFalse();
 
             progression = new Progression(new[] { ItemType.Morph, ItemType.PowerBomb, ItemType.PowerBomb }, new List<RewardType>(), new List<BossType>());
-            missingItems = Logic.GetMissingRequiredItems(tempWorld.WestCrateria.Terminator.Terminator, progression, out _);
+            missingItems = Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.CrateriaTerminator), progression, out _);
             missingItems.Should().BeEmpty();
-            tempWorld.WestCrateria.Terminator.Terminator.IsAvailable(progression).Should().BeTrue();
+            tempWorld.FindLocation(LocationId.CrateriaTerminator).IsAvailable(progression).Should().BeTrue();
         }
 
         [Fact]
@@ -91,24 +91,24 @@ namespace Randomizer.SMZ3.Tests.LogicTests
             config.LogicConfig.FireRodDarkRooms = false;
             World tempWorld = new World(config, "", 0, "");
             var progression = new Progression();
-            var missingItems = Logic.GetMissingRequiredItems(tempWorld.HyruleCastle.BackOfEscape.DarkCross, progression, out _);
+            var missingItems = Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.SewersDarkCross), progression, out _);
             missingItems.Should().HaveCount(1)
                 .And.ContainEquivalentOf(new[] { ItemType.Lamp });
-            tempWorld.HyruleCastle.BackOfEscape.DarkCross.IsAvailable(progression).Should().BeFalse();
+            tempWorld.FindLocation(LocationId.SewersDarkCross).IsAvailable(progression).Should().BeFalse();
 
             config.LogicConfig.FireRodDarkRooms = true;
             tempWorld = new World(config, "", 0, "");
             progression = new Progression();
-            missingItems = Logic.GetMissingRequiredItems(tempWorld.HyruleCastle.BackOfEscape.DarkCross, progression, out _);
+            missingItems = Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.SewersDarkCross), progression, out _);
             missingItems.Should().HaveCount(2)
                 .And.ContainEquivalentOf(new[] { ItemType.Lamp })
                 .And.ContainEquivalentOf(new[] { ItemType.Firerod });
-            tempWorld.HyruleCastle.BackOfEscape.DarkCross.IsAvailable(progression).Should().BeFalse();
+            tempWorld.FindLocation(LocationId.SewersDarkCross).IsAvailable(progression).Should().BeFalse();
 
             progression = new Progression(new[] { ItemType.Firerod }, new List<RewardType>(), new List<BossType>());
-            missingItems = Logic.GetMissingRequiredItems(tempWorld.HyruleCastle.BackOfEscape.DarkCross, progression, out _);
+            missingItems = Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.SewersDarkCross), progression, out _);
             missingItems.Should().BeEmpty();
-            tempWorld.HyruleCastle.BackOfEscape.DarkCross.IsAvailable(progression).Should().BeTrue();
+            tempWorld.FindLocation(LocationId.SewersDarkCross).IsAvailable(progression).Should().BeTrue();
         }
 
         [Fact]
@@ -119,18 +119,18 @@ namespace Randomizer.SMZ3.Tests.LogicTests
             config.LogicConfig.InfiniteBombJump = false;
             World tempWorld = new World(config, "", 0, "");
             var progression = new Progression(new[] { ItemType.Morph, ItemType.PowerBomb, ItemType.Bombs }, new List<RewardType>(), new List<BossType>());
-            var missingItems = Logic.GetMissingRequiredItems(tempWorld.CentralCrateria.PowerBomb.PowerBomb, progression, out _);
+            var missingItems = Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.CrateriaPowerBomb), progression, out _);
             missingItems.Should().HaveCount(2)
                 .And.ContainEquivalentOf(new[] { ItemType.SpaceJump })
                 .And.ContainEquivalentOf(new[] { ItemType.SpeedBooster });
-            tempWorld.CentralCrateria.PowerBomb.PowerBomb.IsAvailable(progression).Should().BeFalse();
+            tempWorld.FindLocation(LocationId.CrateriaPowerBomb).IsAvailable(progression).Should().BeFalse();
 
             config.LogicConfig.InfiniteBombJump = true;
             tempWorld = new World(config, "", 0, "");
             progression = new Progression(new[] { ItemType.Morph, ItemType.PowerBomb, ItemType.Bombs }, new List<RewardType>(), new List<BossType>());
-            missingItems = Logic.GetMissingRequiredItems(tempWorld.CentralCrateria.PowerBomb.PowerBomb, progression, out _);
+            missingItems = Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.CrateriaPowerBomb), progression, out _);
             missingItems.Should().BeEmpty();
-            tempWorld.CentralCrateria.PowerBomb.PowerBomb.IsAvailable(progression).Should().BeTrue();
+            tempWorld.FindLocation(LocationId.CrateriaPowerBomb).IsAvailable(progression).Should().BeTrue();
         }
 
         [Fact]
@@ -141,23 +141,23 @@ namespace Randomizer.SMZ3.Tests.LogicTests
             config.LogicConfig.ParlorSpeedBooster = false;
             World tempWorld = new World(config, "", 0, "");
             var progression = new Progression();
-            var missingItems = Logic.GetMissingRequiredItems(tempWorld.WestCrateria.Terminator.Terminator, progression, out _);
+            var missingItems = Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.CrateriaTerminator), progression, out _);
             missingItems.Should().HaveCount(7)
                 .And.NotContainEquivalentOf(new[] { ItemType.SpeedBooster });
-            tempWorld.WestCrateria.Terminator.Terminator.IsAvailable(progression).Should().BeFalse();
+            tempWorld.FindLocation(LocationId.CrateriaTerminator).IsAvailable(progression).Should().BeFalse();
 
             config.LogicConfig.ParlorSpeedBooster = true;
             tempWorld = new World(config, "", 0, "");
             progression = new Progression();
-            missingItems = Logic.GetMissingRequiredItems(tempWorld.WestCrateria.Terminator.Terminator, progression, out _);
+            missingItems = Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.CrateriaTerminator), progression, out _);
             missingItems.Should().HaveCount(8)
                 .And.ContainEquivalentOf(new[] { ItemType.SpeedBooster });
-            tempWorld.WestCrateria.Terminator.Terminator.IsAvailable(progression).Should().BeFalse();
+            tempWorld.FindLocation(LocationId.CrateriaTerminator).IsAvailable(progression).Should().BeFalse();
 
             progression = new Progression(new[] { ItemType.SpeedBooster }, new List<RewardType>(), new List<BossType>());
-            missingItems = Logic.GetMissingRequiredItems(tempWorld.WestCrateria.Terminator.Terminator, progression, out _);
+            missingItems = Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.CrateriaTerminator), progression, out _);
             missingItems.Should().BeEmpty();
-            tempWorld.WestCrateria.Terminator.Terminator.IsAvailable(progression).Should().BeTrue();
+            tempWorld.FindLocation(LocationId.CrateriaTerminator).IsAvailable(progression).Should().BeTrue();
         }
 
         [Fact]
@@ -168,23 +168,23 @@ namespace Randomizer.SMZ3.Tests.LogicTests
             config.LogicConfig.MockBall = false;
             World tempWorld = new World(config, "", 0, "");
             var progression = new Progression(new[] { ItemType.Morph, ItemType.Bombs , ItemType.Missile , ItemType.PowerBomb, ItemType.ScrewAttack }, new List<RewardType>(), new List<BossType>());
-            var missingItems = Logic.GetMissingRequiredItems(tempWorld.GreenBrinstar.MockballHall.TopSuperMissile, progression, out _);
+            var missingItems = Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.GreenBrinstarEarlySupersTop), progression, out _);
             missingItems.Should().HaveCount(1)
                 .And.ContainEquivalentOf(new[] { ItemType.SpeedBooster });
-            tempWorld.GreenBrinstar.MockballHall.TopSuperMissile.IsAvailable(progression).Should().BeFalse();
+            tempWorld.FindLocation(LocationId.GreenBrinstarEarlySupersTop).IsAvailable(progression).Should().BeFalse();
 
             config.LogicConfig.MockBall = true;
             tempWorld = new World(config, "", 0, "");
-            missingItems = Logic.GetMissingRequiredItems(tempWorld.GreenBrinstar.MockballHall.TopSuperMissile, progression, out _);
+            missingItems = Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.GreenBrinstarEarlySupersTop), progression, out _);
             missingItems.Should().BeEmpty();
-            tempWorld.GreenBrinstar.MockballHall.TopSuperMissile.IsAvailable(progression).Should().BeTrue();
+            tempWorld.FindLocation(LocationId.GreenBrinstarEarlySupersTop).IsAvailable(progression).Should().BeTrue();
 
             progression = new Progression(new[] { ItemType.Bombs, ItemType.Missile, ItemType.PowerBomb, ItemType.ScrewAttack }, new List<RewardType>(), new List<BossType>());
-            missingItems = Logic.GetMissingRequiredItems(tempWorld.GreenBrinstar.MockballHall.TopSuperMissile, progression, out _);
+            missingItems = Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.GreenBrinstarEarlySupersTop), progression, out _);
             missingItems.Should().HaveCount(2)
                 .And.ContainEquivalentOf(new[] { ItemType.SpeedBooster })
                 .And.ContainEquivalentOf(new[] { ItemType.Morph });
-            tempWorld.GreenBrinstar.MockballHall.TopSuperMissile.IsAvailable(progression).Should().BeFalse();
+            tempWorld.FindLocation(LocationId.GreenBrinstarEarlySupersTop).IsAvailable(progression).Should().BeFalse();
         }
 
         [Fact]
@@ -255,12 +255,12 @@ namespace Randomizer.SMZ3.Tests.LogicTests
 
             var tempWorld = new World(config, "", 0, "");
             var progression = new Progression(new [] { ItemType.CardMaridiaL1, ItemType.Morph, ItemType.Super, ItemType.PowerBomb, ItemType.Gravity, ItemType.Grapple }, new List<RewardType>(), new List<BossType>());
-            tempWorld.InnerMaridia.LeftSandPit.Left.IsAvailable(progression).Should().BeTrue();
-            tempWorld.InnerMaridia.LeftSandPit.Right.IsAvailable(progression).Should().BeTrue();
+            tempWorld.FindLocation(LocationId.InnerMaridiaWestSandHoleLeft).IsAvailable(progression).Should().BeTrue();
+            tempWorld.FindLocation(LocationId.InnerMaridiaWestSandHoleRight).IsAvailable(progression).Should().BeTrue();
 
             config.LogicConfig.WallJumpDifficulty = WallJumpDifficulty.None;
-            tempWorld.InnerMaridia.LeftSandPit.Left.IsAvailable(progression).Should().BeFalse();
-            tempWorld.InnerMaridia.LeftSandPit.Right.IsAvailable(progression).Should().BeFalse();
+            tempWorld.FindLocation(LocationId.InnerMaridiaWestSandHoleLeft).IsAvailable(progression).Should().BeFalse();
+            tempWorld.FindLocation(LocationId.InnerMaridiaWestSandHoleRight).IsAvailable(progression).Should().BeFalse();
 
         }
 
@@ -273,17 +273,17 @@ namespace Randomizer.SMZ3.Tests.LogicTests
 
             var tempWorld = new World(config, "", 0, "");
             var progression = new Progression(new[] { ItemType.CardMaridiaL1, ItemType.Morph, ItemType.Super, ItemType.PowerBomb, ItemType.Gravity, ItemType.SpaceJump }, new List<RewardType>(), new List<BossType>());
-            var missingItems = Logic.GetMissingRequiredItems(tempWorld.InnerMaridia.LeftSandPit.Left, progression, out _);
+            var missingItems = Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.InnerMaridiaWestSandHoleLeft), progression, out _);
             missingItems.Should().HaveCount(1)
                 .And.ContainEquivalentOf(new[] { ItemType.SpringBall });
-            tempWorld.InnerMaridia.LeftSandPit.Left.IsAvailable(progression).Should().BeFalse();
-            tempWorld.InnerMaridia.LeftSandPit.Right.IsAvailable(progression).Should().BeFalse();
+            tempWorld.FindLocation(LocationId.InnerMaridiaWestSandHoleLeft).IsAvailable(progression).Should().BeFalse();
+            tempWorld.FindLocation(LocationId.InnerMaridiaWestSandHoleRight).IsAvailable(progression).Should().BeFalse();
 
             progression = new Progression(new[] { ItemType.CardMaridiaL1, ItemType.Morph, ItemType.Super, ItemType.PowerBomb, ItemType.Gravity, ItemType.SpaceJump, ItemType.SpringBall, ItemType.HiJump }, new List<RewardType>(), new List<BossType>());
-            missingItems = Logic.GetMissingRequiredItems(tempWorld.InnerMaridia.LeftSandPit.Left, progression, out _);
+            missingItems = Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.InnerMaridiaWestSandHoleLeft), progression, out _);
             missingItems.Should().BeEmpty();
-            tempWorld.InnerMaridia.LeftSandPit.Left.IsAvailable(progression).Should().BeTrue();
-            tempWorld.InnerMaridia.LeftSandPit.Right.IsAvailable(progression).Should().BeTrue();
+            tempWorld.FindLocation(LocationId.InnerMaridiaWestSandHoleLeft).IsAvailable(progression).Should().BeTrue();
+            tempWorld.FindLocation(LocationId.InnerMaridiaWestSandHoleRight).IsAvailable(progression).Should().BeTrue();
         }
 
         [Fact]
@@ -294,21 +294,21 @@ namespace Randomizer.SMZ3.Tests.LogicTests
             config.LogicConfig.LaunchPadRequiresIceBeam = false;
             var tempWorld = new World(config, "", 0, "");
             var progression = new Progression(new[] { ItemType.ETank, ItemType.ETank, ItemType.Morph, ItemType.SpeedBooster, ItemType.PowerBomb, ItemType.PowerBomb}, new List<RewardType>(), new List<BossType>());
-            var missingItems = Logic.GetMissingRequiredItems(tempWorld.CentralCrateria.CrateriaSuper.SuperMissile, progression, out _);
+            var missingItems = Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.CrateriaSuper), progression, out _);
             missingItems.Should().BeEmpty();
-            tempWorld.CentralCrateria.CrateriaSuper.SuperMissile.IsAvailable(progression).Should().BeTrue();
+            tempWorld.FindLocation(LocationId.CrateriaSuper).IsAvailable(progression).Should().BeTrue();
 
             config.LogicConfig.LaunchPadRequiresIceBeam = true;
             tempWorld = new World(config, "", 0, "");
-            missingItems = Logic.GetMissingRequiredItems(tempWorld.CentralCrateria.CrateriaSuper.SuperMissile, progression, out _);
+            missingItems = Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.CrateriaSuper), progression, out _);
             missingItems.Should().HaveCount(1)
                 .And.ContainEquivalentOf(new[] { ItemType.Ice });
-            tempWorld.CentralCrateria.CrateriaSuper.SuperMissile.IsAvailable(progression).Should().BeFalse();
+            tempWorld.FindLocation(LocationId.CrateriaSuper).IsAvailable(progression).Should().BeFalse();
 
             progression = new Progression(new[] { ItemType.ETank, ItemType.ETank, ItemType.Morph, ItemType.SpeedBooster, ItemType.PowerBomb, ItemType.PowerBomb, ItemType.Ice }, new List<RewardType>(), new List<BossType>());
-            missingItems = Logic.GetMissingRequiredItems(tempWorld.CentralCrateria.CrateriaSuper.SuperMissile, progression, out _);
+            missingItems = Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.CrateriaSuper), progression, out _);
             missingItems.Should().BeEmpty();
-            tempWorld.CentralCrateria.CrateriaSuper.SuperMissile.IsAvailable(progression).Should().BeTrue();
+            tempWorld.FindLocation(LocationId.CrateriaSuper).IsAvailable(progression).Should().BeTrue();
         }
 
         [Fact]
@@ -319,21 +319,21 @@ namespace Randomizer.SMZ3.Tests.LogicTests
             config.LogicConfig.WaterwayNeedsGravitySuit = false;
             var tempWorld = new World(config, "", 0, "");
             var progression = new Progression(new[] { ItemType.ETank, ItemType.ETank, ItemType.Morph, ItemType.SpeedBooster, ItemType.PowerBomb, ItemType.PowerBomb, ItemType.Missile }, new List<RewardType>(), new List<BossType>());
-            var missingItems = Logic.GetMissingRequiredItems(tempWorld.PinkBrinstar.WaterwayEnergyTank.Waterway, progression, out _);
+            var missingItems = Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.PinkBrinstarWaterwayEnergyTank), progression, out _);
             missingItems.Should().BeEmpty();
-            tempWorld.PinkBrinstar.WaterwayEnergyTank.Waterway.IsAvailable(progression).Should().BeTrue();
+            tempWorld.FindLocation(LocationId.PinkBrinstarWaterwayEnergyTank).IsAvailable(progression).Should().BeTrue();
 
             config.LogicConfig.WaterwayNeedsGravitySuit = true;
             tempWorld = new World(config, "", 0, "");
-            missingItems = Logic.GetMissingRequiredItems(tempWorld.PinkBrinstar.WaterwayEnergyTank.Waterway, progression, out _);
+            missingItems = Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.PinkBrinstarWaterwayEnergyTank), progression, out _);
             missingItems.Should().HaveCount(1)
                 .And.ContainEquivalentOf(new[] { ItemType.Gravity });
-            tempWorld.PinkBrinstar.WaterwayEnergyTank.Waterway.IsAvailable(progression).Should().BeFalse();
+            tempWorld.FindLocation(LocationId.PinkBrinstarWaterwayEnergyTank).IsAvailable(progression).Should().BeFalse();
 
             progression = new Progression(new[] { ItemType.ETank, ItemType.ETank, ItemType.Morph, ItemType.SpeedBooster, ItemType.PowerBomb, ItemType.PowerBomb, ItemType.Missile, ItemType.Gravity }, new List<RewardType>(), new List<BossType>());
-            missingItems = Logic.GetMissingRequiredItems(tempWorld.CentralCrateria.CrateriaSuper.SuperMissile, progression, out _);
+            missingItems = Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.CrateriaSuper), progression, out _);
             missingItems.Should().BeEmpty();
-            tempWorld.PinkBrinstar.WaterwayEnergyTank.Waterway.IsAvailable(progression).Should().BeTrue();
+            tempWorld.FindLocation(LocationId.PinkBrinstarWaterwayEnergyTank).IsAvailable(progression).Should().BeTrue();
         }
 
         [Fact]
@@ -344,23 +344,23 @@ namespace Randomizer.SMZ3.Tests.LogicTests
             config.LogicConfig.EasyEastCrateriaSkyItem = false;
             var tempWorld = new World(config, "", 0, "");
             var progression = new Progression(new[] { ItemType.ETank, ItemType.ETank, ItemType.Morph, ItemType.PowerBomb, ItemType.PowerBomb, ItemType.Super, ItemType.Gravity, ItemType.Grapple }, new List<RewardType>(), new List<BossType>() { BossType.Phantoon });
-            var missingItems = Logic.GetMissingRequiredItems(tempWorld.EastCrateria.WestOcean.SkyMissile, progression, out _);
+            var missingItems = Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.CrateriaWestOceanSky), progression, out _);
             missingItems.Should().BeEmpty();
-            tempWorld.EastCrateria.WestOcean.SkyMissile.IsAvailable(progression).Should().BeTrue();
+            tempWorld.FindLocation(LocationId.CrateriaWestOceanSky).IsAvailable(progression).Should().BeTrue();
 
             config.LogicConfig.EasyEastCrateriaSkyItem = true;
             tempWorld = new World(config, "", 0, "");
-            missingItems = Logic.GetMissingRequiredItems(tempWorld.EastCrateria.WestOcean.SkyMissile, progression, out _);
+            missingItems = Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.CrateriaWestOceanSky), progression, out _);
             missingItems.Should().HaveCount(2)
                 .And.ContainEquivalentOf(new[] { ItemType.SpaceJump })
                 .And.ContainEquivalentOf(new[] { ItemType.SpeedBooster });
 
-            tempWorld.EastCrateria.WestOcean.SkyMissile.IsAvailable(progression).Should().BeFalse();
+            tempWorld.FindLocation(LocationId.CrateriaWestOceanSky).IsAvailable(progression).Should().BeFalse();
 
             progression = new Progression(new[] { ItemType.ETank, ItemType.ETank, ItemType.Morph, ItemType.PowerBomb, ItemType.PowerBomb, ItemType.Super, ItemType.Gravity, ItemType.Grapple, ItemType.SpaceJump }, new List<RewardType>(), new List<BossType>() { BossType.Phantoon });
-            missingItems = Logic.GetMissingRequiredItems(tempWorld.EastCrateria.WestOcean.SkyMissile, progression, out _);
+            missingItems = Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.CrateriaWestOceanSky), progression, out _);
             missingItems.Should().BeEmpty();
-            tempWorld.EastCrateria.WestOcean.SkyMissile.IsAvailable(progression).Should().BeTrue();
+            tempWorld.FindLocation(LocationId.CrateriaWestOceanSky).IsAvailable(progression).Should().BeTrue();
         }
 
         [Fact]
@@ -418,33 +418,33 @@ namespace Randomizer.SMZ3.Tests.LogicTests
 
             var tempWorld = new World(config, "", 0, "");
             var progression = new Progression(new[] { ItemType.Morph, ItemType.PowerBomb, ItemType.CardBrinstarL1 }, new List<RewardType>(), new List<BossType>());
-            Logic.GetMissingRequiredItems(tempWorld.BlueBrinstar.BlueBrinstarTop.MainItem, progression, out _).Should().BeEmpty();
-            Logic.GetMissingRequiredItems(tempWorld.BlueBrinstar.BlueBrinstarTop.HiddenItem, progression, out _).Should().BeEmpty();
-            tempWorld.BlueBrinstar.BlueBrinstarTop.MainItem.IsAvailable(progression).Should().BeTrue();
-            tempWorld.BlueBrinstar.BlueBrinstarTop.HiddenItem.IsAvailable(progression).Should().BeTrue();
+            Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.BlueBrinstarDoubleMissileVisible), progression, out _).Should().BeEmpty();
+            Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.BlueBrinstarDoubleMissileHidden), progression, out _).Should().BeEmpty();
+            tempWorld.FindLocation(LocationId.BlueBrinstarDoubleMissileVisible).IsAvailable(progression).Should().BeTrue();
+            tempWorld.FindLocation(LocationId.BlueBrinstarDoubleMissileHidden).IsAvailable(progression).Should().BeTrue();
 
             config.LogicConfig.EasyBlueBrinstarTop = true;
             tempWorld = new World(config, "", 0, "");
-            Logic.GetMissingRequiredItems(tempWorld.BlueBrinstar.BlueBrinstarTop.MainItem, progression, out _).Should().HaveCount(2)
+            Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.BlueBrinstarDoubleMissileVisible), progression, out _).Should().HaveCount(2)
                 .And.ContainEquivalentOf(new[] { ItemType.SpaceJump })
                 .And.ContainEquivalentOf(new[] { ItemType.Gravity });
-            Logic.GetMissingRequiredItems(tempWorld.BlueBrinstar.BlueBrinstarTop.HiddenItem, progression, out _).Should().HaveCount(2)
+            Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.BlueBrinstarDoubleMissileHidden), progression, out _).Should().HaveCount(2)
                 .And.ContainEquivalentOf(new[] { ItemType.SpaceJump })
                 .And.ContainEquivalentOf(new[] { ItemType.Gravity });
-            tempWorld.BlueBrinstar.BlueBrinstarTop.MainItem.IsAvailable(progression).Should().BeFalse();
-            tempWorld.BlueBrinstar.BlueBrinstarTop.HiddenItem.IsAvailable(progression).Should().BeFalse();
+            tempWorld.FindLocation(LocationId.BlueBrinstarDoubleMissileVisible).IsAvailable(progression).Should().BeFalse();
+            tempWorld.FindLocation(LocationId.BlueBrinstarDoubleMissileHidden).IsAvailable(progression).Should().BeFalse();
 
             progression = new Progression(new[] { ItemType.Morph, ItemType.PowerBomb, ItemType.Gravity, ItemType.CardBrinstarL1 }, new List<RewardType>(), new List<BossType>());
-            Logic.GetMissingRequiredItems(tempWorld.BlueBrinstar.BlueBrinstarTop.MainItem, progression, out _).Should().BeEmpty();
-            Logic.GetMissingRequiredItems(tempWorld.BlueBrinstar.BlueBrinstarTop.HiddenItem, progression, out _).Should().BeEmpty();
-            tempWorld.BlueBrinstar.BlueBrinstarTop.MainItem.IsAvailable(progression).Should().BeTrue();
-            tempWorld.BlueBrinstar.BlueBrinstarTop.HiddenItem.IsAvailable(progression).Should().BeTrue();
+            Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.BlueBrinstarDoubleMissileVisible), progression, out _).Should().BeEmpty();
+            Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.BlueBrinstarDoubleMissileHidden), progression, out _).Should().BeEmpty();
+            tempWorld.FindLocation(LocationId.BlueBrinstarDoubleMissileVisible).IsAvailable(progression).Should().BeTrue();
+            tempWorld.FindLocation(LocationId.BlueBrinstarDoubleMissileHidden).IsAvailable(progression).Should().BeTrue();
 
             progression = new Progression(new[] { ItemType.Morph, ItemType.PowerBomb, ItemType.SpaceJump, ItemType.CardBrinstarL1 }, new List<RewardType>(), new List<BossType>());
-            Logic.GetMissingRequiredItems(tempWorld.BlueBrinstar.BlueBrinstarTop.MainItem, progression, out _).Should().BeEmpty();
-            Logic.GetMissingRequiredItems(tempWorld.BlueBrinstar.BlueBrinstarTop.HiddenItem, progression, out _).Should().BeEmpty();
-            tempWorld.BlueBrinstar.BlueBrinstarTop.MainItem.IsAvailable(progression).Should().BeTrue();
-            tempWorld.BlueBrinstar.BlueBrinstarTop.HiddenItem.IsAvailable(progression).Should().BeTrue();
+            Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.BlueBrinstarDoubleMissileVisible), progression, out _).Should().BeEmpty();
+            Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.BlueBrinstarDoubleMissileHidden), progression, out _).Should().BeEmpty();
+            tempWorld.FindLocation(LocationId.BlueBrinstarDoubleMissileVisible).IsAvailable(progression).Should().BeTrue();
+            tempWorld.FindLocation(LocationId.BlueBrinstarDoubleMissileHidden).IsAvailable(progression).Should().BeTrue();
         }
 
         [Fact]
@@ -454,21 +454,21 @@ namespace Randomizer.SMZ3.Tests.LogicTests
 
             var tempWorld = new World(config, "", 0, "");
             var progression = new Progression(new[] { ItemType.Flippers, ItemType.ThreeHundredRupees}, new List<RewardType>(), new List<BossType>());
-            Logic.GetMissingRequiredItems(tempWorld.LightWorldNorthEast.ZorasDomain.Zora, progression, out _).Should().BeEmpty();
-            tempWorld.LightWorldNorthEast.ZorasDomain.Zora.IsAvailable(progression).Should().BeTrue();
+            Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.KingZora), progression, out _).Should().BeEmpty();
+            tempWorld.FindLocation(LocationId.KingZora).IsAvailable(progression).Should().BeTrue();
 
             config.LogicConfig.ZoraNeedsRupeeItems = true;
             tempWorld = new World(config, "", 0, "");
-            var items = Logic.GetMissingRequiredItems(tempWorld.LightWorldNorthEast.ZorasDomain.Zora, progression,
+            var items = Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.KingZora), progression,
                 out _);
-            Logic.GetMissingRequiredItems(tempWorld.LightWorldNorthEast.ZorasDomain.Zora, progression, out _).Should()
+            Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.KingZora), progression, out _).Should()
                 .HaveCount(1)
                 .And.ContainEquivalentOf(new[] { ItemType.ThreeHundredRupees });
-            tempWorld.LightWorldNorthEast.ZorasDomain.Zora.IsAvailable(progression).Should().BeFalse();
+            tempWorld.FindLocation(LocationId.KingZora).IsAvailable(progression).Should().BeFalse();
 
             progression = new Progression(new[] { ItemType.Flippers, ItemType.ThreeHundredRupees, ItemType.ThreeHundredRupees }, new List<RewardType>(), new List<BossType>());
-            Logic.GetMissingRequiredItems(tempWorld.LightWorldNorthEast.ZorasDomain.Zora, progression, out _).Should().BeEmpty();
-            tempWorld.LightWorldNorthEast.ZorasDomain.Zora.IsAvailable(progression).Should().BeTrue();
+            Logic.GetMissingRequiredItems(tempWorld.FindLocation(LocationId.KingZora), progression, out _).Should().BeEmpty();
+            tempWorld.FindLocation(LocationId.KingZora).IsAvailable(progression).Should().BeTrue();
         }
     }
 }

--- a/tests/Randomizer.SMZ3.Tests/LogicTests/RandomizerTests.cs
+++ b/tests/Randomizer.SMZ3.Tests/LogicTests/RandomizerTests.cs
@@ -25,7 +25,7 @@ namespace Randomizer.SMZ3.Tests.LogicTests
     {
         // If this test breaks, update Smz3Randomizer.Version
         [Theory]
-        [InlineData("test", -2044032863)] // Smz3Randomizer v4.0
+        [InlineData("test", 558598333)] // Smz3Randomizer v4.0
         public void StandardFillerWithSameSeedGeneratesSameWorld(string seed, int expectedHash)
         {
             var filler = new StandardFiller(GetLogger<StandardFiller>());


### PR DESCRIPTION
One last set of changes to close #341! This one aims to make `Room` classes more lightweight by removing all the `Location` properties. The changes look worse than they actually are, because a lot of lines got indented by one step.

(The ultimate goal is to get the `Room` definitions so lightweight that they no longer each need their own class. This is because graph-based logic will/would need *way* more room definitions and having a class for each one would be tiring.)