### PR TITLE
Temp workaround for starting flutes

### DIFF
--- a/src/Randomizer.Data/Options/ItemSettingOptions.yml
+++ b/src/Randomizer.Data/Options/ItemSettingOptions.yml
@@ -202,7 +202,7 @@
     - Flute
   - Display: Start with Flute
     MemoryValues:
-      12: 3
+      12: 2
     MatchingItemTypes:
     - Flute
 - Item: Bug Net


### PR DESCRIPTION
This is related to #371, but doesn't fully fix it.

Basically, starting with a flute breaks being able to switch to the shovel when you get it. This is probably related to the split shovel/flute items and will need some other memory adjustments that I'll need to figure out. However, when testing, I found that when you activate the flute, it sort of works itself out, so for now I'm updating it to require you to activate the flute if you start with it.