### PR TITLE
Init settings bug fix

### DIFF
--- a/src/Randomizer.App/Randomizer.App.csproj
+++ b/src/Randomizer.App/Randomizer.App.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net6.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>chozo20.ico</ApplicationIcon>
-    <Version>9.3.2</Version>
+    <Version>9.3.3</Version>
     <Title>SMZ3 Cas' Randomizer</Title>
     <AssemblyTitle>SMZ3 Cas' Randomizer</AssemblyTitle>
     <Authors>Vivelin</Authors>

--- a/src/Randomizer.App/Windows/RomListWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/RomListWindow.xaml.cs
@@ -52,7 +52,6 @@ namespace Randomizer.App.Windows
                     "can start playing randomized SMZ3 games. Please do so now.",
                     "SMZ3 Cas’ Randomizer", MessageBoxButton.OK, MessageBoxImage.Information);
                 OptionsMenuItem_Click(this, new RoutedEventArgs());
-                return;
             }
 
             if (!string.IsNullOrEmpty(Options.GeneralOptions.TwitchOAuthToken))

--- a/src/Randomizer.App/Windows/RomListWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/RomListWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.IO;
 using System.Windows;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -93,8 +94,29 @@ namespace Randomizer.App.Windows
             optionsDialog.Options = Options.GeneralOptions;
             optionsDialog.ShowDialog();
 
+            if (!string.IsNullOrEmpty(Options.GeneralOptions.RomOutputPath) && !Directory.Exists(Options.GeneralOptions.RomOutputPath))
+            {
+                try
+                {
+                    Directory.CreateDirectory(Options.GeneralOptions.RomOutputPath);
+                }
+                catch
+                {
+                    // Oh well, next check will warn the user
+                }
+            }
+
+            if (!Options.GeneralOptions.Validate())
+            {
+                MessageBox.Show(this, "Missing required settings. Verify that you have entered valid " +
+                                      "roms and a valid output folder.",
+                "SMZ3 Cas’ Randomizer", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+
+
             try
             {
+
                 Options.Save(OptionsFactory.GetFilePath());
             }
             catch


### PR DESCRIPTION
Fixes a few things

1. The options window would not actually create the output directory, meaning if someone closed and reopened before generating a rom it would ask to update settings again
2. It never validated the options when closing the options window, so people wouldn't know if they missed required fields
3. It would never show the rom list/generate button after updating the options initially, meaning people would be stuck in a loop unless they selected a, output folder that already exists