### PR TITLE
Cancel MSU resume when tracks shuffle

### DIFF
--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/GameService.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/GameService.cs
@@ -41,6 +41,38 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
         }
 
         /// <summary>
+        /// Updates memory values so both SM and Z3 will cancel any pending MSU resumes and play
+        /// all tracks from the start until new resume points have been stored.
+        /// </summary>
+        /// <returns>True, even if it didn't do anything</returns>
+        public void TryCancelMsuResume()
+        {
+            if (IsInGame(Game.SM))
+            {
+                // Zero out SM's NO_RESUME_AFTER variable
+                AutoTracker?.WriteToMemory(new EmulatorAction()
+                {
+                    Type = EmulatorActionType.WriteBytes,
+                    Domain = MemoryDomain.WRAM,
+                    Address = 0x7E033A, // As declared in sm/msu.asm
+                    WriteValues = new List<byte>() { 0, 0 }
+                });
+            }
+
+            if (IsInGame(Game.Zelda))
+            {
+                // Zero out Z3's MSUResumeTime variable
+                AutoTracker?.WriteToMemory(new EmulatorAction()
+                {
+                    Type = EmulatorActionType.WriteBytes,
+                    Domain = MemoryDomain.WRAM,
+                    Address = 0x7E1E6B, // As declared in z3/randomizer/ram.asm
+                    WriteValues = new List<byte>() { 0, 0, 0, 0 }
+                });
+            }
+        }
+
+        /// <summary>
         /// Gives an item to the player
         /// </summary>
         /// <param name="item">The item to give</param>

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/MsuModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/MsuModule.cs
@@ -353,6 +353,7 @@ public class MsuModule : TrackerModule, IDisposable
             Logger.LogError(exception, "Error creating MSU");
         }
 
+        Tracker.GameService?.TryCancelMsuResume();
     }
 
     public void Dispose()


### PR DESCRIPTION
I wasn't sure if it made more sense to do the emulator writes in `GameService` or do them straight from `MsuModule`, so I went for `GameService`, but I can move it if I need to, since `MsuModule` also has a `Tracker` property and can get to `AutoTracker` from there. Let me know!

Otherwise, this seems to be working. The only downside is it might unnecessarily cancel resume on the rare occasion a resumable track gets shuffled and winds up as the same track, but I don't think we need to worry about it too much?

Closes #386.