### PR TITLE
Allow customizing qusb2snes ip address

### DIFF
--- a/src/Randomizer.App/Windows/OptionsWindow.xaml
+++ b/src/Randomizer.App/Windows/OptionsWindow.xaml
@@ -223,6 +223,11 @@
                 </Grid>
               </controls:LabeledControl>
 
+              <controls:LabeledControl Text="QUSB2SNES Ip Address:"
+                                       ToolTip="QUSB2SNES override IP address. Leave blank to use the default">
+                <TextBox Text="{Binding AutoTrackerQUsb2SnesIp}"/>
+              </controls:LabeledControl>
+
               <controls:LabeledControl Text="Current song display style:"
                                        ToolTip="Changes the orientation of the information displayed in the current song window and the written text file with the current song.">
                 <ComboBox SelectedItem="{Binding MsuTrackDisplayStyle}"

--- a/src/Randomizer.App/Windows/TrackerWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/TrackerWindow.xaml.cs
@@ -805,7 +805,7 @@ namespace Randomizer.App.Windows
             };
             _autoTrackerDisableMenuItem.Click += (sender, e) =>
             {
-                Tracker.AutoTracker?.SetConnector(EmulatorConnectorType.None);
+                Tracker.AutoTracker?.SetConnector(EmulatorConnectorType.None, "");
             };
             menu.Items.Add(_autoTrackerDisableMenuItem);
 
@@ -816,7 +816,7 @@ namespace Randomizer.App.Windows
             };
             _autoTrackerLuaMenuItem.Click += (sender, e) =>
             {
-                Tracker.AutoTracker?.SetConnector(EmulatorConnectorType.Lua);
+                Tracker.AutoTracker?.SetConnector(EmulatorConnectorType.Lua, "");
             };
             menu.Items.Add(_autoTrackerLuaMenuItem);
 
@@ -827,7 +827,7 @@ namespace Randomizer.App.Windows
             };
             _autoTrackerUSB2SNESMenuItem.Click += (sender, e) =>
             {
-                Tracker.AutoTracker?.SetConnector(EmulatorConnectorType.USB2SNES);
+                Tracker.AutoTracker?.SetConnector(EmulatorConnectorType.USB2SNES, _options.AutoTrackerQUsb2SnesIp);
             };
             menu.Items.Add(_autoTrackerUSB2SNESMenuItem);
 
@@ -877,7 +877,7 @@ namespace Randomizer.App.Windows
             Tracker.AutoTracker.AutoTrackerConnected += (sender, e) => Dispatcher.Invoke(UpdateAutoTrackerMenu);
             Tracker.AutoTracker.AutoTrackerDisconnected += (sender, e) => Dispatcher.Invoke(UpdateAutoTrackerMenu);
 
-            Tracker.AutoTracker.SetConnector(_options.AutoTrackerDefaultConnector);
+            Tracker.AutoTracker.SetConnector(_options.AutoTrackerDefaultConnector, _options.AutoTrackerQUsb2SnesIp);
         }
 
         private void UpdateAutoTrackerMenu()

--- a/src/Randomizer.Data/Options/GeneralOptions.cs
+++ b/src/Randomizer.Data/Options/GeneralOptions.cs
@@ -99,6 +99,8 @@ namespace Randomizer.Data.Options
 
         public int AutoTrackerDefaultConnector { get; set; } = (int)EmulatorConnectorType.None;
 
+        public string? AutoTrackerQUsb2SnesIp { get; set; }
+
         public bool AutoTrackerChangeMap { get; set; }
         public int UndoExpirationTime { get; set; } = 3;
 

--- a/src/Randomizer.Data/Options/RandomizerOptions.cs
+++ b/src/Randomizer.Data/Options/RandomizerOptions.cs
@@ -90,6 +90,11 @@ namespace Randomizer.Data.Options
             get => (EmulatorConnectorType)GeneralOptions.AutoTrackerDefaultConnector;
         }
 
+        public string? AutoTrackerQUsb2SnesIp
+        {
+            get => GeneralOptions.AutoTrackerQUsb2SnesIp;
+        }
+
         public static RandomizerOptions Load(string path)
         {
             var json = File.ReadAllText(path);

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/AutoTracker.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/AutoTracker.cs
@@ -293,7 +293,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// <summary>
         /// Disables the current connector and creates the requested type
         /// </summary>
-        public void SetConnector(EmulatorConnectorType type)
+        public void SetConnector(EmulatorConnectorType type, string? qusb2SnesIp)
         {
             if (_connector != null)
             {
@@ -305,7 +305,7 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
             {
                 if (type == EmulatorConnectorType.USB2SNES)
                 {
-                    _connector = new USB2SNESConnector(_loggerFactory.CreateLogger<USB2SNESConnector>());
+                    _connector = new USB2SNESConnector(_loggerFactory.CreateLogger<USB2SNESConnector>(), qusb2SnesIp);
                 }
                 else
                 {

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/USB2SNESConnector.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/USB2SNESConnector.cs
@@ -26,13 +26,15 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         /// Constructor
         /// </summary>
         /// <param name="logger"></param>
-        public USB2SNESConnector(ILogger<USB2SNESConnector> logger)
+        /// <param name="qusb2SnesIp"></param>
+        public USB2SNESConnector(ILogger<USB2SNESConnector> logger, string? qusb2SnesIp)
         {
             _logger = logger;
 
             _lastMessage = null;
 
-            var url = new Uri("ws://localhost:8080");
+            var ip = string.IsNullOrEmpty(qusb2SnesIp) ? "localhost" : qusb2SnesIp;
+            var url = new Uri($"ws://{ip}:8080");
 
             _client = new WebsocketClient(url);
             _client.ReconnectTimeout = TimeSpan.FromSeconds(5);

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/AutoTrackerModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/AutoTrackerModule.cs
@@ -56,7 +56,7 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
         /// </summary>
         public void Dispose()
         {
-            _autoTracker.SetConnector(EmulatorConnectorType.None);
+            _autoTracker.SetConnector(EmulatorConnectorType.None, "");
         }
     }
 


### PR DESCRIPTION
Updated to be able to specify the IP address to use a non-localhost IP address. Needed for my current funky setup of having SMZ3 in a VM and RetroArch on Linux.