### PR TITLE
Multiworld Fixes

### DIFF
--- a/setup/randomizer.app.iss
+++ b/setup/randomizer.app.iss
@@ -4,7 +4,7 @@
 #include "CodeDependencies.iss"
 
 #define MyAppName "SMZ3 Cas' Randomizer"
-#define MyAppVersion "9.3.0"
+#define MyAppVersion "9.3.1"
 #define MyAppPublisher "Vivelin"
 #define MyAppURL "https://github.com/Vivelin/SMZ3Randomizer"
 #define MyAppExeName "Randomizer.App.exe"

--- a/src/Randomizer.App/Randomizer.App.csproj
+++ b/src/Randomizer.App/Randomizer.App.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net6.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>chozo20.ico</ApplicationIcon>
-    <Version>9.3.0</Version>
+    <Version>9.3.1</Version>
     <Title>SMZ3 Cas' Randomizer</Title>
     <AssemblyTitle>SMZ3 Cas' Randomizer</AssemblyTitle>
     <Authors>Vivelin</Authors>

--- a/src/Randomizer.Multiplayer.Server/MultiplayerDbService.cs
+++ b/src/Randomizer.Multiplayer.Server/MultiplayerDbService.cs
@@ -220,11 +220,11 @@ public class MultiplayerDbService
             if (dbState == null) return;
             dbState.Tracked = locationState.Tracked;
             dbState.TrackedTime = locationState.TrackedTime;
-            await SaveChanges(dbContext, $"Unable to save location state for player {locationState.Player.Guid}");
+            await SaveChanges(dbContext, $"Unable to save location state");
         }
         catch (Exception e)
         {
-            _logger.LogError(e, "Unable to save location state for player {Player}", locationState.Player.Guid);
+            _logger.LogError(e, "Unable to save location state");
         }
     }
 
@@ -243,11 +243,11 @@ public class MultiplayerDbService
             if (dbState == null) return;
             dbState.TrackingValue = itemState.TrackingValue;
             dbState.TrackedTime = itemState.TrackedTime;
-            await SaveChanges(dbContext, $"Unable to save item state for player {itemState.Player.Guid}");
+            await SaveChanges(dbContext, $"Unable to save item state");
         }
         catch (Exception e)
         {
-            _logger.LogError(e, "Unable to save item state for player {Player}", itemState.Player.Guid);
+            _logger.LogError(e, "Unable to save item state");
         }
 
     }
@@ -267,11 +267,11 @@ public class MultiplayerDbService
             if (dbState == null) return;
             dbState.Tracked = dungeonState.Tracked;
             dbState.TrackedTime = dungeonState.TrackedTime;
-            await SaveChanges(dbContext, $"Unable to save dungeon state for player {dungeonState.Player.Guid}");
+            await SaveChanges(dbContext, $"Unable to save dungeon state");
         }
         catch (Exception e)
         {
-            _logger.LogError(e, "Unable to save dungeon state for player {Player}", dungeonState.Player.Guid);
+            _logger.LogError(e, "Unable to save dungeon state");
         }
 
     }
@@ -291,11 +291,11 @@ public class MultiplayerDbService
             if (dbState == null) return;
             dbState.Tracked = bossState.Tracked;
             dbState.TrackedTime = bossState.TrackedTime;
-            await SaveChanges(dbContext, $"Unable to save boss state for player {bossState.Player.Guid}");
+            await SaveChanges(dbContext, $"Unable to save boss state");
         }
         catch (Exception e)
         {
-            _logger.LogError(e, "Unable to save boss state for player {Player}", bossState.Player.Guid);
+            _logger.LogError(e, "Unable to save boss state");
         }
     }
 

--- a/src/Randomizer.Multiplayer.Server/Randomizer.Multiplayer.Server.csproj
+++ b/src/Randomizer.Multiplayer.Server/Randomizer.Multiplayer.Server.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>2.1.0</Version>
+    <Version>2.1.1</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
   </PropertyGroup>
 

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/GameService.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/GameService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Randomizer.Shared;
 using Randomizer.SMZ3.Tracking.Services;
@@ -340,11 +341,14 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         {
             if (!IsInGame())
             {
+                _logger.LogWarning("Could not kill player as they are not in game");
                 return false;
             }
 
             if (AutoTracker!.CurrentGame == Game.Zelda)
             {
+                MarkRecentlyKilled();
+
                 // Set health to 0
                 AutoTracker.WriteToMemory(new EmulatorAction()
                 {
@@ -367,6 +371,8 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
             }
             else if (AutoTracker.CurrentGame == Game.SM)
             {
+                MarkRecentlyKilled();
+
                 // Empty reserves
                 AutoTracker.WriteToMemory(new EmulatorAction()
                 {
@@ -396,6 +402,8 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
 
                 return true;
             }
+
+            _logger.LogWarning("Could not kill player as they are not in either Zelda or Metroid currently");
             return false;
         }
 
@@ -511,6 +519,18 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
                 _logger.LogInformation("Giving player {ItemCount} missing items", otherCollectedItems.Count);
                 TryGiveItemTypes(otherCollectedItems);
             }
+        }
+
+        /// <summary>
+        /// If the player was recently killed by the game service
+        /// </summary>
+        public bool PlayerRecentlyKilled { get; private set; }
+
+        private async void MarkRecentlyKilled()
+        {
+            PlayerRecentlyKilled = true;
+            await Task.Delay(TimeSpan.FromSeconds(10));
+            PlayerRecentlyKilled = false;
         }
 
         private static byte[] Int16ToBytes(int value)

--- a/src/Randomizer.SMZ3.Tracking/Tracker.cs
+++ b/src/Randomizer.SMZ3.Tracking/Tracker.cs
@@ -1072,12 +1072,13 @@ namespace Randomizer.SMZ3.Tracking
         /// <param name="autoTracked">If this was tracked by the auto tracker</param>
         /// <param name="location">The location an item was tracked from</param>
         /// <param name="giftedItem">If the item was gifted to the player by tracker or another player</param>
+        /// <param name="silent">If tracker should not say anything</param>
         /// <returns>
         /// <see langword="true"/> if the item was actually tracked; <see
         /// langword="false"/> if the item could not be tracked, e.g. when
         /// tracking Bow twice.
         /// </returns>
-        public bool TrackItem(Item item, string? trackedAs = null, float? confidence = null, bool tryClear = true, bool autoTracked = false, Location? location = null, bool giftedItem = false)
+        public bool TrackItem(Item item, string? trackedAs = null, float? confidence = null, bool tryClear = true, bool autoTracked = false, Location? location = null, bool giftedItem = false, bool silent = false)
         {
             var didTrack = false;
             var accessibleBefore = _worldService.AccessibleLocations(false);
@@ -1089,7 +1090,7 @@ namespace Randomizer.SMZ3.Tracking
                                 && autoTracked
                                 && location?.Region.GetType() == typeof(GanonsTower)
                                 && !ItemService.GetProgression(false).BigKeyGT;
-            var stateResponse = !isGTPreBigKey && (!autoTracked
+            var stateResponse = !isGTPreBigKey && !silent && (!autoTracked
                                                || !item.Metadata.IsDungeonItem()
                                                || World.Config.ZeldaKeysanity);
 

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/MultiplayerModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/MultiplayerModule.cs
@@ -193,6 +193,7 @@ public class MultiplayerModule : TrackerModule
     {
         if (args.DeathLinkEnabled && !args.IsLocalPlayer)
         {
+            Logger.LogInformation("Other player died with death link enabled");
             Tracker.GameService!.TryKillPlayer();
             Tracker.Say(x => x.Multiplayer.OtherPlayedDiedDeathLink, args.PhoneticName);
         }
@@ -243,7 +244,7 @@ public class MultiplayerModule : TrackerModule
 
     private async void TrackerOnPlayerDied(object? sender, TrackerEventArgs e)
     {
-        if (!e.AutoTracked) return;
+        if (!e.AutoTracked || Tracker.GameService!.PlayerRecentlyKilled) return;
         await _multiplayerGameService.TrackDeath();
     }
 


### PR DESCRIPTION
- Prevent tracker remarking on deaths when killed by the game service
- Prevent death linked players from tracking deaths to the server
- Fixed server logging that was broken