### PR TITLE
Initial MSU Randomization Integration

### DIFF
--- a/src/Randomizer.App/Controls/FileSystemInput.xaml.cs
+++ b/src/Randomizer.App/Controls/FileSystemInput.xaml.cs
@@ -99,6 +99,7 @@ namespace Randomizer.App.Controls
                 if (string.IsNullOrEmpty(FileValidationHash) || string.IsNullOrEmpty(FileValidationErrorMessage))
                 {
                     Path = dialog.FileName;
+                    OnPathUpdated?.Invoke(this, EventArgs.Empty);
                 }
                 else
                 {
@@ -115,6 +116,7 @@ namespace Randomizer.App.Controls
                     }
 
                     Path = dialog.FileName;
+                    OnPathUpdated?.Invoke(this, EventArgs.Empty);
                 }
             }
         }
@@ -133,8 +135,11 @@ namespace Randomizer.App.Controls
             if (dialog.ShowDialog(owner) == CommonFileDialogResult.Ok)
             {
                 Path = dialog.FileName;
+                OnPathUpdated?.Invoke(this, EventArgs.Empty);
             }
         }
+
+        public event EventHandler? OnPathUpdated;
 
     }
 }

--- a/src/Randomizer.App/Randomizer.App.csproj
+++ b/src/Randomizer.App/Randomizer.App.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net7.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>chozo20.ico</ApplicationIcon>
-    <Version>9.4.0-beta.1</Version>
+    <Version>9.4.0</Version>
     <Title>SMZ3 Cas' Randomizer</Title>
     <AssemblyTitle>SMZ3 Cas' Randomizer</AssemblyTitle>
     <Authors>Vivelin</Authors>
@@ -68,10 +68,15 @@
     <EmbeddedResource Include="Patches\HoldFire.ips" />
     <None Remove="Patches\UnifiedAim.ips" />
     <EmbeddedResource Include="Patches\UnifiedAim.ips" />
+    <None Remove="msu-randomizer-settings.yml" />
+    <EmbeddedResource Include="msu-randomizer-settings.yml" />
+    <None Remove="msu-randomizer-types.json" />
+    <EmbeddedResource Include="msu-randomizer-types.json" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.4.4" />
+    <PackageReference Include="MattEqualsCoder.MSURandomizer.UI" Version="1.0.1" />
     <PackageReference Include="Microsoft-WindowsAPICodePack-Shell" Version="1.1.5" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
     <PackageReference Include="NReco.Logging.File" Version="1.1.6" />

--- a/src/Randomizer.App/RomGenerator.cs
+++ b/src/Randomizer.App/RomGenerator.cs
@@ -170,7 +170,7 @@ namespace Randomizer.App
             var fileSuffix = $"{DateTimeOffset.Now:yyyyMMdd-HHmmss}_{safeSeed}";
             var romFileName = $"SMZ3_Cas_{fileSuffix}.sfc";
             var romPath = Path.Combine(folderPath, romFileName);
-            _msuGeneratorService.EnableMsu1Support(options.PatchOptions.Msu1Path, romPath, out var msuError);
+            _msuGeneratorService.ApplyMsuOptions(romPath);
             Rom.UpdateChecksum(bytes);
             await File.WriteAllBytesAsync(romPath, bytes);
 
@@ -194,7 +194,7 @@ namespace Randomizer.App
             return new GenerateRomResults()
             {
                 Rom = rom,
-                MsuError = msuError
+                MsuError = ""
             };
         }
 
@@ -426,6 +426,8 @@ namespace Randomizer.App
                 Settings = settingsString,
                 GeneratorVersion = Smz3Randomizer.Version.Major,
                 MultiplayerGameDetails = multiplayerGameDetails,
+                MsuRandomizationStyle = options.PatchOptions.MsuRandomizationStyle,
+                MsuPaths = string.Join("|", options.PatchOptions.MsuPaths)
             };
             _dbContext.GeneratedRoms.Add(rom);
 

--- a/src/Randomizer.App/Windows/GenerateRomWindow.xaml
+++ b/src/Randomizer.App/Windows/GenerateRomWindow.xaml
@@ -10,6 +10,7 @@
         xmlns:options="clr-namespace:Randomizer.Data.Options;assembly=Randomizer.Data"
         xmlns:windows="clr-namespace:Randomizer.App.Windows"
         mc:Ignorable="d"
+        Loaded="GenerateRomWindow_OnLoaded"
         Closing="Window_Closing"
         Title="SMZ3 Cas' Randomizer"
         Width="{Binding WindowWidth, Mode=TwoWay}"
@@ -307,16 +308,37 @@
 
 
               <controls:LabeledControl Text="Custom music pack:">
-                <controls:FileSystemInput Path="{Binding Msu1Path, Mode=TwoWay}"
-                                          Filter="MSU-1 files (*.msu)|*.msu|All files (*.*)|*.*"
-                                          DialogTitle="Select MSU-1 file" />
-              </controls:LabeledControl>
+                <Grid>
+                  <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"></ColumnDefinition>
+                    <ColumnDefinition Width="Auto"></ColumnDefinition>
+                  </Grid.ColumnDefinitions>
+                  <TextBox Grid.Column="0" Name="SelectedMsuTextBox" IsReadOnly="True"></TextBox>
+                  <StackPanel Grid.Column="1" Orientation="Horizontal"
+                              HorizontalAlignment="Right">
+                    <Button x:Name="SelectMsuButton"
+                            Click="SelectMsuButton_OnClick">Select _MSU</Button>
+                    <Button x:Name="MsuOptionsButton"
+                            MinWidth="0"
+                            Width="23"
+                            Content="▼"
+                            FontSize="8"
+                            BorderThickness="0,1,1,1"
+                            Margin="0,0,0,0"
+                            Click="MsuOptionsButton_OnClick">
+                      <Button.ContextMenu>
+                        <ContextMenu>
+                          <MenuItem Header="Pick _Random MSU from List" Name="RandomMsuMenuItem" Click="RandomMsuMenuItem_OnClick"></MenuItem>
+                          <MenuItem Header="Create _Shuffled MSU" Name="ShuffledMsuMenuItem" Click="ShuffledMsuMenuItem_OnClick"></MenuItem>
+                          <MenuItem Header="_Continuously Reshuffle MSU" Name="ContinuousShuffleMsuMenuItem" Click="ContinuousShuffleMsuMenuItem_OnClick"></MenuItem>
+                          <MenuItem Header="Select MSU _File" Name="SelectMsuFileMenuItem" Click="SelectMsuFileMenuItem_OnClick"></MenuItem>
+                          <MenuItem Header="Play _Vanilla Music" Name="VanillaMusicMenuItem" Click="VanillaMusicMenuItem_OnClick"></MenuItem>
+                        </ContextMenu>
+                      </Button.ContextMenu>
+                    </Button>
+                  </StackPanel>
+                </Grid>
 
-              <controls:LabeledControl Text="">
-                <CheckBox IsChecked="{Binding EnableExtendedSoundtrack}"
-                          IsEnabled="{Binding CanEnableExtendedSoundtrack}"
-                          Content="Enable extended soundtrack"
-                          ToolTip="Enables support for the extended MSU-1 soundtrack. Only available if a custom music pack is selected." />
               </controls:LabeledControl>
 
             </StackPanel>
@@ -342,6 +364,7 @@
 
           <Expander Header="Locations"
                     Visibility="{Binding InvisibleInPlando, Mode=OneTime, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Window}}"
+                    IsExpanded="{Binding LocationExpanded}"
                     x:Name="Locations">
             <StackPanel Orientation="Vertical"
                         Margin="24,11,11,11">

--- a/src/Randomizer.App/Windows/OptionsWindow.xaml
+++ b/src/Randomizer.App/Windows/OptionsWindow.xaml
@@ -55,6 +55,14 @@
                                           IsFolderPicker="True"
                                           DialogTitle="Select ROM output folder" />
               </controls:LabeledControl>
+
+              <controls:LabeledControl Text="MSU parent folder:">
+                <controls:FileSystemInput Path="{Binding MsuPath, Mode=TwoWay}"
+                                          IsFolderPicker="True"
+                                          DialogTitle="Select MSU parent folder"
+                                          OnPathUpdated="FileSystemInput_OnOnPathUpdated"
+                                          />
+              </controls:LabeledControl>
             </StackPanel>
           </Expander>
 

--- a/src/Randomizer.App/Windows/OptionsWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/OptionsWindow.xaml.cs
@@ -256,5 +256,25 @@ namespace Randomizer.App.Windows
             _ = TryParse(new string(UndoExpirationTimeTextBox.Text.Where(char.IsDigit).ToArray()), out var number);
             UndoExpirationTimeTextBox.Text = Math.Max(1, number).ToString();
         }
+
+        private void FileSystemInput_OnOnPathUpdated(object? sender, EventArgs e)
+        {
+            var outputPath = Options.RomOutputPath;
+            var msuPath = Options.MsuPath;
+
+            if (string.IsNullOrEmpty(outputPath) || string.IsNullOrEmpty(msuPath))
+            {
+                return;
+            }
+
+            var outputDrive = new DriveInfo(outputPath);
+            var msuDrive = new DriveInfo(msuPath);
+            if (outputDrive.Name != msuDrive.Name)
+            {
+                MessageBox.Show(this,
+                    "To preserve drive space, it is recommended that the Rom Output and MSU folders be on the same drive.",
+                    "SMZ3 Cas' Randomizer", MessageBoxButton.OK, MessageBoxImage.Warning);
+            }
+        }
     }
 }

--- a/src/Randomizer.App/msu-randomizer-settings.yml
+++ b/src/Randomizer.App/msu-randomizer-settings.yml
@@ -1,0 +1,10 @@
+﻿UserOptionsFilePath: "%LocalAppData%\\SMZ3CasRandomizer\\msu-user-settings.yml"
+MsuCachePath: "%LocalAppData%\\SMZ3CasRandomizer"
+ContinuousReshuffleSeconds: 60
+MsuWindowDisplayRandomButton: false
+MsuWindowDisplayShuffleButton: false
+MsuWindowDisplayContinuousButton: false
+MsuWindowDisplayOptionsButton: false
+MsuWindowDisplaySelectButton: true
+ForcedMsuType: "Super Metroid / A Link to the Past Combination Randomizer"
+MsuWindowTitle: SMZ3 Cas' Randomizer

--- a/src/Randomizer.App/msu-randomizer-types.json
+++ b/src/Randomizer.App/msu-randomizer-types.json
@@ -1,0 +1,502 @@
+﻿[
+  {
+    "meta": {
+      "name": "The Legend of Zelda: A Link to the Past"
+    },
+    "tracks": {
+      "basic": [
+        {
+          "title": "Opening Theme",
+          "name": "Link to the Past",
+          "nonlooping": true
+        },
+        {
+          "title": "Light World Overworld",
+          "name": "Hyrule Field"
+        },
+        {
+          "title": "Rain State Overworld",
+          "name": "Time of Falling Rain"
+        },
+        {
+          "title": "Bunny Overworld",
+          "name": "The Silly Pink Rabbit"
+        },
+        {
+          "title": "Light World Lost Woods",
+          "name": "Forest of Mystery"
+        },
+        {
+          "title": "Opening Story Credits",
+          "name": "Seal of Seven Maidens"
+        },
+        {
+          "title": "Kakariko Village"
+        },
+        {
+          "title": "Mirror Portal",
+          "name": "Dimensional Shift",
+          "nonlooping": true
+        },
+        {
+          "title": "Dark World Overworld",
+          "name": "Dark Golden Land"
+        },
+        {
+          "title": "Pedestal Pull Sequence",
+          "name": "Unsealing the Master Sword",
+          "nonlooping": true
+        },
+        {
+          "title": "File Select/Game Over",
+          "name": "Beginning of the Journey"
+        },
+        {
+          "title": "Kakariko Guards Summoned",
+          "name": "Soldiers of Kakariko Village"
+        },
+        {
+          "title": "Dark Death Mountain",
+          "name": "Black Mist"
+        },
+        {
+          "title": "Money Making Game"
+        },
+        {
+          "title": "Dark World Lost Woods",
+          "extended": true,
+          "remap": 13
+        },
+        {
+          "title": "Hyrule Castle",
+          "name": "Majestic Castle"
+        },
+        {
+          "title": "Generic Light World Dungeon",
+          "name": "Lost Ancient Ruins"
+        },
+        {
+          "title": "Cave",
+          "name": "Dank Dungeons"
+        },
+        {
+          "title": "Boss Victory",
+          "name": "Great Victory!",
+          "nonlooping": true
+        },
+        {
+          "title": "Sanctuary",
+          "name": "Safety in the Sanctuary"
+        },
+        {
+          "title": "Generic Boss Battle",
+          "name": "Anger of the Guardians"
+        },
+        {
+          "title": "Generic Dark World Dungeon",
+          "name": "Dungeon of Shadows"
+        },
+        {
+          "title": "Shop/Fortune Teller"
+        },
+        {
+          "title": "Cave 2"
+        },
+        {
+          "title": "Princess Zelda's Rescue"
+        },
+        {
+          "title": "Crystal Get",
+          "name": "Meeting the Maidens"
+        },
+        {
+          "title": "Fairy Fountain",
+          "name": "The Goddess Appears"
+        },
+        {
+          "title": "Agahnim's Theme",
+          "name": "Priest of the Dark Order"
+        },
+        {
+          "title": "Ganon Appears",
+          "name": "Release of Ganon",
+          "nonlooping": true
+        },
+        {
+          "title": "Ganon's Theme",
+          "name": "Ganon's Message"
+        },
+        {
+          "title": "Ganon Fight",
+          "name": "The Prince of Darkness"
+        },
+        {
+          "title": "Triforce Room",
+          "name": "Power of the Gods"
+        },
+        {
+          "title": "Triumphant Return",
+          "name": "Epilogue ~ Beautiful Hyrule",
+          "nonlooping": true
+        },
+        {
+          "title": "Credits",
+          "name": "Staff Roll",
+          "nonlooping": true
+        }
+      ],
+      "extended": [
+        {
+          "title": "Eastern Palace",
+          "fallback": 17
+        },
+        {
+          "title": "Desert Palace",
+          "fallback": 17
+        },
+        {
+          "title": "Agahnim's Tower",
+          "fallback": 16
+        },
+        {
+          "title": "Swamp Palace",
+          "fallback": 22
+        },
+        {
+          "title": "Palace of Darkness",
+          "fallback": 22
+        },
+        {
+          "title": "Misery Mire",
+          "fallback": 22
+        },
+        {
+          "title": "Skull Woods",
+          "fallback": 22
+        },
+        {
+          "title": "Ice Palace",
+          "fallback": 22
+        },
+        {
+          "title": "Tower of Hera",
+          "fallback": 17
+        },
+        {
+          "title": "Thieves' Town",
+          "fallback": 22
+        },
+        {
+          "title": "Turtle Rock",
+          "fallback": 22
+        },
+        {
+          "title": "Ganon's Tower",
+          "fallback": 22
+        },
+        {
+          "title": "Eastern Palace Boss",
+          "fallback": 21
+        },
+        {
+          "title": "Desert Palace Boss",
+          "fallback": 21
+        },
+        {
+          "title": "Agahnim's Tower Boss",
+          "fallback": 21
+        },
+        {
+          "title": "Swamp Palace Boss",
+          "fallback": 21
+        },
+        {
+          "title": "Palace of Darkness Boss",
+          "fallback": 21
+        },
+        {
+          "title": "Misery Mire Boss",
+          "fallback": 21
+        },
+        {
+          "title": "Skull Woods Boss",
+          "fallback": 21
+        },
+        {
+          "title": "Ice Palace Boss",
+          "fallback": 21
+        },
+        {
+          "title": "Tower of Hera Boss",
+          "fallback": 21
+        },
+        {
+          "title": "Thieves' Town Boss",
+          "fallback": 21
+        },
+        {
+          "title": "Turtle Rock Boss",
+          "fallback": 21
+        },
+        {
+          "title": "Ganon's Tower Boss",
+          "fallback": 21
+        },
+        {
+          "title": "Ganon's Tower 2",
+          "fallback": 22,
+          "remap": 46
+        },
+        {
+          "title": "Light World 2",
+          "fallback": 2
+        },
+        {
+          "title": "Dark World 2",
+          "fallback": 9
+        }
+      ],
+      "longest": 50,
+      "src": "https://www.romhacking.net/hacks/2483/"
+    }
+  },
+  {
+    "meta": {
+      "name": "Super Metroid"
+    },
+    "tracks": {
+      "basic": [
+        {
+          "title": "File Start",
+          "name": "Samus Aran's Appearance Fanfare",
+          "nonlooping": true
+        },
+        {
+          "title": "Item Acquisition Fanfare",
+          "nonlooping": true
+        },
+        {
+          "title": "Item room"
+        },
+        {
+          "title": "Opening with intro",
+          "pair": 5
+        },
+        {
+          "title": "Opening without intro",
+          "pair": 4
+        },
+        {
+          "title": "Crateria (First Landing Thunder)",
+          "name": "Arrival on Crateria (with thunder FX)"
+        },
+        {
+          "title": "Crateria (First Landing No Thunder)",
+          "name": "Arrival on Crateria (without thunder FX)"
+        },
+        {
+          "title": "Crateria",
+          "name": "The Space Pirates Appear"
+        },
+        {
+          "title": "Crateria Statue Room",
+          "name": "Statue Room"
+        },
+        {
+          "title": "Samus' Ship",
+          "name": "Theme of Samus Aran"
+        },
+        {
+          "title": "Brinstar with vegetation"
+        },
+        {
+          "title": "Brinstar Red Soil"
+        },
+        {
+          "title": "Upper Norfair"
+        },
+        {
+          "title": "Lower Norfair"
+        },
+        {
+          "title": "Upper Maridia"
+        },
+        {
+          "title": "Lower Maridia"
+        },
+        {
+          "title": "Tourian"
+        },
+        {
+          "title": "Mother Brain Battle"
+        },
+        {
+          "title": "Big Boss Battle 1"
+        },
+        {
+          "title": "Evacuation"
+        },
+        {
+          "title": "Mysterious Statue Chamber",
+          "name": "Chozo Statue Awakens"
+        },
+        {
+          "title": "Big Boss Battle 2",
+          "pair": 23
+        },
+        {
+          "title": "Tension / Hostile Incoming",
+          "pair": 22
+        },
+        {
+          "title": "Plant Miniboss"
+        },
+        {
+          "title": "Ceres Station"
+        },
+        {
+          "title": "Wrecked Ship Power Off"
+        },
+        {
+          "title": "Wrecked Ship Power On"
+        },
+        {
+          "title": "Theme of Super Metroid"
+        },
+        {
+          "title": "Death Cry",
+          "nonlooping": true
+        },
+        {
+          "title": "Ending",
+          "nonlooping": true
+        }
+      ],
+      "extended": [
+        {
+          "title": "Kraid Incoming",
+          "pair": 32,
+          "fallback": 23
+        },
+        {
+          "title": "Kraid Battle",
+          "pair": 31,
+          "fallback": 22
+        },
+        {
+          "title": "Phantoon Incoming",
+          "pair": 34,
+          "fallback": 23
+        },
+        {
+          "title": "Phantoon Battle",
+          "pair": 33,
+          "fallback": 22
+        },
+        {
+          "title": "Draygon Battle",
+          "fallback": 19
+        },
+        {
+          "title": "Ridley Battle",
+          "fallback": 19
+        },
+        {
+          "title": "Baby Incoming",
+          "pair": 38,
+          "fallback": 23
+        },
+        {
+          "title": "The Baby",
+          "pair": 37,
+          "fallback": 22
+        },
+        {
+          "title": "Hyper Beam",
+          "fallback": 10
+        },
+        {
+          "title": "Game Over"
+        }
+      ]
+    }
+  },
+  {
+    "meta": {
+      "name": "Super Metroid / A Link to the Past Combination Randomizer"
+    },
+    "tracks": {
+      "basic": [
+        {
+          "num": 99,
+          "title": "SMZ3 Credits",
+          "nonlooping": true
+        }
+      ]
+    },
+    "copy": [
+      {
+        "msu": "The Legend of Zelda: A Link to the Past",
+        "modifier": 0,
+        "ignore": [
+          1,
+          3,
+          6,
+          25,
+          34
+        ]
+      },
+      {
+        "msu": "Super Metroid",
+        "modifier": 100,
+        "ignore": [
+          102,
+          107,
+          125,
+          128
+        ]
+      }
+    ]
+  },
+  {
+    "meta": {
+      "name": "Super Metroid / A Link to the Past Combination Randomizer Legacy",
+      "selectable": false,
+      "exactmatches": [
+        "Super Metroid / A Link to the Past Combination Randomizer"
+      ]
+    },
+    "tracks": {
+      "basic": [
+        {
+          "num": 99,
+          "title": "SMZ3 Credits",
+          "nonlooping": true
+        }
+      ]
+    },
+    "copy": [
+      {
+        "msu": "The Legend of Zelda: A Link to the Past",
+        "modifier": 100,
+        "ignore": [
+          101,
+          103,
+          106,
+          125,
+          134
+        ]
+      },
+      {
+        "msu": "Super Metroid",
+        "modifier": 0,
+        "ignore": [
+          2,
+          7,
+          25,
+          28
+        ]
+      }
+    ]
+  }
+]

--- a/src/Randomizer.Data/Configuration/ConfigFiles/MsuConfig.cs
+++ b/src/Randomizer.Data/Configuration/ConfigFiles/MsuConfig.cs
@@ -1,0 +1,140 @@
+﻿using System.Collections.Generic;
+using Randomizer.Data.Configuration.ConfigTypes;
+
+namespace Randomizer.Data.Configuration.ConfigFiles;
+
+public class MsuConfig : IMergeable<MsuConfig>, IConfigFile<MsuConfig>
+{
+    /// <summary>
+    /// Names for various tracks when asking "what's the current song for"
+    /// </summary>
+    public Dictionary<int, SchrodingersString> TrackLocations = new Dictionary<int, SchrodingersString>()
+    {
+        { 2, new SchrodingersString("light world", "hyrule field") },
+        { 4, new SchrodingersString("bunny") },
+        { 5, new SchrodingersString("lost woods") },
+        { 7, new SchrodingersString("kakariko", "kakariko village", "link's house") },
+        { 8, new SchrodingersString("mirror") },
+        { 9, new SchrodingersString("dark world") },
+        { 10, new SchrodingersString("pedestal pull", "master sword pedestal", "pedestal") },
+        { 11, new SchrodingersString("zelda game over") },
+        { 12, new SchrodingersString("guards") },
+        { 13, new SchrodingersString("dark death mountain") },
+        { 14, new SchrodingersString("minigame") },
+        { 15, new SchrodingersString("dark woods") },
+        { 16, new SchrodingersString("hyrule castle") },
+        { 17, new SchrodingersString("pendant dungeon") },
+        { 18, new SchrodingersString("cave 1", "mini moldorm cave", "superbunny cave", "paradox cave", "spike cave", "spiral cave", "Kakariko well", "bumper cave", "hype cave", "link's uncle", "checkerboard cave", "hookshot cave", "Mire shed", "hammer pegs") },
+        { 19, new SchrodingersString("boss victory", "Boss fanfare") },
+        { 20, new SchrodingersString("sanctuary") },
+        { 21, new SchrodingersString("zelda boss battle") },
+        { 22, new SchrodingersString("crystal dungeon") },
+        { 23, new SchrodingersString("shop") },
+        { 24, new SchrodingersString("cave 2", "lost woods hideout", "king's tomb", "dam", "swamp ruins", "waterfall fairy", "magic bat", "graveyard ledge", "sahasrahla", "pyramid fair", "aginah", "cave 45", "cave number 45") },
+        { 26, new SchrodingersString("crystal retrieved", "crystal get") },
+        { 27, new SchrodingersString("fairy", "great fairy", "ice rod cave") },
+        { 28, new SchrodingersString("agahnims floor") },
+        { 29, new SchrodingersString("ganon reveal", "ganon bat") },
+        { 30, new SchrodingersString("ganons message", "ganon intro") },
+        { 31, new SchrodingersString("ganon battle", "ganon fight") },
+        { 32, new SchrodingersString("triforce room") },
+        { 33, new SchrodingersString("epilogue", "zelda epilogue", "zelda credits") },
+        { 35, new SchrodingersString("eastern palace") },
+        { 36, new SchrodingersString("desert palace") },
+        { 37, new SchrodingersString("agahnims tower") },
+        { 38, new SchrodingersString("swamp palace") },
+        { 39, new SchrodingersString("palace of darkness", "dark palace") },
+        { 40, new SchrodingersString("misery mire") },
+        { 41, new SchrodingersString("skull woods") },
+        { 42, new SchrodingersString("ice palace") },
+        { 43, new SchrodingersString("tower of hera") },
+        { 44, new SchrodingersString("thieves town") },
+        { 45, new SchrodingersString("turtle rock") },
+        { 46, new SchrodingersString("ganons tower") },
+        { 47, new SchrodingersString("armos knights") },
+        { 48, new SchrodingersString("lanmolas") },
+        { 49, new SchrodingersString("agahnim 1") },
+        { 50, new SchrodingersString("arrghus") },
+        { 51, new SchrodingersString("helmasaur king") },
+        { 52, new SchrodingersString("vitreous") },
+        { 53, new SchrodingersString("mothula") },
+        { 54, new SchrodingersString("kholdstare") },
+        { 55, new SchrodingersString("moldorm") },
+        { 56, new SchrodingersString("blind") },
+        { 57, new SchrodingersString("trinexx") },
+        { 58, new SchrodingersString("agahnim 2") },
+        { 59, new SchrodingersString("ganons tower climb", "g t climb") },
+        { 60, new SchrodingersString("light world 2") },
+        { 61, new SchrodingersString("dark world 2") },
+        { 99, new SchrodingersString("s m z 3 credits") },
+        { 101, new SchrodingersString("samus fanfare") },
+        { 102, new SchrodingersString("item acquired") },
+        { 103, new SchrodingersString("item room", "elevator room") },
+        { 104, new SchrodingersString("metroid opening with intro") },
+        { 105, new SchrodingersString("metroid opening without intro") },
+        { 106, new SchrodingersString("crateria landing with thunder", "crateria landing") },
+        { 107, new SchrodingersString("crateria landing without thunder") },
+        { 108, new SchrodingersString("crateria space pirates appear", "blue brinstar", "crateria 1", "space pirates appear") },
+        { 109, new SchrodingersString("golden statues", "golden four") },
+        { 110, new SchrodingersString("samus aran theme", "crateria 2") },
+        { 111, new SchrodingersString("green brinstar", "pink brinstar") },
+        { 112, new SchrodingersString("red brinstar", "kraid's lair") },
+        { 113, new SchrodingersString("upper norfair") },
+        { 114, new SchrodingersString("lower norfair") },
+        { 115, new SchrodingersString("inner maridia") },
+        { 116, new SchrodingersString("outer maridia") },
+        { 117, new SchrodingersString("tourian") },
+        { 118, new SchrodingersString("mother brain") },
+        { 119, new SchrodingersString("big boss battle 1", "bozo", "bomb torizo", "golden torizo") },
+        { 120, new SchrodingersString("evacuation", "escape") },
+        { 121, new SchrodingersString("chozo statue awakens", "mysterious statue chamber") },
+        { 122, new SchrodingersString("big boss battle 2", "crocomire") },
+        { 123, new SchrodingersString("tension", "boss incoming", "hostile incoming") },
+        { 124, new SchrodingersString("plant miniboss", "spore spawn", "botwoon") },
+        { 126, new SchrodingersString("wrecked ship powered off") },
+        { 127, new SchrodingersString("wrecked ship powered on") },
+        { 128, new SchrodingersString("theme of super metroid") },
+        { 129, new SchrodingersString("death cry", "samus death") },
+        { 130, new SchrodingersString("metroid credits") },
+        { 131, new SchrodingersString("kraid incoming") },
+        { 132, new SchrodingersString("kraid battle", "kraid fight") },
+        { 133, new SchrodingersString("phantoon incoming") },
+        { 134, new SchrodingersString("phantoon battle", "phantoon fight") },
+        { 135, new SchrodingersString("draygon battle", "draygon fight") },
+        { 136, new SchrodingersString("ridley battle", "ridley fight") },
+        { 137, new SchrodingersString("baby incoming") },
+        { 138, new SchrodingersString("the baby") },
+        { 139, new SchrodingersString("hyper beam") },
+        { 140, new SchrodingersString("metroid game over", "super metroid game over") },
+    };
+
+    /// <summary>
+    /// Gets the phrases for what song is playing
+    /// </summary>
+    /// <remarks>
+    /// <c>{0}</c> is a placeholder for the song details
+    /// </remarks>
+    public SchrodingersString? CurrentSong { get; init; } = new("That's {0}", "That song is {0}");
+
+    /// <summary>
+    /// Gets the phrases for what msu the current song is from
+    /// </summary>
+    /// <remarks>
+    /// <c>{0}</c> is a placeholder for the msu details
+    /// </remarks>
+    public SchrodingersString? CurrentMsu { get; init; } = new("The song is from the MSU pack {0}", "That song is from {0}");
+
+    /// <summary>
+    /// Gets the phrases for not being able to determine the playing song
+    /// </summary>
+    public SchrodingersString? UnknownSong { get; init; } = new("Sorry, I could not get the song details");
+
+    /// <summary>
+    /// Returns default response information
+    /// </summary>
+    /// <returns></returns>
+    public static MsuConfig Default()
+    {
+        return new MsuConfig();
+    }
+}

--- a/src/Randomizer.Data/Configuration/ConfigProvider.cs
+++ b/src/Randomizer.Data/Configuration/ConfigProvider.cs
@@ -174,6 +174,14 @@ namespace Randomizer.Data.Configuration
             LoadYamlConfigs<GameLinesConfig, GameLinesConfig>("game.yml", profiles);
 
         /// <summary>
+        /// Returns the configs with msus
+        /// </summary>
+        /// <param name="profiles">The selected tracker profile(s) to load</param>
+        /// <returns></returns>
+        public virtual MsuConfig GetMsuConfig(params string?[] profiles) =>
+            LoadYamlConfigs<MsuConfig, MsuConfig>("msu.yml", profiles);
+
+        /// <summary>
         /// Returns a collection of all possible config profiles to
         /// select from
         /// </summary>

--- a/src/Randomizer.Data/Configuration/ConfigServiceCollectionExtensions.cs
+++ b/src/Randomizer.Data/Configuration/ConfigServiceCollectionExtensions.cs
@@ -88,6 +88,12 @@ namespace Randomizer.Data.Configuration
                 return configs.GameLines;
             });
 
+            services.AddScoped(serviceProvider =>
+            {
+                var configs = serviceProvider.GetRequiredService<Configs>();
+                return configs.MsuConfig;
+            });
+
             return services;
         }
     }

--- a/src/Randomizer.Data/Configuration/Configs.cs
+++ b/src/Randomizer.Data/Configuration/Configs.cs
@@ -34,6 +34,7 @@ namespace Randomizer.Data.Configuration
             Rewards = provider.GetRewardConfig(profiles);
             UILayouts = provider.GetUIConfig(profiles);
             GameLines = provider.GetGameConfig(profiles);
+            MsuConfig = provider.GetMsuConfig(profiles);
         }
 
         /// <summary>
@@ -120,5 +121,10 @@ namespace Randomizer.Data.Configuration
         /// Gets the in game lines
         /// </summary>
         public GameLinesConfig GameLines { get; }
+
+        /// <summary>
+        /// Gets the msu config
+        /// </summary>
+        public MsuConfig MsuConfig { get; }
     }
 }

--- a/src/Randomizer.Data/Configuration/Yaml/README.md
+++ b/src/Randomizer.Data/Configuration/Yaml/README.md
@@ -23,6 +23,7 @@ Next you can then either copy the yml files from the Templates folder or create 
 - **responses.yml** - Responses for specific actions performed by the user
 - **rewards.yml** - Additional reward information
 - **rooms.yml** - Additional room information
+- **msu.yml** - Responses and configurations for MSU details
 
 **NOTE:** Contained inside each of the template yaml files is additional details on what can be modified for Tracker to say or understand.
 

--- a/src/Randomizer.Data/Options/GeneralOptions.cs
+++ b/src/Randomizer.Data/Options/GeneralOptions.cs
@@ -71,6 +71,8 @@ namespace Randomizer.Data.Options
         public string RomOutputPath { get; set; }
             = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SMZ3CasRandomizer", "Seeds");
 
+        public string? MsuPath { get; set; }
+
         public string AutoTrackerScriptsOutputPath { get; set; }
             = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SMZ3CasRandomizer", "AutoTrackerScripts");
 

--- a/src/Randomizer.Data/Options/PatchOptions.cs
+++ b/src/Randomizer.Data/Options/PatchOptions.cs
@@ -1,7 +1,9 @@
-﻿using System.ComponentModel;
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.IO;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
+using MSURandomizerLibrary;
 
 namespace Randomizer.Data.Options
 {
@@ -12,6 +14,10 @@ namespace Randomizer.Data.Options
     public class PatchOptions : INotifyPropertyChanged
     {
         private string _msu1Path = "";
+        private string _msuName = "";
+        private MsuRandomizationStyle? _msuRandomizationStyle;
+        private List<string> _msuPaths = new List<string>();
+
 
         public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -34,6 +40,45 @@ namespace Randomizer.Data.Options
                     _msu1Path = value;
                     OnPropertyChanged(nameof(Msu1Path));
                     OnPropertyChanged(nameof(CanEnableExtendedSoundtrack));
+                }
+            }
+        }
+
+        public string MsuName
+        {
+            get => _msuName;
+            set
+            {
+                if (value != _msuName)
+                {
+                    _msuName = value;
+                    OnPropertyChanged(nameof(MsuName));
+                }
+            }
+        }
+
+        public List<string> MsuPaths
+        {
+            get => _msuPaths;
+            set
+            {
+                if (value != _msuPaths)
+                {
+                    _msuPaths = value;
+                    OnPropertyChanged(nameof(MsuPaths));
+                }
+            }
+        }
+
+        public MsuRandomizationStyle? MsuRandomizationStyle
+        {
+            get => _msuRandomizationStyle;
+            set
+            {
+                if (value != _msuRandomizationStyle)
+                {
+                    _msuRandomizationStyle = value;
+                    OnPropertyChanged(nameof(MsuRandomizationStyle));
                 }
             }
         }

--- a/src/Randomizer.Data/Options/RandomizerOptions.cs
+++ b/src/Randomizer.Data/Options/RandomizerOptions.cs
@@ -59,6 +59,7 @@ namespace Randomizer.Data.Options
         public bool EarlyItemsExpanded { get; set; } = false;
 
         public bool CustomizationExpanded { get; set; } = false;
+        public bool LocationExpanded { get; set; } = false;
         public bool LogicExpanded { get; set; } = false;
 
         public bool CommonExpanded { get; set; } = false;

--- a/src/Randomizer.Data/Randomizer.Data.csproj
+++ b/src/Randomizer.Data/Randomizer.Data.csproj
@@ -58,6 +58,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="MattEqualsCoder.MSURandomizer.Library" Version="1.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="YamlDotNet" Version="13.1.1" />
   </ItemGroup>

--- a/src/Randomizer.Multiplayer.Server/Randomizer.Multiplayer.Server.csproj
+++ b/src/Randomizer.Multiplayer.Server/Randomizer.Multiplayer.Server.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>2.1.1</Version>
+    <Version>2.1.2</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
   </PropertyGroup>
 

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/SpeckyClip.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/SpeckyClip.cs
@@ -17,9 +17,9 @@
         {
             var inCorrectLocation = currentState is
                 { CurrentRoom: 55, IsOnBottomHalfOfRoom: true, IsOnRightHalfOfRoom: false };
-            var prevInWall = prevState.LinkY is >= 1845 and <= 1855;
+            var prevInWall = prevState.LinkY is >= 1840 and <= 1863;
             var nowBelowWall = currentState is
-                { LinkX: >= 3665, LinkX: <= 3695, LinkY: >= 1858, LinkY: <= 1875, CurrentRoom: 55 };
+                { LinkX: >= 3650, LinkX: <= 3696, LinkY: >= 1864, LinkY: <= 1872, CurrentRoom: 55 };
             if (inCorrectLocation && prevInWall && nowBelowWall)
             {
                 tracker.Say(x => x.AutoTracker.SpeckyClip);

--- a/src/Randomizer.SMZ3.Tracking/Randomizer.SMZ3.Tracking.csproj
+++ b/src/Randomizer.SMZ3.Tracking/Randomizer.SMZ3.Tracking.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="BunLabs.Common" Version="1.0.4" />
+    <PackageReference Include="MattEqualsCoder.MSURandomizer.Library" Version="1.0.1" />
     <PackageReference Include="System.Speech" Version="7.0.0" />
     <PackageReference Include="Websocket.Client" Version="4.6.1" />
     <PackageReference Include="YamlDotNet" Version="13.1.1" />

--- a/src/Randomizer.SMZ3.Tracking/Tracker.cs
+++ b/src/Randomizer.SMZ3.Tracking/Tracker.cs
@@ -295,6 +295,11 @@ namespace Randomizer.SMZ3.Tracking
         public GeneratedRom? Rom { get; private set; }
 
         /// <summary>
+        /// The path to the generated rom
+        /// </summary>
+        public string? RomPath { get; private set; }
+
+        /// <summary>
         /// The region the player is currently in according to the Auto Tracker
         /// </summary>
         public RegionInfo? CurrentRegion { get; private set; }
@@ -406,11 +411,13 @@ namespace Randomizer.SMZ3.Tracking
         /// Loads the state from the database for a given rom
         /// </summary>
         /// <param name="rom">The rom to load</param>
+        /// <param name="romPath">The full path to the rom to load</param>
         /// <returns>True or false if the load was successful</returns>
-        public bool Load(GeneratedRom rom)
+        public bool Load(GeneratedRom rom, string romPath)
         {
             IsDirty = false;
             Rom = rom;
+            RomPath = romPath;
             var trackerState = _stateService.LoadState(_worldAccessor.Worlds, rom);
 
             if (trackerState != null)

--- a/src/Randomizer.Shared/Migrations/20230819021736_MsuPaths.Designer.cs
+++ b/src/Randomizer.Shared/Migrations/20230819021736_MsuPaths.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Randomizer.Shared.Models;
 
@@ -10,9 +11,11 @@ using Randomizer.Shared.Models;
 namespace Randomizer.Shared.Migrations
 {
     [DbContext(typeof(RandomizerContext))]
-    partial class RandomizerContextModelSnapshot : ModelSnapshot
+    [Migration("20230819021736_MsuPaths")]
+    partial class MsuPaths
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "7.0.9");
@@ -35,9 +38,6 @@ namespace Randomizer.Shared.Migrations
 
                     b.Property<string>("MsuPaths")
                         .HasColumnType("TEXT");
-
-                    b.Property<int?>("MsuRandomizationStyle")
-                        .HasColumnType("INTEGER");
 
                     b.Property<long?>("MultiplayerGameDetailsId")
                         .HasColumnType("INTEGER");

--- a/src/Randomizer.Shared/Migrations/20230819021736_MsuPaths.cs
+++ b/src/Randomizer.Shared/Migrations/20230819021736_MsuPaths.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Randomizer.Shared.Migrations
+{
+    /// <inheritdoc />
+    public partial class MsuPaths : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "MsuPaths",
+                table: "GeneratedRoms",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MsuPaths",
+                table: "GeneratedRoms");
+        }
+    }
+}

--- a/src/Randomizer.Shared/Migrations/20230819130906_MsuRandomizationStyle.Designer.cs
+++ b/src/Randomizer.Shared/Migrations/20230819130906_MsuRandomizationStyle.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Randomizer.Shared.Models;
 
@@ -10,9 +11,11 @@ using Randomizer.Shared.Models;
 namespace Randomizer.Shared.Migrations
 {
     [DbContext(typeof(RandomizerContext))]
-    partial class RandomizerContextModelSnapshot : ModelSnapshot
+    [Migration("20230819130906_MsuRandomizationStyle")]
+    partial class MsuRandomizationStyle
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "7.0.9");

--- a/src/Randomizer.Shared/Migrations/20230819130906_MsuRandomizationStyle.cs
+++ b/src/Randomizer.Shared/Migrations/20230819130906_MsuRandomizationStyle.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Randomizer.Shared.Migrations
+{
+    /// <inheritdoc />
+    public partial class MsuRandomizationStyle : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "MsuRandomizationStyle",
+                table: "GeneratedRoms",
+                type: "INTEGER",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MsuRandomizationStyle",
+                table: "GeneratedRoms");
+        }
+    }
+}

--- a/src/Randomizer.Shared/Models/GeneratedRom.cs
+++ b/src/Randomizer.Shared/Models/GeneratedRom.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Diagnostics.CodeAnalysis;
+using MSURandomizerLibrary;
 using Randomizer.Shared.Multiplayer;
 
 namespace Randomizer.Shared.Models
@@ -20,6 +21,8 @@ namespace Randomizer.Shared.Models
         public string SpoilerPath { get; init; } = "";
         [ForeignKey("MultiplayerGameDetails")]
         public long? MultiplayerGameDetailsId { get; set; }
+        public string? MsuPaths { get; set; }
+        public MsuRandomizationStyle? MsuRandomizationStyle { get; set; }
         public virtual MultiplayerGameDetails? MultiplayerGameDetails { get; set; }
         public TrackerState? TrackerState { get; set; }
 

--- a/src/Randomizer.Shared/Randomizer.Shared.csproj
+++ b/src/Randomizer.Shared/Randomizer.Shared.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MattEqualsCoder.MSURandomizer.Library" Version="1.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.9">

--- a/src/Randomizer.Tools/RomGenerator.cs
+++ b/src/Randomizer.Tools/RomGenerator.cs
@@ -147,11 +147,11 @@ public class RomGenerator
 
         if (copyMsu)
         {
-            var msuGenerator = new MsuGeneratorService();
+            /*var msuGenerator = new MsuGeneratorService();
             if (!msuGenerator.EnableMsu1Support(MsuPath, romPath, out var error))
             {
                 throw new Exception(error);
-            }
+            }*/
         }
 
         if (openRom)


### PR DESCRIPTION
This pulls in the MSU Randomizer Library and UI to allow people to select and randomize MSUs rather than have to pick the MSU by browsing through their filesystem. It also implements the basic track commands for "what is the current song for X" and "what MSU pack is the current song for X from?".

This also fixes the Specky Clip detection. Meant to split that out, but forgot. Whoops.

Wanted to get this out there before I went to bed for the night. I'll proofread tomorrow myself for if I need to add more comments or things like that.