### PR TITLE
Initial implementation of cross platform randomizer

### DIFF
--- a/CasRandomizer.sln
+++ b/CasRandomizer.sln
@@ -43,6 +43,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Randomizer.Sprites", "src\R
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Randomizer.PatchBuilder", "src\Randomizer.PatchBuilder\Randomizer.PatchBuilder.csproj", "{F4C0D33B-CAE0-4F70-95B8-0D1B44F4B927}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Randomizer.CrossPlatform", "src\Randomizer.CrossPlatform\Randomizer.CrossPlatform.csproj", "{B18DD122-3612-4948-B512-464D410A271B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -101,6 +103,10 @@ Global
 		{F4C0D33B-CAE0-4F70-95B8-0D1B44F4B927}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F4C0D33B-CAE0-4F70-95B8-0D1B44F4B927}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F4C0D33B-CAE0-4F70-95B8-0D1B44F4B927}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B18DD122-3612-4948-B512-464D410A271B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B18DD122-3612-4948-B512-464D410A271B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B18DD122-3612-4948-B512-464D410A271B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B18DD122-3612-4948-B512-464D410A271B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Randomizer.App/App.xaml.cs
+++ b/src/Randomizer.App/App.xaml.cs
@@ -141,6 +141,7 @@ namespace Randomizer.App
 
             // Misc
             services.AddGitHubReleaseCheckerServices();
+            services.AddSingleton<IGameDbService, GameDbService>();
         }
 
         private void Application_Startup(object sender, StartupEventArgs e)

--- a/src/Randomizer.App/App.xaml.cs
+++ b/src/Randomizer.App/App.xaml.cs
@@ -142,6 +142,7 @@ namespace Randomizer.App
             // Misc
             services.AddGitHubReleaseCheckerServices();
             services.AddSingleton<IGameDbService, GameDbService>();
+            services.AddTransient<SourceRomValidationService>();
         }
 
         private void Application_Startup(object sender, StartupEventArgs e)

--- a/src/Randomizer.App/Windows/GenerateRomWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/GenerateRomWindow.xaml.cs
@@ -36,6 +36,7 @@ namespace Randomizer.App.Windows
         private readonly RomGenerationService _romGenerator;
         private readonly LocationConfig _locations;
         private readonly MsuUiService _msuUiService;
+        private readonly SpriteService _spriteService;
         private RandomizerOptions? _options;
 
         public GenerateRomWindow(IServiceProvider serviceProvider,
@@ -48,9 +49,8 @@ namespace Randomizer.App.Windows
             _romGenerator = romGenerator;
             _locations = locations;
             _msuUiService = msuUiService;
+            _spriteService = spriteService;
             InitializeComponent();
-
-            _ = spriteService.LoadSpritesAsync();
         }
 
         public PlandoConfig? PlandoConfig { get; set; }
@@ -762,7 +762,13 @@ namespace Randomizer.App.Windows
 
             UpdateMsuTextBox();
             _msuUiService.LookupMsus();
-            UpdateSpriteTextBoxes();
+
+            Task.Run(async () =>
+            {
+                await _spriteService.LoadSpritesAsync();
+                Dispatcher.Invoke(UpdateSpriteTextBoxes);
+            });
+
         }
 
         private void SelectMsuFileMenuItem_OnClick(object sender, RoutedEventArgs e)
@@ -846,31 +852,37 @@ namespace Randomizer.App.Windows
 
         private void UpdateSpriteTextBoxes()
         {
-            if (string.IsNullOrEmpty(Options.PatchOptions.SelectedSamusSprite.Author))
+            if (Options.PatchOptions.SelectedSamusSprite.IsDefault ||
+                Options.PatchOptions.SelectedSamusSprite.IsRandomSprite)
             {
-                SamusSpriteTextBox.Text = $"{Options.PatchOptions.SelectedSamusSprite.Name}";
+                SamusSpriteTextBox.Text = Options.PatchOptions.SelectedSamusSprite.ToString();
             }
             else
             {
-                SamusSpriteTextBox.Text = $"{Options.PatchOptions.SelectedSamusSprite.Name} by {Options.PatchOptions.SelectedSamusSprite.Author}";
+                var sprite = _spriteService.GetSprite(SpriteType.Samus);
+                SamusSpriteTextBox.Text = sprite.ToString();
             }
 
-            if (string.IsNullOrEmpty(Options.PatchOptions.SelectedLinkSprite.Author))
+            if (Options.PatchOptions.SelectedLinkSprite.IsDefault ||
+                Options.PatchOptions.SelectedLinkSprite.IsRandomSprite)
             {
-                LinkSpriteTextBox.Text = $"{Options.PatchOptions.SelectedLinkSprite.Name}";
+                LinkSpriteTextBox.Text = Options.PatchOptions.SelectedLinkSprite.ToString();
             }
             else
             {
-                LinkSpriteTextBox.Text = $"{Options.PatchOptions.SelectedLinkSprite.Name} by {Options.PatchOptions.SelectedLinkSprite.Author}";
+                var sprite = _spriteService.GetSprite(SpriteType.Link);
+                LinkSpriteTextBox.Text = sprite.ToString();
             }
 
-            if (string.IsNullOrEmpty(Options.PatchOptions.SelectedShipSprite.Author))
+            if (Options.PatchOptions.SelectedShipSprite.IsDefault ||
+                Options.PatchOptions.SelectedShipSprite.IsRandomSprite)
             {
-                ShipSpriteTextBox.Text = $"{Options.PatchOptions.SelectedShipSprite.Name}";
+                ShipSpriteTextBox.Text = Options.PatchOptions.SelectedShipSprite.ToString();
             }
             else
             {
-                ShipSpriteTextBox.Text = $"{Options.PatchOptions.SelectedShipSprite.Name} by {Options.PatchOptions.SelectedShipSprite.Author}";
+                var sprite = _spriteService.GetSprite(SpriteType.Ship);
+                ShipSpriteTextBox.Text = sprite.ToString();
             }
         }
     }

--- a/src/Randomizer.App/Windows/OptionsWindow.xaml
+++ b/src/Randomizer.App/Windows/OptionsWindow.xaml
@@ -36,19 +36,19 @@
                         Margin="24,11,11,0">
 
               <controls:LabeledControl Text="ALttP Japanese v1.0 ROM (required):">
-                <controls:FileSystemInput Path="{Binding Z3RomPath, Mode=TwoWay}"
+                <controls:FileSystemInput x:Name="ZeldaRomFileSystemInput"
+                                          Path="{Binding Z3RomPath, Mode=TwoWay}"
                                           Filter="SNES ROMs (*.sfc, *.smc)|*.sfc;*.smc|All files (*.*)|*.*"
                                           DialogTitle="Select 'A Link to the Past' ROM"
-                                          FileValidationHash="03a63945398191337e896e5771f77173"
-                                          FileValidationErrorMessage="Selected rom does not match the known hash for the Japanese v1.0 version of A Link to the Past and may not work as expected. Would you like to continue?" />
+                                          OnPathUpdated="ZeldaRomFileSystemInput_OnOnPathUpdated" />
               </controls:LabeledControl>
 
               <controls:LabeledControl Text="Super Metroid Japanese/US ROM (required):">
-                <controls:FileSystemInput Path="{Binding SMRomPath, Mode=TwoWay}"
+                <controls:FileSystemInput x:Name="MetroidRomFileSystemInput"
+                                          Path="{Binding SMRomPath, Mode=TwoWay}"
                                           Filter="SNES ROMs (*.sfc, *.smc)|*.sfc;*.smc|All files (*.*)|*.*"
                                           DialogTitle="Select 'Super Metroid' ROM"
-                                          FileValidationHash="21f3e98df4780ee1c667b84e57d88675"
-                                          FileValidationErrorMessage="Selected rom does not match the known hash for the Japanese/US version of Super Metroid and may not work as expected. Would you like to continue?"/>
+                                          OnPathUpdated="MetroidRomFileSystemInput_OnOnPathUpdated"/>
               </controls:LabeledControl>
 
               <controls:LabeledControl Text="ROM output folder:">

--- a/src/Randomizer.App/Windows/OptionsWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/OptionsWindow.xaml.cs
@@ -10,6 +10,7 @@ using System.Windows.Input;
 using Microsoft.Extensions.Logging;
 using Randomizer.Data.Configuration;
 using Randomizer.Data.Options;
+using Randomizer.Data.Services;
 using Randomizer.Shared;
 using Randomizer.SMZ3.ChatIntegration;
 using static System.Int32;
@@ -27,16 +28,18 @@ namespace Randomizer.App.Windows
         private GeneralOptions _options = new();
         private bool _canLogIn = true;
         private ICollection<string> _availableProfiles;
-
+        private SourceRomValidationService _sourceRomValidationService;
 
         public OptionsWindow(IChatAuthenticationService chatAuthenticationService,
             ConfigProvider configProvider,
-            ILogger<OptionsWindow> logger)
+            ILogger<OptionsWindow> logger,
+            SourceRomValidationService sourceRomValidationService)
         {
             InitializeComponent();
             _trackerConfigProvider = configProvider;
             _chatAuthenticationService = chatAuthenticationService;
             _logger = logger;
+            _sourceRomValidationService = sourceRomValidationService;
             _availableProfiles = configProvider.GetAvailableProfiles();
             PropertyChanged?.Invoke(this, new(nameof(DisabledProfiles)));
         }
@@ -273,6 +276,26 @@ namespace Randomizer.App.Windows
             {
                 MessageBox.Show(this,
                     "To preserve drive space, it is recommended that the Rom Output and MSU folders be on the same drive.",
+                    "SMZ3 Cas' Randomizer", MessageBoxButton.OK, MessageBoxImage.Warning);
+            }
+        }
+
+        private void MetroidRomFileSystemInput_OnOnPathUpdated(object? sender, EventArgs e)
+        {
+            if (!_sourceRomValidationService.ValidateMetroidRom(MetroidRomFileSystemInput.Path))
+            {
+                MessageBox.Show(this,
+                    "The rom selected does not appear to be a valid Super Metroid Japanese/US ROM. Generated SMZ3 ROMs may not work as expected.",
+                    "SMZ3 Cas' Randomizer", MessageBoxButton.OK, MessageBoxImage.Warning);
+            }
+        }
+
+        private void ZeldaRomFileSystemInput_OnOnPathUpdated(object? sender, EventArgs e)
+        {
+            if (!_sourceRomValidationService.ValidateZeldaRom(ZeldaRomFileSystemInput.Path))
+            {
+                MessageBox.Show(this,
+                    "The rom selected does not appear to be a valid ALttP Japanese v1.0 ROM. Generated SMZ3 ROMs may not work as expected.",
                     "SMZ3 Cas' Randomizer", MessageBoxButton.OK, MessageBoxImage.Warning);
             }
         }

--- a/src/Randomizer.CrossPlatform/Program.cs
+++ b/src/Randomizer.CrossPlatform/Program.cs
@@ -1,0 +1,238 @@
+﻿using System.Diagnostics;
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using MSURandomizerLibrary.Models;
+using MSURandomizerLibrary.Services;
+using Randomizer.Data.Options;
+using Randomizer.Data.Services;
+using Randomizer.SMZ3.Generation;
+using Serilog;
+using Serilog.Events;
+
+namespace Randomizer.CrossPlatform;
+
+public static class Program
+{
+    public static void Main(string[] args)
+    {
+        var logLevel = LogEventLevel.Warning;
+        if (args.Any(x => x == "-v"))
+            logLevel = LogEventLevel.Information;
+
+        Log.Logger = new LoggerConfiguration()
+            .Enrich.FromLogContext()
+            .WriteTo.Console(logLevel)
+            .WriteTo.File(LogPath, rollingInterval: RollingInterval.Day, retainedFileCountLimit: 30)
+            .CreateLogger();
+
+        var services = new ServiceCollection()
+            .AddLogging(logging =>
+            {
+                logging.AddSerilog(dispose: true);
+            })
+            .ConfigureServices()
+            .BuildServiceProvider();
+
+        InitializeMsuRandomizer(services.GetRequiredService<IMsuRandomizerInitializationService>());
+
+        var optionsFile = new FileInfo("randomizer-options.yml");
+        var randomizerOptions = services.GetRequiredService<OptionsFactory>().LoadFromFile(optionsFile.FullName, optionsFile.FullName, true);
+        randomizerOptions.Save();
+
+        if (string.IsNullOrEmpty(randomizerOptions.GeneralOptions.Z3RomPath) || string.IsNullOrEmpty(randomizerOptions
+                                                                                 .GeneralOptions.SMRomPath)
+                                                                             || !File.Exists(randomizerOptions
+                                                                                 .GeneralOptions.Z3RomPath) ||
+                                                                             !File.Exists(randomizerOptions
+                                                                                 .GeneralOptions.SMRomPath))
+        {
+            Console.WriteLine($"Please update {optionsFile.FullName} to include the paths to the Super Metroid and A Link to the Past roms and any other desired options for generation.");
+            return;
+        }
+
+        var result = DisplayMenu("What do you want to do?", new List<string>()
+        {
+            "Generate & Play a Rom",
+            "Play a Rom",
+            "Delete Rom(s)"
+        });
+
+        if (result == null)
+        {
+            return;
+        }
+
+        // Generates a new rom
+        if (result.Value.Item1 == 0)
+        {
+            // Allow the user to select an MSU
+            if (!string.IsNullOrEmpty(randomizerOptions.GeneralOptions.MsuPath))
+            {
+                var msus = services.GetRequiredService<IMsuLookupService>().LookupMsus(randomizerOptions.GeneralOptions.MsuPath)
+                    .Where(x => x.ValidTracks.Count > 10).ToList();
+
+                result = DisplayMenu("Which msu do you want to use?",
+                    msus.Select(x => $"{x.Name} ({x.MsuTypeName})").ToList());
+                if (result != null)
+                {
+                    randomizerOptions.PatchOptions.MsuPaths = new List<string>() { msus[result.Value.Item1].Path };
+                }
+            }
+
+            // Generate the rom
+            var results = services.GetRequiredService<RomGenerationService>().GenerateRandomRomAsync(randomizerOptions).Result;
+            if (string.IsNullOrEmpty(results.GenerationError))
+            {
+                var romPath = Path.Combine(randomizerOptions.RomOutputPath, results.Rom!.RomPath);
+                Console.WriteLine($"Rom generated successfully: {romPath}");
+                Launch(romPath, randomizerOptions);
+            }
+            else
+            {
+                Console.WriteLine($"Error generating rom: {results.GenerationError}");
+            }
+        }
+        // Plays a previously generated rom
+        else if (result.Value.Item1 == 1)
+        {
+            var roms = services.GetRequiredService<IGameDbService>().GetGeneratedRomsList()
+                .OrderByDescending(x => x.Id)
+                .ToList();
+
+            result = DisplayMenu("Which rom do you want to play?",
+                roms.Select(x => $"{x.Seed} - {x.Date:G}").ToList());
+
+            if (result != null)
+            {
+                var selectedRom = roms[result.Value.Item1];
+                var romPath = Path.Combine(randomizerOptions.RomOutputPath, selectedRom.RomPath);
+                Launch(romPath, randomizerOptions);
+            }
+        }
+        // Deletes rom(s)
+        else if (result.Value.Item1 == 2)
+        {
+            var dbService = services.GetRequiredService<IGameDbService>();
+            var roms = dbService.GetGeneratedRomsList()
+                .OrderByDescending(x => x.Id)
+                .ToList();
+
+            while (roms.Count > 0)
+            {
+                result = DisplayMenu("Which rom do you want to delete?",
+                    roms.Select(x => $"{x.Seed} - {x.Date:G}").ToList());
+
+                if (result == null)
+                {
+                    break;
+                }
+                else
+                {
+                    var selectedRom = roms[result.Value.Item1];
+                    if (!dbService.DeleteGeneratedRom(selectedRom, out var error))
+                    {
+                        Log.Error("Could not delete rom: {Message}", error);
+                    }
+                    else
+                    {
+                        roms.Remove(selectedRom);
+                    }
+                }
+            }
+        }
+    }
+
+    static (int, string)? DisplayMenu(string prompt, List<string> options)
+    {
+        Console.WriteLine(prompt);
+
+        for (var i = 0; i < options.Count; i++)
+        {
+            Console.WriteLine($"  {i+1}) {options[i]}");
+        }
+
+        while (true)
+        {
+            Console.Write($"Enter a value (1-{options.Count}): ");
+            var selectedOption = Console.ReadLine();
+            if (string.IsNullOrEmpty(selectedOption))
+            {
+                return null;
+            }
+
+            if (int.TryParse(selectedOption, out var value) && value >= 1 && value <= options.Count)
+            {
+                return (value - 1, options[value - 1]);
+            }
+        }
+
+    }
+
+    static void Launch(string romPath, RandomizerOptions options)
+    {
+        if (!File.Exists(romPath))
+        {
+            Log.Error("No test rom found at {Path}", romPath);
+            return;
+        }
+
+        var launchApplication = options.GeneralOptions.LaunchApplication;
+        var launchArguments = "";
+        if (string.IsNullOrEmpty(launchApplication))
+        {
+            launchApplication = romPath;
+        }
+        else
+        {
+            if (string.IsNullOrEmpty(options.GeneralOptions.LaunchArguments))
+            {
+                launchArguments = $"\"{romPath}\"";
+            }
+            else if (options.GeneralOptions.LaunchArguments.Contains("%rom%"))
+            {
+                launchArguments = options.GeneralOptions.LaunchArguments.Replace("%rom%", $"{romPath}");
+            }
+            else
+            {
+                launchArguments = $"{options.GeneralOptions.LaunchArguments} \"{romPath}\"";
+            }
+        }
+
+        try
+        {
+            Console.WriteLine($"Executing {launchApplication} {launchArguments}");
+            Log.Information("Executing {FileName} {Arguments}", launchApplication, launchArguments);
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = launchApplication,
+                Arguments = launchArguments,
+                UseShellExecute = true,
+            });
+        }
+        catch (Exception e)
+        {
+            Log.Error(e, "Unable to launch rom");
+        }
+    }
+
+    static void InitializeMsuRandomizer(IMsuRandomizerInitializationService msuRandomizerInitializationService)
+    {
+        var settingsStream =  Assembly.GetExecutingAssembly()
+            .GetManifestResourceStream("Randomizer.CrossPlatform.msu-randomizer-settings.yml");
+        var typesStream = Assembly.GetExecutingAssembly()
+            .GetManifestResourceStream("Randomizer.CrossPlatform.msu-randomizer-types.json");
+        var msuInitializationRequest = new MsuRandomizerInitializationRequest()
+        {
+            MsuAppSettingsStream = settingsStream,
+            MsuTypeConfigStream = typesStream,
+            LookupMsus = true
+        };
+        msuRandomizerInitializationService.Initialize(msuInitializationRequest);
+    }
+
+#if DEBUG
+    private static string LogPath => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SMZ3CasRandomizer", "smz3-cas-debug_.log");
+#else
+    private static string LogPath => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SMZ3CasRandomizer", "smz3-cas.log");
+#endif
+}

--- a/src/Randomizer.CrossPlatform/Randomizer.CrossPlatform.csproj
+++ b/src/Randomizer.CrossPlatform/Randomizer.CrossPlatform.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <EmbeddedResource Include="msu-randomizer-settings.yml" />
+      <EmbeddedResource Include="msu-randomizer-types.json" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions">
+        <HintPath>..\..\..\..\..\.nuget\packages\microsoft.extensions.dependencyinjection.abstractions\7.0.0\lib\net7.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+      </Reference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Randomizer.Data\Randomizer.Data.csproj" />
+      <ProjectReference Include="..\Randomizer.SMZ3.Twitch\Randomizer.SMZ3.Twitch.csproj" />
+      <ProjectReference Include="..\Randomizer.SMZ3\Randomizer.SMZ3.csproj" />
+      <ProjectReference Include="..\Randomizer.Sprites\Randomizer.Sprites.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Serilog" Version="3.0.1" />
+      <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" />
+      <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+      <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    </ItemGroup>
+
+</Project>

--- a/src/Randomizer.CrossPlatform/ServiceCollectionExtensions.cs
+++ b/src/Randomizer.CrossPlatform/ServiceCollectionExtensions.cs
@@ -31,6 +31,7 @@ public static class ServiceCollectionExtensions
         // Misc
         services.AddSingleton<OptionsFactory>();
         services.AddSingleton<IGameDbService, GameDbService>();
+        services.AddTransient<SourceRomValidationService>();
 
         return services;
     }

--- a/src/Randomizer.CrossPlatform/ServiceCollectionExtensions.cs
+++ b/src/Randomizer.CrossPlatform/ServiceCollectionExtensions.cs
@@ -1,0 +1,37 @@
+using Microsoft.Extensions.DependencyInjection;
+using MSURandomizerLibrary;
+using Randomizer.Data.Configuration;
+using Randomizer.Data.Options;
+using Randomizer.Data.Services;
+using Randomizer.SMZ3.ChatIntegration;
+using Randomizer.SMZ3.Twitch;
+using Randomizer.Sprites;
+
+namespace Randomizer.CrossPlatform;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection ConfigureServices(this IServiceCollection services)
+    {
+        // Randomizer + Tracker
+        services.AddConfigs();
+        services.AddRandomizerServices();
+
+        services.AddSingleton<ITrackerStateService, TrackerStateService>();
+        services.AddSingleton<SpriteService>();
+
+        // Chat
+        services.AddSingleton<IChatApi, TwitchChatAPI>();
+        services.AddScoped<IChatClient, TwitchChatClient>();
+        services.AddSingleton<IChatAuthenticationService, TwitchAuthenticationService>();
+
+        // MSU Randomizer
+        services.AddMsuRandomizerServices();
+
+        // Misc
+        services.AddSingleton<OptionsFactory>();
+        services.AddSingleton<IGameDbService, GameDbService>();
+
+        return services;
+    }
+}

--- a/src/Randomizer.CrossPlatform/msu-randomizer-settings.yml
+++ b/src/Randomizer.CrossPlatform/msu-randomizer-settings.yml
@@ -1,0 +1,16 @@
+﻿UserOptionsFilePath: "%LocalAppData%\\SMZ3CasRandomizer\\msu-user-settings.yml"
+MsuCachePath: "%LocalAppData%\\SMZ3CasRandomizer"
+ContinuousReshuffleSeconds: 60
+MsuWindowDisplayRandomButton: false
+MsuWindowDisplayShuffleButton: false
+MsuWindowDisplayContinuousButton: false
+MsuWindowDisplayOptionsButton: false
+MsuWindowDisplaySelectButton: true
+ForcedMsuType: "Super Metroid / A Link to the Past Combination Randomizer"
+MsuWindowTitle: SMZ3 Cas' Randomizer
+MsuTypeNameOverrides:
+  "Super Metroid / A Link to the Past Combination Randomizer Legacy": "SMZ3 Classic (Metroid First)"
+  "Super Metroid / A Link to the Past Combination Randomizer": "SMZ3 Combo Randomizer"
+Smz3MsuTypes:
+  - SMZ3 Classic (Metroid First)
+  - SMZ3 Combo Randomizer

--- a/src/Randomizer.CrossPlatform/msu-randomizer-types.json
+++ b/src/Randomizer.CrossPlatform/msu-randomizer-types.json
@@ -1,0 +1,502 @@
+﻿[
+  {
+    "meta": {
+      "name": "The Legend of Zelda: A Link to the Past"
+    },
+    "tracks": {
+      "basic": [
+        {
+          "title": "Opening Theme",
+          "name": "Link to the Past",
+          "nonlooping": true
+        },
+        {
+          "title": "Light World Overworld",
+          "name": "Hyrule Field"
+        },
+        {
+          "title": "Rain State Overworld",
+          "name": "Time of Falling Rain"
+        },
+        {
+          "title": "Bunny Overworld",
+          "name": "The Silly Pink Rabbit"
+        },
+        {
+          "title": "Light World Lost Woods",
+          "name": "Forest of Mystery"
+        },
+        {
+          "title": "Opening Story Credits",
+          "name": "Seal of Seven Maidens"
+        },
+        {
+          "title": "Kakariko Village"
+        },
+        {
+          "title": "Mirror Portal",
+          "name": "Dimensional Shift",
+          "nonlooping": true
+        },
+        {
+          "title": "Dark World Overworld",
+          "name": "Dark Golden Land"
+        },
+        {
+          "title": "Pedestal Pull Sequence",
+          "name": "Unsealing the Master Sword",
+          "nonlooping": true
+        },
+        {
+          "title": "File Select/Game Over",
+          "name": "Beginning of the Journey"
+        },
+        {
+          "title": "Kakariko Guards Summoned",
+          "name": "Soldiers of Kakariko Village"
+        },
+        {
+          "title": "Dark Death Mountain",
+          "name": "Black Mist"
+        },
+        {
+          "title": "Money Making Game"
+        },
+        {
+          "title": "Dark World Lost Woods",
+          "extended": true,
+          "remap": 13
+        },
+        {
+          "title": "Hyrule Castle",
+          "name": "Majestic Castle"
+        },
+        {
+          "title": "Generic Light World Dungeon",
+          "name": "Lost Ancient Ruins"
+        },
+        {
+          "title": "Cave",
+          "name": "Dank Dungeons"
+        },
+        {
+          "title": "Boss Victory",
+          "name": "Great Victory!",
+          "nonlooping": true
+        },
+        {
+          "title": "Sanctuary",
+          "name": "Safety in the Sanctuary"
+        },
+        {
+          "title": "Generic Boss Battle",
+          "name": "Anger of the Guardians"
+        },
+        {
+          "title": "Generic Dark World Dungeon",
+          "name": "Dungeon of Shadows"
+        },
+        {
+          "title": "Shop/Fortune Teller"
+        },
+        {
+          "title": "Cave 2"
+        },
+        {
+          "title": "Princess Zelda's Rescue"
+        },
+        {
+          "title": "Crystal Get",
+          "name": "Meeting the Maidens"
+        },
+        {
+          "title": "Fairy Fountain",
+          "name": "The Goddess Appears"
+        },
+        {
+          "title": "Agahnim's Theme",
+          "name": "Priest of the Dark Order"
+        },
+        {
+          "title": "Ganon Appears",
+          "name": "Release of Ganon",
+          "nonlooping": true
+        },
+        {
+          "title": "Ganon's Theme",
+          "name": "Ganon's Message"
+        },
+        {
+          "title": "Ganon Fight",
+          "name": "The Prince of Darkness"
+        },
+        {
+          "title": "Triforce Room",
+          "name": "Power of the Gods"
+        },
+        {
+          "title": "Triumphant Return",
+          "name": "Epilogue ~ Beautiful Hyrule",
+          "nonlooping": true
+        },
+        {
+          "title": "Credits",
+          "name": "Staff Roll",
+          "nonlooping": true
+        }
+      ],
+      "extended": [
+        {
+          "title": "Eastern Palace",
+          "fallback": 17
+        },
+        {
+          "title": "Desert Palace",
+          "fallback": 17
+        },
+        {
+          "title": "Agahnim's Tower",
+          "fallback": 16
+        },
+        {
+          "title": "Swamp Palace",
+          "fallback": 22
+        },
+        {
+          "title": "Palace of Darkness",
+          "fallback": 22
+        },
+        {
+          "title": "Misery Mire",
+          "fallback": 22
+        },
+        {
+          "title": "Skull Woods",
+          "fallback": 22
+        },
+        {
+          "title": "Ice Palace",
+          "fallback": 22
+        },
+        {
+          "title": "Tower of Hera",
+          "fallback": 17
+        },
+        {
+          "title": "Thieves' Town",
+          "fallback": 22
+        },
+        {
+          "title": "Turtle Rock",
+          "fallback": 22
+        },
+        {
+          "title": "Ganon's Tower",
+          "fallback": 22
+        },
+        {
+          "title": "Eastern Palace Boss",
+          "fallback": 21
+        },
+        {
+          "title": "Desert Palace Boss",
+          "fallback": 21
+        },
+        {
+          "title": "Agahnim's Tower Boss",
+          "fallback": 21
+        },
+        {
+          "title": "Swamp Palace Boss",
+          "fallback": 21
+        },
+        {
+          "title": "Palace of Darkness Boss",
+          "fallback": 21
+        },
+        {
+          "title": "Misery Mire Boss",
+          "fallback": 21
+        },
+        {
+          "title": "Skull Woods Boss",
+          "fallback": 21
+        },
+        {
+          "title": "Ice Palace Boss",
+          "fallback": 21
+        },
+        {
+          "title": "Tower of Hera Boss",
+          "fallback": 21
+        },
+        {
+          "title": "Thieves' Town Boss",
+          "fallback": 21
+        },
+        {
+          "title": "Turtle Rock Boss",
+          "fallback": 21
+        },
+        {
+          "title": "Ganon's Tower Boss",
+          "fallback": 21
+        },
+        {
+          "title": "Ganon's Tower 2",
+          "fallback": 22,
+          "remap": 46
+        },
+        {
+          "title": "Light World 2",
+          "fallback": 2
+        },
+        {
+          "title": "Dark World 2",
+          "fallback": 9
+        }
+      ],
+      "longest": 50,
+      "src": "https://www.romhacking.net/hacks/2483/"
+    }
+  },
+  {
+    "meta": {
+      "name": "Super Metroid"
+    },
+    "tracks": {
+      "basic": [
+        {
+          "title": "File Start",
+          "name": "Samus Aran's Appearance Fanfare",
+          "nonlooping": true
+        },
+        {
+          "title": "Item Acquisition Fanfare",
+          "nonlooping": true
+        },
+        {
+          "title": "Item room"
+        },
+        {
+          "title": "Opening with intro",
+          "pair": 5
+        },
+        {
+          "title": "Opening without intro",
+          "pair": 4
+        },
+        {
+          "title": "Crateria (First Landing Thunder)",
+          "name": "Arrival on Crateria (with thunder FX)"
+        },
+        {
+          "title": "Crateria (First Landing No Thunder)",
+          "name": "Arrival on Crateria (without thunder FX)"
+        },
+        {
+          "title": "Crateria",
+          "name": "The Space Pirates Appear"
+        },
+        {
+          "title": "Crateria Statue Room",
+          "name": "Statue Room"
+        },
+        {
+          "title": "Samus' Ship",
+          "name": "Theme of Samus Aran"
+        },
+        {
+          "title": "Brinstar with vegetation"
+        },
+        {
+          "title": "Brinstar Red Soil"
+        },
+        {
+          "title": "Upper Norfair"
+        },
+        {
+          "title": "Lower Norfair"
+        },
+        {
+          "title": "Upper Maridia"
+        },
+        {
+          "title": "Lower Maridia"
+        },
+        {
+          "title": "Tourian"
+        },
+        {
+          "title": "Mother Brain Battle"
+        },
+        {
+          "title": "Big Boss Battle 1"
+        },
+        {
+          "title": "Evacuation"
+        },
+        {
+          "title": "Mysterious Statue Chamber",
+          "name": "Chozo Statue Awakens"
+        },
+        {
+          "title": "Big Boss Battle 2",
+          "pair": 23
+        },
+        {
+          "title": "Tension / Hostile Incoming",
+          "pair": 22
+        },
+        {
+          "title": "Plant Miniboss"
+        },
+        {
+          "title": "Ceres Station"
+        },
+        {
+          "title": "Wrecked Ship Power Off"
+        },
+        {
+          "title": "Wrecked Ship Power On"
+        },
+        {
+          "title": "Theme of Super Metroid"
+        },
+        {
+          "title": "Death Cry",
+          "nonlooping": true
+        },
+        {
+          "title": "Ending",
+          "nonlooping": true
+        }
+      ],
+      "extended": [
+        {
+          "title": "Kraid Incoming",
+          "pair": 32,
+          "fallback": 23
+        },
+        {
+          "title": "Kraid Battle",
+          "pair": 31,
+          "fallback": 22
+        },
+        {
+          "title": "Phantoon Incoming",
+          "pair": 34,
+          "fallback": 23
+        },
+        {
+          "title": "Phantoon Battle",
+          "pair": 33,
+          "fallback": 22
+        },
+        {
+          "title": "Draygon Battle",
+          "fallback": 19
+        },
+        {
+          "title": "Ridley Battle",
+          "fallback": 19
+        },
+        {
+          "title": "Baby Incoming",
+          "pair": 38,
+          "fallback": 23
+        },
+        {
+          "title": "The Baby",
+          "pair": 37,
+          "fallback": 22
+        },
+        {
+          "title": "Hyper Beam",
+          "fallback": 10
+        },
+        {
+          "title": "Game Over"
+        }
+      ]
+    }
+  },
+  {
+    "meta": {
+      "name": "Super Metroid / A Link to the Past Combination Randomizer"
+    },
+    "tracks": {
+      "basic": [
+        {
+          "num": 99,
+          "title": "SMZ3 Credits",
+          "nonlooping": true
+        }
+      ]
+    },
+    "copy": [
+      {
+        "msu": "The Legend of Zelda: A Link to the Past",
+        "modifier": 0,
+        "ignore": [
+          1,
+          3,
+          6,
+          25,
+          34
+        ]
+      },
+      {
+        "msu": "Super Metroid",
+        "modifier": 100,
+        "ignore": [
+          102,
+          107,
+          125,
+          128
+        ]
+      }
+    ]
+  },
+  {
+    "meta": {
+      "name": "Super Metroid / A Link to the Past Combination Randomizer Legacy",
+      "selectable": false,
+      "exactmatches": [
+        "Super Metroid / A Link to the Past Combination Randomizer"
+      ]
+    },
+    "tracks": {
+      "basic": [
+        {
+          "num": 99,
+          "title": "SMZ3 Credits",
+          "nonlooping": true
+        }
+      ]
+    },
+    "copy": [
+      {
+        "msu": "The Legend of Zelda: A Link to the Past",
+        "modifier": 100,
+        "ignore": [
+          101,
+          103,
+          106,
+          125,
+          134
+        ]
+      },
+      {
+        "msu": "Super Metroid",
+        "modifier": 0,
+        "ignore": [
+          2,
+          7,
+          25,
+          28
+        ]
+      }
+    ]
+  }
+]

--- a/src/Randomizer.Data/Options/GeneralOptions.cs
+++ b/src/Randomizer.Data/Options/GeneralOptions.cs
@@ -73,6 +73,10 @@ namespace Randomizer.Data.Options
 
         public string? MsuPath { get; set; }
 
+        public string? LaunchApplication { get; set; }
+
+        public string? LaunchArguments { get; set; }
+
         public string AutoTrackerScriptsOutputPath { get; set; }
             = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SMZ3CasRandomizer", "AutoTrackerScripts");
 

--- a/src/Randomizer.Data/Options/PatchOptions.cs
+++ b/src/Randomizer.Data/Options/PatchOptions.cs
@@ -36,6 +36,7 @@ namespace Randomizer.Data.Options
 
         public Sprite? PreviousShipSprite { get; set; }
 
+        [YamlIgnore]
         public string Msu1Path
         {
             get => _msu1Path;
@@ -50,6 +51,7 @@ namespace Randomizer.Data.Options
             }
         }
 
+        [YamlIgnore]
         public string MsuName
         {
             get => _msuName;

--- a/src/Randomizer.Data/Options/SeedOptions.cs
+++ b/src/Randomizer.Data/Options/SeedOptions.cs
@@ -8,6 +8,7 @@ using System.Text.Json.Serialization;
 using System.Windows;
 using Randomizer.Shared;
 using Randomizer.Shared.Enums;
+using YamlDotNet.Serialization;
 
 namespace Randomizer.Data.Options
 {
@@ -43,10 +44,10 @@ namespace Randomizer.Data.Options
         public bool OpenPyramid { get; set; } = false;
         public int TourianBossCount { get; set; } = 4;
 
-        [JsonIgnore]
+        [JsonIgnore, YamlIgnore]
         public int MaxHints => 15;
 
-        [JsonIgnore]
+        [JsonIgnore, YamlIgnore]
         public bool CopySeedAndRaceSettings { get; set; }
 
         public IDictionary<LocationId, int> LocationItems { get; set; } = new Dictionary<LocationId, int>();

--- a/src/Randomizer.Data/Options/Sprite.cs
+++ b/src/Randomizer.Data/Options/Sprite.cs
@@ -105,6 +105,19 @@ namespace Randomizer.Data.Options
         public override int GetHashCode()
             => HashCode.Combine(FilePath, SpriteType);
 
+        public override string ToString()
+        {
+            if (IsDefault)
+            {
+                return $"Default";
+            }
+            else if (IsRandomSprite)
+            {
+                return $"Random {SpriteType} Sprite";
+            }
+            return string.IsNullOrEmpty(Author) ? Name : $"{Name} by {Author}";
+        }
+
         public static string SpritePath
         {
             get

--- a/src/Randomizer.Data/Randomizer.Data.csproj
+++ b/src/Randomizer.Data/Randomizer.Data.csproj
@@ -66,7 +66,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Randomizer.Shared\Randomizer.Shared.csproj" />
   </ItemGroup>
-  
+
   <!--<ItemGroup>
     <FrameworkReference Include="Microsoft.WindowsDesktop.App" />
   </ItemGroup>-->

--- a/src/Randomizer.Data/Services/GameDbService.cs
+++ b/src/Randomizer.Data/Services/GameDbService.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Randomizer.Data.Options;
+using Randomizer.Shared.Models;
+
+namespace Randomizer.Data.Services;
+
+public class GameDbService : IGameDbService
+{
+    private readonly RandomizerContext _context;
+    private readonly RandomizerOptions _options;
+
+    public GameDbService(RandomizerContext context, OptionsFactory optionsFactory)
+    {
+        _context = context;
+        _options = optionsFactory.Create();
+    }
+
+    public bool UpdateGeneratedRom(GeneratedRom rom, string? label = null)
+    {
+        var updated = false;
+
+        if (label != null && label != rom.Label)
+        {
+            rom.Label = label;
+            updated = true;
+        }
+
+        if (updated)
+        {
+            _context.SaveChanges();
+        }
+
+        return updated;
+    }
+
+    public IEnumerable<GeneratedRom> GetGeneratedRomsList()
+    {
+        return _context.GeneratedRoms
+            .Include(x => x.MultiplayerGameDetails)
+            .Include(x => x.TrackerState)
+            .ThenInclude(x => x!.History)
+            .Where(x => x.MultiplayerGameDetails == null);
+    }
+
+    public IEnumerable<MultiplayerGameDetails> GetMultiplayerGamesList()
+    {
+        return _context.MultiplayerGames
+            .Include(x => x.GeneratedRom)
+            .ThenInclude(x => x!.TrackerState);
+    }
+
+    public ICollection<TrackerHistoryEvent> GetGameHistory(GeneratedRom rom)
+    {
+        if (rom.TrackerState?.History.Count > 0)
+        {
+            return rom.TrackerState.History;
+        }
+
+        if (rom.TrackerState == null)
+        {
+            _context.Entry(rom).Reference<TrackerState>(x => x.TrackerState).Load();
+            if (rom.TrackerState == null)
+            {
+                return new List<TrackerHistoryEvent>();
+            }
+        }
+
+        _context.Entry(rom.TrackerState).Collection(x => x.History).Load();
+        return rom.TrackerState.History;
+    }
+
+    public bool DeleteGeneratedRom(GeneratedRom rom, out string error)
+    {
+        // Try to delete the folder first
+        try
+        {
+            var path = Path.GetDirectoryName(Path.Combine(_options.RomOutputPath, rom.RomPath));
+
+            if (!string.IsNullOrEmpty(path))
+            {
+                var directory = new DirectoryInfo(path);
+                directory.Delete(true);
+            }
+        }
+        catch (Exception ex)
+        {
+            if (ex is not DirectoryNotFoundException)
+            {
+                error = "There was an error in trying to delete the rom directory. Verify the rom is not open in your emulator.";
+                return false;
+            }
+        }
+
+        // Delete the tracker info if it is available
+        if (rom.TrackerState != null)
+        {
+            _context.Entry(rom.TrackerState).Collection(x => x.ItemStates).Load();
+            _context.Entry(rom.TrackerState).Collection(x => x.LocationStates).Load();
+            _context.Entry(rom.TrackerState).Collection(x => x.RegionStates).Load();
+            _context.Entry(rom.TrackerState).Collection(x => x.DungeonStates).Load();
+            _context.Entry(rom.TrackerState).Collection(x => x.MarkedLocations).Load();
+            _context.Entry(rom.TrackerState).Collection(x => x.BossStates).Load();
+            _context.Entry(rom.TrackerState).Collection(x => x.History).Load();
+
+            _context.TrackerStates.Remove(rom.TrackerState);
+        }
+
+        // Remove the rom itself from the db and save the db
+        _context.GeneratedRoms.Remove(rom);
+        _context.SaveChanges();
+
+        error = "";
+        return true;
+    }
+
+    public bool DeleteMultiplayerGame(MultiplayerGameDetails details, out string error)
+    {
+        // If there's a rom, try to delete it first and don't continue
+        // if it wasn't deleted
+        if (details.GeneratedRom != null)
+        {
+            if (!DeleteGeneratedRom(details.GeneratedRom, out error))
+            {
+                return false;
+            }
+        }
+        else
+        {
+            var rom = _context.GeneratedRoms
+                .Where(x => x.MultiplayerGameDetailsId == details.Id)
+                .Include(x => x.MultiplayerGameDetails)
+                .Include(x => x.TrackerState)
+                .ThenInclude(x => x!.History)
+                .FirstOrDefault();
+
+            if (rom != null && !DeleteGeneratedRom(rom, out error))
+            {
+                return false;
+            }
+        }
+
+        _context.MultiplayerGames.Remove(details);
+        _context.SaveChanges();
+
+        error = "";
+        return true;
+    }
+
+}

--- a/src/Randomizer.Data/Services/IGameDbService.cs
+++ b/src/Randomizer.Data/Services/IGameDbService.cs
@@ -1,0 +1,53 @@
+﻿using System.Collections.Generic;
+using Randomizer.Shared.Models;
+
+namespace Randomizer.Data.Services;
+
+/// <summary>
+/// Service for retrieving roms and multiplayer games from the database
+/// </summary>
+public interface IGameDbService
+{
+    /// <summary>
+    /// Updates and saves values for a rom to the database
+    /// </summary>
+    /// <param name="rom">The GeneratedRom to update</param>
+    /// <param name="label">The value to update for the label</param>
+    /// <returns>True if the GeneratedRom was updated</returns>
+    public bool UpdateGeneratedRom(GeneratedRom rom, string? label = null);
+
+    /// <summary>
+    /// Retrieves the list of roms from the database
+    /// </summary>
+    /// <returns>The list of roms</returns>
+    public IEnumerable<GeneratedRom> GetGeneratedRomsList();
+
+    /// <summary>
+    /// Retrieves the list of multiplayer games from the database
+    /// </summary>
+    /// <returns>The list of multiplayer games</returns>
+    public IEnumerable<MultiplayerGameDetails> GetMultiplayerGamesList();
+
+    /// <summary>
+    /// Retrieves the history of tracked events for a roms
+    /// </summary>
+    /// <param name="rom">The rom to retrieve the history for</param>
+    /// <returns>The list of tracked events</returns>
+    public ICollection<TrackerHistoryEvent> GetGameHistory(GeneratedRom rom);
+
+    /// <summary>
+    /// Deletes the generated rom from the file system and database
+    /// </summary>
+    /// <param name="rom">The rom to delete</param>
+    /// <param name="error">Error message from trying to delete the rom</param>
+    /// <returns>True if successfully deleted, false otherwise</returns>
+    public bool DeleteGeneratedRom(GeneratedRom rom, out string error);
+
+    /// <summary>
+    /// Deletes the multiplayer game and rom from the file system and database
+    /// </summary>
+    /// <param name="details">The multiplayer game to delete</param>
+    /// <param name="error">Error message from trying to delete the rom</param>
+    /// <returns>True if successfully deleted, false otherwise</returns>
+    public bool DeleteMultiplayerGame(MultiplayerGameDetails details, out string error);
+}

--- a/src/Randomizer.Data/Services/SourceRomValidationService.cs
+++ b/src/Randomizer.Data/Services/SourceRomValidationService.cs
@@ -1,0 +1,37 @@
+using System;
+using System.IO;
+using System.Security.Cryptography;
+
+namespace Randomizer.Data.Services;
+
+public class SourceRomValidationService
+{
+    public bool ValidateZeldaRom(string? path)
+    {
+        return ValidateRom(path, "03a63945398191337e896e5771f77173");
+    }
+
+    public bool ValidateMetroidRom(string? path)
+    {
+        return ValidateRom(path, "21f3e98df4780ee1c667b84e57d88675");
+    }
+
+    private bool ValidateRom(string? path, string expectedHash)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            return false;
+        }
+
+        if (!File.Exists(path))
+        {
+            return false;
+        }
+
+        using var md5 = MD5.Create();
+        using var stream = File.OpenRead(path);
+        var hash = md5.ComputeHash(stream);
+        var hashString = BitConverter.ToString(hash).Replace("-", "");
+        return expectedHash.Equals(hashString, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Randomizer.PatchBuilder/PatchBuilderService.cs
+++ b/src/Randomizer.PatchBuilder/PatchBuilderService.cs
@@ -81,6 +81,30 @@ public class PatchBuilderService
 
         _logger.LogInformation("Building patches");
 
+        var asarPath = Path.Combine(_randomizerRomPath, "resources",
+            OperatingSystem.IsWindows() ? "asar.exe" : "asar");
+        if (!File.Exists(asarPath))
+        {
+            throw new FileNotFoundException(
+                $"{asarPath} not found. Please download from https://github.com/RPGHacker/asar");
+        }
+
+        var ipsPatcher = Path.Combine(_randomizerRomPath, "resources",
+            OperatingSystem.IsWindows() ? "Lunar IPS.exe" : "flips-linux");
+        if (!File.Exists(ipsPatcher))
+        {
+            var downloadUrl = OperatingSystem.IsWindows() ? "https://www.romhacking.net/utilities/240/" : "https://www.romhacking.net/utilities/1040/";
+            throw new FileNotFoundException(
+                $"{ipsPatcher} not found. Please download from {downloadUrl}");
+        }
+
+        var smRom = Path.Combine(_randomizerRomPath, "resources", "sm.sfc");
+        if (!File.Exists(smRom))
+        {
+            throw new FileNotFoundException(
+                $"{smRom} not found.");
+        }
+
         var info = new FileInfo(config.EnvironmentSettings.PatchBuildScriptPath);
 
         // Run the patch build.bat file

--- a/src/Randomizer.PatchBuilder/Program.cs
+++ b/src/Randomizer.PatchBuilder/Program.cs
@@ -29,10 +29,6 @@ var serviceProvider = new ServiceCollection()
 
 var logger = serviceProvider.GetRequiredService<ILogger<Program>>();
 
-var typesStream = Assembly.GetExecutingAssembly()
-    .GetManifestResourceStream("Randomizer.PatchBuilder.msu-randomizer-types.json");
-serviceProvider.GetRequiredService<IMsuTypeService>().LoadMsuTypes(typesStream!);
-
 InitializeMsuRandomizer(serviceProvider.GetRequiredService<IMsuRandomizerInitializationService>());
 
 var yamlPath = "";

--- a/src/Randomizer.PatchBuilder/Randomizer.PatchBuilder.csproj
+++ b/src/Randomizer.PatchBuilder/Randomizer.PatchBuilder.csproj
@@ -13,6 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <PackageReference Include="MattEqualsCoder.MSURandomizer.Library" Version="1.2.1" />
       <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
     </ItemGroup>
 

--- a/src/Randomizer.SMZ3/Generation/RomTextService.cs
+++ b/src/Randomizer.SMZ3/Generation/RomTextService.cs
@@ -45,9 +45,9 @@ public class RomTextService
         try
         {
 #if DEBUG
-            var autoTrackerSourcePath = Path.Combine(GetSourceDirectory(), "Randomizer.SMZ3.Tracking\\AutoTracking\\LuaScripts");
+            var autoTrackerSourcePath = Path.Combine(GetSourceDirectory(), "Randomizer.SMZ3.Tracking", "AutoTracking", "LuaScripts");
 #else
-            var autoTrackerSourcePath = Environment.ExpandEnvironmentVariables("%LocalAppData%\\SMZ3CasRandomizer\\AutotrackerScripts");
+            var autoTrackerSourcePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SMZ3CasRandomizer", "AutoTrackerScripts");
 #endif
             var autoTrackerDestPath = options.AutoTrackerScriptsOutputPath;
 

--- a/src/Randomizer.Shared/Models/RandomizerContext.cs
+++ b/src/Randomizer.Shared/Models/RandomizerContext.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.IO;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore;
 #pragma warning disable CS8618
@@ -15,13 +16,7 @@ namespace Randomizer.Shared.Models {
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
-            var dbPath = Environment.ExpandEnvironmentVariables("%LocalAppData%\\SMZ3CasRandomizer\\smz3.db");
-            if (Debugger.IsAttached)
-            {
-                dbPath = "smz3.db";
-            }
-
-            optionsBuilder.UseSqlite($"FileName={dbPath}", option =>
+            optionsBuilder.UseSqlite($"FileName={DbPath}", option =>
             {
                 option.MigrationsAssembly(Assembly.GetExecutingAssembly().FullName);
             });
@@ -55,6 +50,12 @@ namespace Randomizer.Shared.Models {
         public DbSet<TrackerBossState> TrackerBossStates { get; set; }
         public DbSet<TrackerHistoryEvent> TrackerHistoryEvents { get; set; }
         public DbSet<MultiplayerGameDetails> MultiplayerGames { get; set; }
+
+#if DEBUG
+        private static string DbPath => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SMZ3CasRandomizer", "smz3-debug.db");
+#else
+        private static string DbPath => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "SMZ3CasRandomizer", "smz3.db");
+#endif
 
     }
 

--- a/src/Randomizer.Sprites/SpriteService.cs
+++ b/src/Randomizer.Sprites/SpriteService.cs
@@ -43,7 +43,9 @@ public class SpriteService
 
             var sprites = playerSprites.Concat(shipSprites).Concat(defaults).OrderBy(x => x.Name).ToList();
 
-            var extraSpriteDirectory = Environment.ExpandEnvironmentVariables("%LocalAppData%\\SMZ3CasRandomizer\\Sprites");
+            var extraSpriteDirectory =
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                    "SMZ3CasRandomizer", "Sprites");
 
             if (Directory.Exists(extraSpriteDirectory))
             {


### PR DESCRIPTION
This is a first implementation of a cross platform randomizer.  Right now it's just a console app that is only capable of generating roms, playing previously generated roms, and deleting roms. This doesn't work with tracking at all yet.

The main summary of changes I implemented are as follows:

1. I created a GameDbService which to use for retrieving generated roms and multiplayer games to be shared between the two
2. Since currently this tool requires you to edit the options manually, I updated the Randomizer Options to work with yaml instead of json. For previous users, it should load the json, but then it will save the yaml after that. I figure in a future version, we can remove the json support.
4. I updated usages of Environment.ExpandEnvironmentVariables to Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) and used Path.Combine instead of hard coding slashes into the paths as that's cross platform compatible.
5. As an FYI, I split out a lot of the files that created to be different between debug and release files. I've had issues in the past where because the two shared files in the Local App Data problems would crop up.

A couple of other notes:
- I added LaunchApplication and LaunchArguments to the General Options. In a future commit, I'll update the Randomizer.App to be able to use that. It can be used to start a different version of snes9x or even RetroArch when launching a rom.
- Apparently I didn't push a commit for the patch builder which verifies that files are there. Whoops!