### PR TITLE
Implemented linux auto tracking

### DIFF
--- a/src/Randomizer.App/Windows/OptionsWindow.xaml
+++ b/src/Randomizer.App/Windows/OptionsWindow.xaml
@@ -7,6 +7,7 @@
         xmlns:vm="clr-namespace:Randomizer.App.ViewModels"
         xmlns:options="clr-namespace:Randomizer.Data.Options;assembly=Randomizer.Data"
         xmlns:app="clr-namespace:Randomizer.App"
+        xmlns:enums="clr-namespace:Randomizer.Shared.Enums;assembly=Randomizer.Shared"
         x:Name="Self"
         ResizeMode="NoResize"
         mc:Ignorable="d"
@@ -177,10 +178,9 @@
                     <ColumnDefinition Width="*" />
                   </Grid.ColumnDefinitions>
 
-                  <ComboBox ItemsSource="{Binding QuickLaunchOptions}"
-                            SelectedIndex="{Binding LaunchButton}"
-                            Height="23"
-                            VerticalAlignment="Top">
+                  <ComboBox SelectedItem="{Binding LaunchButtonOption}"
+                            ItemsSource="{Binding Source={app:EnumBindingSource {x:Type options:LaunchButtonOptions}}}"
+                            MinWidth="75">
                   </ComboBox>
                 </Grid>
               </controls:LabeledControl>
@@ -192,10 +192,9 @@
                     <ColumnDefinition Width="*" />
                   </Grid.ColumnDefinitions>
 
-                  <ComboBox ItemsSource="{Binding TrackerVoiceFrequencyOptions}"
-                            SelectedIndex="{Binding VoiceFrequency}"
-                            Height="23"
-                            VerticalAlignment="Top">
+                  <ComboBox SelectedItem="{Binding TrackerVoiceFrequency}"
+                            ItemsSource="{Binding Source={app:EnumBindingSource {x:Type enums:TrackerVoiceFrequency}}}"
+                            MinWidth="75">
                   </ComboBox>
                 </Grid>
               </controls:LabeledControl>
@@ -218,10 +217,9 @@
                     <ColumnDefinition Width="*" />
                   </Grid.ColumnDefinitions>
 
-                  <ComboBox ItemsSource="{Binding AutoTrackerConnectorOptions}"
-                            SelectedIndex="{Binding AutoTrackerDefaultConnector}"
-                            Height="23"
-                            VerticalAlignment="Top">
+                  <ComboBox SelectedItem="{Binding AutoTrackerDefaultConnectionType}"
+                            ItemsSource="{Binding Source={app:EnumBindingSource {x:Type options:EmulatorConnectorType}}}"
+                            MinWidth="75">
                   </ComboBox>
                 </Grid>
               </controls:LabeledControl>

--- a/src/Randomizer.App/Windows/TrackerWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/TrackerWindow.xaml.cs
@@ -1048,9 +1048,9 @@ namespace Randomizer.App.Windows
         private async Task SaveStateAsync()
         {
             // If there is a rom, save it to the database
-            if (GeneratedRom.IsValid(Rom))
+            if (GeneratedRom.IsValid(Tracker.Rom))
             {
-                await Tracker.SaveAsync(Rom);
+                await Tracker.SaveAsync();
             }
 
             SavedState?.Invoke(this, EventArgs.Empty);

--- a/src/Randomizer.CrossPlatform/ConsoleTrackerDisplayService.cs
+++ b/src/Randomizer.CrossPlatform/ConsoleTrackerDisplayService.cs
@@ -1,0 +1,284 @@
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using Randomizer.Data.Options;
+using Randomizer.Data.WorldData;
+using Randomizer.Data.WorldData.Regions;
+using Randomizer.Shared;
+using Randomizer.Shared.Enums;
+using Randomizer.Shared.Models;
+using Randomizer.SMZ3.Generation;
+using Randomizer.SMZ3.Tracking;
+using Randomizer.SMZ3.Tracking.AutoTracking;
+using Randomizer.SMZ3.Tracking.Services;
+
+namespace Randomizer.CrossPlatform;
+
+public class ConsoleTrackerDisplayService
+{
+    private readonly System.Timers.Timer _timer;
+    private readonly Smz3GeneratedRomLoader _romLoaderService;
+    private readonly TrackerOptionsAccessor _trackerOptionsAccessor;
+    private readonly RandomizerOptions _options;
+    private readonly IServiceProvider _serviceProvider;
+    private Tracker _tracker = null!;
+    private World _world = null!;
+    private IWorldService _worldService = null!;
+    private Region _lastRegion = null!;
+
+    public ConsoleTrackerDisplayService(IServiceProvider serviceProvider, Smz3GeneratedRomLoader romLoaderService, TrackerOptionsAccessor trackerOptionsAccessor, OptionsFactory optionsFactory)
+    {
+        _romLoaderService = romLoaderService;
+        _trackerOptionsAccessor = trackerOptionsAccessor;
+        _options = optionsFactory.Create();
+        _serviceProvider = serviceProvider;
+        _timer = new System.Timers.Timer(TimeSpan.FromMilliseconds(250));
+        _timer.Elapsed += delegate { UpdateScreen(); };
+    }
+
+    public async Task StartTracking(GeneratedRom rom, string romPath)
+    {
+        _trackerOptionsAccessor.Options = _options.GeneralOptions.GetTrackerOptions();
+        _world = _romLoaderService.LoadGeneratedRom(rom).First(x => x.IsLocalWorld);
+        _worldService = _serviceProvider.GetRequiredService<IWorldService>();
+        _tracker = _serviceProvider.GetRequiredService<Tracker>();
+        _tracker.Load(rom, romPath);
+        _tracker.TryStartTracking();
+        _tracker.AutoTracker?.SetConnector(_options.AutoTrackerDefaultConnector, _options.AutoTrackerQUsb2SnesIp);
+
+        if (_tracker.AutoTracker != null)
+        {
+            _tracker.AutoTracker.AutoTrackerConnected += delegate
+            {
+                UpdateScreen();
+                if (!_timer.Enabled)
+                {
+                    _timer.Start();
+                }
+            };
+
+            _tracker.LocationCleared += delegate(object? _, LocationClearedEventArgs args)
+            {
+                _lastRegion = args.Location.Region;
+            };
+        }
+
+        while (true)
+        {
+            Console.ReadKey();
+            _timer.Stop();
+            Console.Clear();
+            Console.Write("Do you want to quit? (y/n) ");
+            var response = Console.ReadLine();
+
+            if ("y".Equals(response, StringComparison.OrdinalIgnoreCase))
+            {
+                await _tracker.SaveAsync();
+                break;
+            }
+
+            _timer.Start();
+            UpdateScreen();
+        }
+    }
+
+    private void UpdateScreen()
+    {
+        var columnWidth = (Console.WindowWidth-6)/2;
+
+        var topLines = GetHeaderLines(columnWidth);
+
+        var leftColumnLines = new List<string>();
+        leftColumnLines.AddRange(GetInventoryLines(columnWidth));
+        leftColumnLines.Add("");
+        leftColumnLines.AddRange(GetDungeonLines(columnWidth));
+
+        var rightColumnLines = new List<string>();
+        rightColumnLines.AddRange(GetLocationLines(columnWidth));
+
+        while (leftColumnLines.Count < Console.WindowHeight - 1)
+        {
+            leftColumnLines.Add("");
+        }
+
+        while (rightColumnLines.Count < Console.WindowHeight - 1)
+        {
+            rightColumnLines.Add("");
+        }
+
+        var sb = new StringBuilder();
+
+        foreach (var line in topLines)
+        {
+            sb.AppendLine(line);
+        }
+
+        for (var i = 0; i < leftColumnLines.Count && i < Console.WindowHeight - topLines.Count - 1; i++)
+        {
+            // Retrieve and pad left column, trimming if needed
+            var leftColumn = leftColumnLines[i];
+            if (leftColumn.Length > columnWidth)
+            {
+                leftColumn = leftColumn[..(columnWidth - 3)] + "...     ";
+            }
+            else
+            {
+                leftColumn = leftColumn.PadRight(columnWidth);
+            }
+
+            // Retrieve right column, trimming if needed
+            var rightColumn = rightColumnLines[i];
+            if (rightColumn.Length > columnWidth)
+            {
+                rightColumn = rightColumn[..(columnWidth - 3)] + "...";
+            }
+
+            sb.AppendLine($"{leftColumn}     {rightColumn}");
+        }
+
+        Console.Clear();
+        Console.Write(sb.ToString());
+    }
+
+    private List<string> GetHeaderLines(int columnWidth)
+    {
+        var lines = new List<string>();
+
+        var connected = $"Connected: {_tracker.AutoTracker?.IsConnected == true}";
+
+        switch (_tracker.AutoTracker?.CurrentGame)
+        {
+            case Game.Zelda:
+                lines.Add($"{connected} | {_tracker.AutoTracker.ZeldaState}");
+                break;
+            case Game.SM:
+                lines.Add($"{connected} | {_tracker.AutoTracker.MetroidState}");
+                break;
+            default:
+                lines.Add(connected);
+                break;
+        }
+
+        lines.Add(new string('-', columnWidth * 2 + 5));
+
+        return lines;
+    }
+
+    private IEnumerable<string> GetDungeonLines(int columnWidth)
+    {
+        var lines = new List<string> { "Dungeons", new('-', columnWidth) };
+
+        var dungeons = _world.Dungeons
+            .Select(x => GetDungeonDetails(x).PadRight(18))
+            .ToList();
+
+        var dungeonLine = "";
+        foreach (var dungeon in dungeons)
+        {
+            if (dungeonLine == "")
+            {
+                dungeonLine = dungeon;
+            }
+            else if ($"{dungeonLine}{dungeon}".Length > columnWidth)
+            {
+                lines.Add(dungeonLine);
+                dungeonLine = dungeon;
+            }
+            else
+            {
+                dungeonLine += dungeon;
+            }
+        }
+        lines.Add(dungeonLine);
+
+        return lines;
+    }
+
+    private IEnumerable<string> GetLocationLines(int columnWidth)
+    {
+        var lines = new List<string> { "Locations", new('-', columnWidth) };
+
+        var locations = _worldService.Locations(unclearedOnly: true, outOfLogic: false, assumeKeys: true,
+            sortByTopRegion: true, regionFilter: RegionFilter.None).ToList();
+
+        var regionCounts = locations
+            .GroupBy(x => x.Region)
+            .OrderByDescending(x => x.Count())
+            .ToDictionary(x => x.Key, x => x.Count());
+
+        var locationNames = locations
+            .OrderByDescending(x => x.Region == _lastRegion)
+            .ThenByDescending(x => regionCounts[x.Region])
+            .ThenBy(x => x.ToString())
+            .Select(x => x.ToString());
+        lines.AddRange(locationNames);
+
+        return lines;
+    }
+
+    private IEnumerable<string> GetInventoryLines(int columnWidth)
+    {
+        var lines = new List<string> { "Inventory", new('-', columnWidth) };
+
+        var itemNames = _world.AllItems.Where(x => x.State.TrackingState > 0)
+            .DistinctBy(x => x.Type)
+            .Where(x => !x.Type.IsInAnyCategory(ItemCategory.Junk, ItemCategory.Map, ItemCategory.Compass, ItemCategory.Keycard, ItemCategory.BigKey, ItemCategory.SmallKey) || x.Type is ItemType.Missile or ItemType.Super or ItemType.PowerBomb or ItemType.ETank)
+            .OrderBy(x => x.Type.IsInCategory(ItemCategory.Metroid))
+            .ThenBy(x => x.Name)
+            .Select(x => x.Metadata.HasStages || x.Metadata.Multiple
+                ? $"{x.Name} ({x.State.TrackingState})"
+                : x.Name)
+            .ToList();
+
+        for (var i = 0; i < itemNames.Count; i += 2)
+        {
+            if (i < itemNames.Count - 1)
+            {
+                lines.Add(itemNames[i].PadRight(columnWidth/2) + itemNames[i+1]);
+            }
+            else
+            {
+                lines.Add(itemNames[i]);
+            }
+        }
+
+        return lines;
+    }
+
+    private string GetDungeonDetails(IDungeon dungeon)
+    {
+        var state = dungeon.DungeonState.Cleared ? "\u2713" : "\u274c";
+        var abbreviation = dungeon.DungeonMetadata.Abbreviation;
+
+        var reward = dungeon is IHasReward
+            ? dungeon.MarkedReward switch
+                {
+                    RewardType.None => "??",
+                    RewardType.CrystalBlue => "BC",
+                    RewardType.CrystalRed => "RC",
+                    RewardType.PendantBlue => "BP",
+                    RewardType.PendantGreen => "GP",
+                    RewardType.PendantRed => "RP",
+                    _ => null
+                }
+            : null;
+
+        var requirement = dungeon is INeedsMedallion
+            ? dungeon.MarkedMedallion switch
+            {
+                ItemType.Quake => "Q",
+                ItemType.Bombos => "B",
+                ItemType.Ether => "E",
+                _ => "?"
+            }
+            : null;
+
+        var rewardRequirement = "";
+        if (reward != null)
+        {
+            rewardRequirement = requirement == null ? $" ({reward})" : $" ({reward}/{requirement})";
+        }
+
+        return $"{state} {abbreviation}{rewardRequirement}: {dungeon.DungeonState.RemainingTreasure}";
+    }
+
+}

--- a/src/Randomizer.CrossPlatform/Program.cs
+++ b/src/Randomizer.CrossPlatform/Program.cs
@@ -7,7 +7,6 @@ using Randomizer.Data.Options;
 using Randomizer.Data.Services;
 using Randomizer.SMZ3.Generation;
 using Serilog;
-using Serilog.Events;
 
 namespace Randomizer.CrossPlatform;
 
@@ -17,13 +16,8 @@ public static class Program
 
     public static void Main(string[] args)
     {
-        var logLevel = LogEventLevel.Warning;
-        if (args.Any(x => x == "-v"))
-            logLevel = LogEventLevel.Information;
-
         Log.Logger = new LoggerConfiguration()
             .Enrich.FromLogContext()
-            .WriteTo.Console(logLevel)
             .WriteTo.File(LogPath, rollingInterval: RollingInterval.Day, retainedFileCountLimit: 30)
             .CreateLogger();
 
@@ -45,6 +39,8 @@ public static class Program
         {
             return;
         }
+
+        Console.WriteLine($"Using Randomizer Options file at {optionsFile.FullName}");
 
         var result = DisplayMenu("What do you want to do?", new List<string>()
         {
@@ -82,6 +78,7 @@ public static class Program
                 var romPath = Path.Combine(randomizerOptions.RomOutputPath, results.Rom!.RomPath);
                 Console.WriteLine($"Rom generated successfully: {romPath}");
                 Launch(romPath, randomizerOptions);
+                _ = s_services.GetRequiredService<ConsoleTrackerDisplayService>().StartTracking(results.Rom, romPath);
             }
             else
             {
@@ -103,7 +100,9 @@ public static class Program
                 var selectedRom = roms[result.Value.Item1];
                 var romPath = Path.Combine(randomizerOptions.RomOutputPath, selectedRom.RomPath);
                 Launch(romPath, randomizerOptions);
+                _ = s_services.GetRequiredService<ConsoleTrackerDisplayService>().StartTracking(selectedRom, romPath);
             }
+
         }
         // Deletes rom(s)
         else if (result.Value.Item1 == 2)

--- a/src/Randomizer.CrossPlatform/Randomizer.CrossPlatform.csproj
+++ b/src/Randomizer.CrossPlatform/Randomizer.CrossPlatform.csproj
@@ -20,6 +20,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Randomizer.Data\Randomizer.Data.csproj" />
+      <ProjectReference Include="..\Randomizer.SMZ3.Tracking\Randomizer.SMZ3.Tracking.csproj" />
       <ProjectReference Include="..\Randomizer.SMZ3.Twitch\Randomizer.SMZ3.Twitch.csproj" />
       <ProjectReference Include="..\Randomizer.SMZ3\Randomizer.SMZ3.csproj" />
       <ProjectReference Include="..\Randomizer.Sprites\Randomizer.Sprites.csproj" />

--- a/src/Randomizer.CrossPlatform/ServiceCollectionExtensions.cs
+++ b/src/Randomizer.CrossPlatform/ServiceCollectionExtensions.cs
@@ -3,7 +3,11 @@ using MSURandomizerLibrary;
 using Randomizer.Data.Configuration;
 using Randomizer.Data.Options;
 using Randomizer.Data.Services;
+using Randomizer.Multiplayer.Client;
 using Randomizer.SMZ3.ChatIntegration;
+using Randomizer.SMZ3.Tracking;
+using Randomizer.SMZ3.Tracking.AutoTracking;
+using Randomizer.SMZ3.Tracking.VoiceCommands;
 using Randomizer.SMZ3.Twitch;
 using Randomizer.Sprites;
 
@@ -16,8 +20,16 @@ public static class ServiceCollectionExtensions
         // Randomizer + Tracker
         services.AddConfigs();
         services.AddRandomizerServices();
-
+        services.AddTracker()
+            .AddOptionalModule<PegWorldModeModule>()
+            .AddOptionalModule<SpoilerModule>()
+            .AddOptionalModule<AutoTrackerModule>()
+            .AddOptionalModule<MapModule>()
+            .AddOptionalModule<GameService>();
+        services.AddScoped<AutoTracker>();
         services.AddSingleton<ITrackerStateService, TrackerStateService>();
+        services.AddMultiplayerServices();
+
         services.AddSingleton<SpriteService>();
 
         // Chat
@@ -32,6 +44,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<OptionsFactory>();
         services.AddSingleton<IGameDbService, GameDbService>();
         services.AddTransient<SourceRomValidationService>();
+        services.AddTransient<ConsoleTrackerDisplayService>();
 
         return services;
     }

--- a/src/Randomizer.Data/Options/RandomizerOptions.cs
+++ b/src/Randomizer.Data/Options/RandomizerOptions.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Randomizer.Data.Logic;
+using Randomizer.Shared.Enums;
 using YamlDotNet.Serialization;
 
 namespace Randomizer.Data.Options
@@ -91,7 +92,7 @@ namespace Randomizer.Data.Options
         [YamlIgnore]
         public EmulatorConnectorType AutoTrackerDefaultConnector
         {
-            get => (EmulatorConnectorType)GeneralOptions.AutoTrackerDefaultConnector;
+            get => GeneralOptions.AutoTrackerDefaultConnectionType;
         }
 
         [YamlIgnore]
@@ -115,6 +116,12 @@ namespace Randomizer.Data.Options
             {
                 var options = JsonSerializer.Deserialize<RandomizerOptions>(fileText, s_jsonOptions) ?? new();
                 options.FilePath = savePath;
+                options.GeneralOptions.AutoTrackerDefaultConnectionType =
+                    (EmulatorConnectorType)options.GeneralOptions.AutoTrackerDefaultConnector;
+                options.GeneralOptions.TrackerVoiceFrequency =
+                    (TrackerVoiceFrequency)options.GeneralOptions.VoiceFrequency;
+                options.GeneralOptions.LaunchButtonOption =
+                    (LaunchButtonOptions)options.GeneralOptions.LaunchButton;
                 return options;
             }
         }

--- a/src/Randomizer.Data/Options/TrackerOptions.cs
+++ b/src/Randomizer.Data/Options/TrackerOptions.cs
@@ -110,5 +110,10 @@ namespace Randomizer.Data
         /// The file to write the current song to
         /// </summary>
         public string? MsuTrackOutputPath { get; set; }
+
+        /// <summary>
+        /// Automatically tracks the map and other "hey tracker, look at this" events when viewing
+        /// </summary>
+        public bool AutoSaveLookAtEvents { get; set; }
     }
 }

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/GameService.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/GameService.cs
@@ -583,5 +583,10 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking
             }
             return false;
         }
+
+        public override void AddCommands()
+        {
+
+        }
     }
 }

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/ViewedMap.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/ViewedMap.cs
@@ -52,10 +52,18 @@ namespace Randomizer.SMZ3.Tracking.AutoTracking.ZeldaStateChecks
                 if (currentRegion is LightWorldNorthWest or LightWorldNorthEast or LightWorldSouth or LightWorldDeathMountainEast or LightWorldDeathMountainWest)
                 {
                     tracker.AutoTracker.LatestViewAction = new AutoTrackerViewedAction(UpdateLightWorldRewards);
+                    if (tracker.Options.AutoSaveLookAtEvents)
+                    {
+                        tracker.AutoTracker.LatestViewAction.Invoke();
+                    }
                 }
                 else if (currentRegion is DarkWorldNorthWest or DarkWorldNorthEast or DarkWorldSouth or DarkWorldMire or DarkWorldDeathMountainEast or DarkWorldDeathMountainWest)
                 {
                     tracker.AutoTracker.LatestViewAction = new AutoTrackerViewedAction(UpdateDarkWorldRewards);
+                    if (tracker.Options.AutoSaveLookAtEvents)
+                    {
+                        tracker.AutoTracker.LatestViewAction.Invoke();
+                    }
                 }
 
                 return true;

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/ViewedMedallion.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/ViewedMedallion.cs
@@ -31,7 +31,7 @@ public class ViewedMedallion : IZeldaStateCheck
     /// <returns>True if the check was identified, false otherwise</returns>
     public bool ExecuteCheck(Tracker tracker, AutoTrackerZeldaState currentState, AutoTrackerZeldaState prevState)
     {
-        if (tracker.AutoTracker == null) return false;
+        if (tracker.AutoTracker == null || tracker.AutoTracker.LatestViewAction?.IsValid == true) return false;
 
         _tracker = tracker;
 
@@ -41,11 +41,19 @@ public class ViewedMedallion : IZeldaStateCheck
         if (currentState.OverworldScreen == 112 && x is >= 172 and <= 438 && y is >= 3200 and <= 3432)
         {
             tracker.AutoTracker.LatestViewAction = new AutoTrackerViewedAction(MarkMiseryMireMedallion);
+            if (tracker.Options.AutoSaveLookAtEvents)
+            {
+                tracker.AutoTracker.LatestViewAction.Invoke();
+            }
             return true;
         }
         else if (currentState.OverworldScreen == 71 && x is >= 3708 and <= 4016 && y is >= 128 and <= 368)
         {
             tracker.AutoTracker.LatestViewAction = new AutoTrackerViewedAction(MarkTurtleRockMedallion);
+            if (tracker.Options.AutoSaveLookAtEvents)
+            {
+                tracker.AutoTracker.LatestViewAction.Invoke();
+            }
             return true;
         }
 

--- a/src/Randomizer.SMZ3.Tracking/Services/ISpeechRecognitionService.cs
+++ b/src/Randomizer.SMZ3.Tracking/Services/ISpeechRecognitionService.cs
@@ -1,0 +1,46 @@
+using System.Speech.Recognition;
+
+namespace Randomizer.SMZ3.Tracking.Services;
+
+/// <summary>
+/// Service for recognizing speech from a microphone
+/// </summary>
+public interface ISpeechRecognitionService
+{
+    /// <summary>
+    /// Event fired when speech was successfully understood
+    /// </summary>
+    public event System.EventHandler<SpeechRecognizedEventArgs>? SpeechRecognized;
+
+    /// <summary>
+    /// Updates the microphone to be the default Windows mic
+    /// </summary>
+    public void SetInputToDefaultAudioDevice();
+
+    /// <summary>
+    /// The internal speech recognition engine used by the service, if applicable
+    /// </summary>
+    public SpeechRecognitionEngine? RecognitionEngine { get; }
+
+    /// <summary>
+    /// Stop recognizing speech
+    /// </summary>
+    public void RecognizeAsyncStop();
+
+    /// <summary>
+    /// Start recognizing speech
+    /// </summary>
+    /// <param name="Mode">The recognition mode (single/multiple)</param>
+    public void RecognizeAsync(RecognizeMode Mode);
+
+    /// <summary>
+    /// Initializes the microphone to the default Windows mic
+    /// </summary>
+    /// <returns>True if successful, false otherwise</returns>
+    public bool InitializeMicrophone();
+
+    /// <summary>
+    /// Disposes of the service and speech recognition engine
+    /// </summary>
+    public void Dispose();
+}

--- a/src/Randomizer.SMZ3.Tracking/Services/SpeechRecognitionServiceDisabled.cs
+++ b/src/Randomizer.SMZ3.Tracking/Services/SpeechRecognitionServiceDisabled.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Speech.Recognition;
+
+namespace Randomizer.SMZ3.Tracking.Services;
+
+public class SpeechRecognitionServiceDisabled : ISpeechRecognitionService
+{
+    public event EventHandler<SpeechRecognizedEventArgs>? SpeechRecognized;
+
+    public void SetInputToDefaultAudioDevice()
+    {
+
+    }
+
+    public SpeechRecognitionEngine? RecognitionEngine => null;
+
+    public void RecognizeAsyncStop()
+    {
+    }
+
+    public void RecognizeAsync(RecognizeMode Mode)
+    {
+
+    }
+
+    public bool InitializeMicrophone()
+    {
+        return false;
+    }
+
+    public void Dispose()
+    {
+
+    }
+}

--- a/src/Randomizer.SMZ3.Tracking/Services/SpeechRecognitionServiceEnabled.cs
+++ b/src/Randomizer.SMZ3.Tracking/Services/SpeechRecognitionServiceEnabled.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+using System.Speech.Recognition;
+using Microsoft.Extensions.Logging;
+
+namespace Randomizer.SMZ3.Tracking.Services;
+
+[SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
+public class SpeechRecognitionServiceEnabled : ISpeechRecognitionService
+{
+    private readonly ILogger<SpeechRecognitionServiceEnabled> _logger;
+    private readonly SpeechRecognitionEngine _recognizer = new();
+
+    /// <summary>
+    /// Dll to get the number of microphones
+    /// </summary>
+    /// <returns></returns>
+    [DllImport("winmm.dll")]
+    private static extern int waveInGetNumDevs();
+
+    public SpeechRecognitionServiceEnabled(ILogger<SpeechRecognitionServiceEnabled> logger)
+    {
+        _logger = logger;
+        _recognizer.SpeechRecognized += RecognizerOnSpeechRecognized;
+    }
+
+    private void RecognizerOnSpeechRecognized(object? sender, SpeechRecognizedEventArgs e)
+    {
+        SpeechRecognized?.Invoke(sender, e);
+    }
+
+    public event EventHandler<SpeechRecognizedEventArgs>? SpeechRecognized;
+
+    public void SetInputToDefaultAudioDevice() => _recognizer.SetInputToDefaultAudioDevice();
+
+    public SpeechRecognitionEngine? RecognitionEngine => _recognizer;
+
+    public void RecognizeAsyncStop() =>_recognizer.RecognizeAsyncStop();
+
+    public void RecognizeAsync(RecognizeMode mode) => _recognizer.RecognizeAsync(mode);
+
+    public bool InitializeMicrophone()
+    {
+        try
+        {
+            if (waveInGetNumDevs() == 0)
+            {
+                _logger.LogWarning("No microphone device found.");
+                return false;
+            }
+            _recognizer.SetInputToDefaultAudioDevice();
+            return true;
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error initializing microphone");
+            return false;
+        }
+    }
+
+    public void Dispose() => _recognizer.Dispose();
+}

--- a/src/Randomizer.SMZ3.Tracking/Services/TextToSpeechCommunicator.cs
+++ b/src/Randomizer.SMZ3.Tracking/Services/TextToSpeechCommunicator.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Speech.Synthesis;
-using Randomizer.Data;
 using Randomizer.Data.Options;
 
 namespace Randomizer.SMZ3.Tracking.Services
@@ -11,7 +10,7 @@ namespace Randomizer.SMZ3.Tracking.Services
     /// </summary>
     public class TextToSpeechCommunicator : ICommunicator, IDisposable
     {
-        private readonly SpeechSynthesizer _tts;
+        private readonly SpeechSynthesizer _tts = null!;
         private bool _canSpeak;
 
         /// <summary>
@@ -20,6 +19,11 @@ namespace Randomizer.SMZ3.Tracking.Services
         /// </summary>
         public TextToSpeechCommunicator(TrackerOptionsAccessor trackerOptionsAccessor)
         {
+            if (!OperatingSystem.IsWindows())
+            {
+                return;
+            }
+
             _tts = new SpeechSynthesizer();
             _tts.SelectVoiceByHints(VoiceGender.Female);
             _canSpeak = trackerOptionsAccessor.Options?.VoiceFrequency != Shared.Enums.TrackerVoiceFrequency.Disabled;
@@ -29,13 +33,26 @@ namespace Randomizer.SMZ3.Tracking.Services
         /// Selects a different text-to-speech voice.
         /// </summary>
         public void UseAlternateVoice()
-            => _tts.SelectVoiceByHints(VoiceGender.Male);
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                return;
+            }
+
+            _tts.SelectVoiceByHints(VoiceGender.Male);
+        }
 
         /// <summary>
         /// Aborts all current and queued up text-to-speech actions.
         /// </summary>
         public void Abort()
-            => _tts.SpeakAsyncCancelAll();
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                return;
+            }
+            _tts.SpeakAsyncCancelAll();
+        }
 
         /// <summary>
         /// Speaks the specified text or SSML.
@@ -45,9 +62,17 @@ namespace Randomizer.SMZ3.Tracking.Services
         /// </param>
         public void Say(string text)
         {
+            if (!OperatingSystem.IsWindows())
+            {
+                return;
+            }
+
             if (!_canSpeak) return;
             var prompt = GetPromptFromText(text);
-            _tts.SpeakAsync(prompt);
+            if (prompt != null)
+            {
+                _tts.SpeakAsync(prompt);
+            }
         }
 
         /// <summary>
@@ -59,9 +84,17 @@ namespace Randomizer.SMZ3.Tracking.Services
         /// </param>
         public void SayWait(string text)
         {
+            if (!OperatingSystem.IsWindows())
+            {
+                return;
+            }
+
             if (!_canSpeak) return;
             var prompt = GetPromptFromText(text);
-            _tts.Speak(prompt);
+            if (prompt != null)
+            {
+                _tts.Speak(prompt);
+            }
         }
 
         /// <summary>
@@ -69,6 +102,11 @@ namespace Randomizer.SMZ3.Tracking.Services
         /// </summary>
         public void SpeedUp()
         {
+            if (!OperatingSystem.IsWindows())
+            {
+                return;
+            }
+
             _tts.Rate += 2;
         }
 
@@ -77,6 +115,11 @@ namespace Randomizer.SMZ3.Tracking.Services
         /// </summary>
         public void SlowDown()
         {
+            if (!OperatingSystem.IsWindows())
+            {
+                return;
+            }
+
             _tts.Rate -= 2;
         }
 
@@ -92,8 +135,13 @@ namespace Randomizer.SMZ3.Tracking.Services
         /// </summary>
         /// <param name="text">The plain text or SSML markup to parse.</param>
         /// <returns>A new <see cref="Prompt"/>.</returns>
-        protected static Prompt GetPromptFromText(string text)
+        protected static Prompt? GetPromptFromText(string text)
         {
+            if (!OperatingSystem.IsWindows())
+            {
+                return null;
+            }
+
             // If text does not contain any XML elements, just interpret it as
             // text
             if (!text.Contains("<") && !text.Contains("/>"))
@@ -110,7 +158,7 @@ namespace Randomizer.SMZ3.Tracking.Services
         /// <param name="disposing"></param>
         protected virtual void Dispose(bool disposing)
         {
-            if (disposing)
+            if (disposing && OperatingSystem.IsWindows())
             {
                 _tts.Dispose();
             }

--- a/src/Randomizer.SMZ3.Tracking/TrackerServiceCollectionExtensions.cs
+++ b/src/Randomizer.SMZ3.Tracking/TrackerServiceCollectionExtensions.cs
@@ -42,6 +42,15 @@ namespace Randomizer.SMZ3.Tracking
             services.AddScoped<IRandomizerConfigService, RandomizerConfigService>();
             services.AddScoped<Tracker>();
 
+            if (OperatingSystem.IsWindows())
+            {
+                services.AddScoped<ISpeechRecognitionService, SpeechRecognitionServiceEnabled>();
+            }
+            else
+            {
+                services.AddScoped<ISpeechRecognitionService, SpeechRecognitionServiceDisabled>();
+            }
+
             var assemblies = new[] { Assembly.GetExecutingAssembly() };
 
             var zeldaStateChecks = assemblies
@@ -63,7 +72,7 @@ namespace Randomizer.SMZ3.Tracking
             return services;
         }
 
-        
+
 
         /// <summary>
         /// Enables the specified tracker module.

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/AutoTrackerModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/AutoTrackerModule.cs
@@ -27,11 +27,6 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
         {
             Tracker.AutoTracker = autoTracker;
             _autoTracker = autoTracker;
-
-            AddCommand("Look at this", GetLookAtGameRule(), (result) =>
-            {
-                LookAtGame();
-            });
         }
 
         private GrammarBuilder GetLookAtGameRule()
@@ -57,6 +52,14 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
         public void Dispose()
         {
             _autoTracker.SetConnector(EmulatorConnectorType.None, "");
+        }
+
+        public override void AddCommands()
+        {
+            AddCommand("Look at this", GetLookAtGameRule(), (result) =>
+            {
+                LookAtGame();
+            });
         }
     }
 

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/BossTrackingModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/BossTrackingModule.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 
 using Randomizer.Shared;
@@ -22,86 +23,7 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
         public BossTrackingModule(Tracker tracker, IItemService itemService, IWorldService worldService, ILogger<BossTrackingModule> logger)
             : base(tracker, itemService, worldService, logger)
         {
-            AddCommand("Mark boss as defeated", GetMarkBossAsDefeatedRule(), (result) =>
-            {
-                var dungeon = GetBossDungeonFromResult(tracker, result);
-                if (dungeon != null)
-                {
-                    // Track boss with associated dungeon
-                    tracker.MarkDungeonAsCleared(dungeon, result.Confidence);
-                    return;
-                }
 
-                var boss = GetBossFromResult(tracker, result);
-                if (boss != null)
-                {
-                    // Track standalone boss
-                    var admittedGuilt = result.Text.ContainsAny("killed", "beat", "defeated", "dead")
-                        && !result.Text.ContainsAny("beat off", "beaten off");
-                    tracker.MarkBossAsDefeated(boss, admittedGuilt, result.Confidence);
-                    return;
-                }
-
-                throw new Exception($"Could not find boss or dungeon in command: '{result.Text}'");
-            });
-
-            AddCommand("Mark boss as alive", GetMarkBossAsNotDefeatedRule(), (result) =>
-            {
-                var dungeon = GetBossDungeonFromResult(tracker, result);
-                if (dungeon != null)
-                {
-                    // Untrack boss with associated dungeon
-                    tracker.MarkDungeonAsIncomplete(dungeon, result.Confidence);
-                    return;
-                }
-
-                var boss = GetBossFromResult(tracker, result);
-                if (boss != null)
-                {
-                    // Untrack standalone boss
-                    tracker.MarkBossAsNotDefeated(boss, result.Confidence);
-                    return;
-                }
-
-                throw new Exception($"Could not find boss or dungeon in command: '{result.Text}'");
-            });
-
-            AddCommand("Mark boss as defeated with content", GetBossDefeatedWithContentRule(), (result) =>
-            {
-                var contentItemData = itemService.FirstOrDefault("Content");
-
-                var dungeon = GetBossDungeonFromResult(tracker, result);
-                if (dungeon != null)
-                {
-                    if (contentItemData != null)
-                    {
-                        Tracker.Say(x => x.DungeonBossClearedAddContent);
-                        Tracker.TrackItem(contentItemData);
-                    }
-
-                    // Track boss with associated dungeon
-                    tracker.MarkDungeonAsCleared(dungeon, result.Confidence);
-                    return;
-                }
-
-                var boss = GetBossFromResult(tracker, result);
-                if (boss != null)
-                {
-                    if (contentItemData != null)
-                    {
-                        Tracker.Say(x => x.DungeonBossClearedAddContent);
-                        Tracker.TrackItem(contentItemData);
-                    }
-
-                    // Track standalone boss
-                    var admittedGuilt = result.Text.ContainsAny("killed", "beat", "defeated", "dead")
-                        && !result.Text.ContainsAny("beat off", "beaten off");
-                    tracker.MarkBossAsDefeated(boss, admittedGuilt, result.Confidence);
-                    return;
-                }
-
-                throw new Exception($"Could not find boss or dungeon in command: '{result.Text}'");
-            });
         }
 
         private GrammarBuilder GetMarkBossAsDefeatedRule()
@@ -161,6 +83,91 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
                 .Append(BossKey, bossNames);
 
             return GrammarBuilder.Combine(beatBoss, oneCycled);
+        }
+
+        [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
+        public override void AddCommands()
+        {
+            AddCommand("Mark boss as defeated", GetMarkBossAsDefeatedRule(), (result) =>
+            {
+                var dungeon = GetBossDungeonFromResult(Tracker, result);
+                if (dungeon != null)
+                {
+                    // Track boss with associated dungeon
+                    Tracker.MarkDungeonAsCleared(dungeon, result.Confidence);
+                    return;
+                }
+
+                var boss = GetBossFromResult(Tracker, result);
+                if (boss != null)
+                {
+                    // Track standalone boss
+                    var admittedGuilt = result.Text.ContainsAny("killed", "beat", "defeated", "dead")
+                        && !result.Text.ContainsAny("beat off", "beaten off");
+                    Tracker.MarkBossAsDefeated(boss, admittedGuilt, result.Confidence);
+                    return;
+                }
+
+                throw new Exception($"Could not find boss or dungeon in command: '{result.Text}'");
+            });
+
+            AddCommand("Mark boss as alive", GetMarkBossAsNotDefeatedRule(), (result) =>
+            {
+                var dungeon = GetBossDungeonFromResult(Tracker, result);
+                if (dungeon != null)
+                {
+                    // Untrack boss with associated dungeon
+                    Tracker.MarkDungeonAsIncomplete(dungeon, result.Confidence);
+                    return;
+                }
+
+                var boss = GetBossFromResult(Tracker, result);
+                if (boss != null)
+                {
+                    // Untrack standalone boss
+                    Tracker.MarkBossAsNotDefeated(boss, result.Confidence);
+                    return;
+                }
+
+                throw new Exception($"Could not find boss or dungeon in command: '{result.Text}'");
+            });
+
+            AddCommand("Mark boss as defeated with content", GetBossDefeatedWithContentRule(), (result) =>
+            {
+                var contentItemData = ItemService.FirstOrDefault("Content");
+
+                var dungeon = GetBossDungeonFromResult(Tracker, result);
+                if (dungeon != null)
+                {
+                    if (contentItemData != null)
+                    {
+                        Tracker.Say(x => x.DungeonBossClearedAddContent);
+                        Tracker.TrackItem(contentItemData);
+                    }
+
+                    // Track boss with associated dungeon
+                    Tracker.MarkDungeonAsCleared(dungeon, result.Confidence);
+                    return;
+                }
+
+                var boss = GetBossFromResult(Tracker, result);
+                if (boss != null)
+                {
+                    if (contentItemData != null)
+                    {
+                        Tracker.Say(x => x.DungeonBossClearedAddContent);
+                        Tracker.TrackItem(contentItemData);
+                    }
+
+                    // Track standalone boss
+                    var admittedGuilt = result.Text.ContainsAny("killed", "beat", "defeated", "dead")
+                        && !result.Text.ContainsAny("beat off", "beaten off");
+                    Tracker.MarkBossAsDefeated(boss, admittedGuilt, result.Confidence);
+                    return;
+                }
+
+                throw new Exception($"Could not find boss or dungeon in command: '{result.Text}'");
+            });
         }
     }
 }

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/ChatIntegrationModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/ChatIntegrationModule.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Speech.Recognition;
 using System.Text.RegularExpressions;
@@ -54,27 +55,6 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
             ChatClient.MessageReceived += ChatClient_MessageReceived;
             ChatClient.Disconnected += ChatClient_Disconnected;
             ChatClient.SendMessageFailure += ChatClient_SendMessageFailure;
-
-            AddCommand("Start Ganon's Tower Big Key Guessing Game", GetStartGuessingGameRule(), async (result) =>
-            {
-                await StartGanonsTowerGuessingGame();
-            });
-
-            AddCommand("Close Ganon's Tower Big Key Guessing Game", GetStopGuessingGameGuessesRule(), async (result) =>
-            {
-                await CloseGanonsTowerGuessingGameGuesses();
-            });
-
-            AddCommand("Declare Ganon's Tower Big Key Guessing Game Winner", GetRevealGuessingGameWinnerRule(), async (result) =>
-            {
-                var winningNumber = (int)result.Semantics[WinningGuessKey].Value;
-                await DeclareGanonsTowerGuessingGameWinner(winningNumber);
-            });
-
-            AddCommand("Track Content", GetTrackContent(), async (result) =>
-            {
-                await AskChatAboutContent();
-            });
         }
 
         /// <summary>
@@ -545,6 +525,31 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
                 .Optional("please", "would you kindly")
                 .OneOf("track", "add")
                 .OneOf("content", "con-tent");
+        }
+
+        [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
+        public override void AddCommands()
+        {
+            AddCommand("Start Ganon's Tower Big Key Guessing Game", GetStartGuessingGameRule(), async (result) =>
+            {
+                await StartGanonsTowerGuessingGame();
+            });
+
+            AddCommand("Close Ganon's Tower Big Key Guessing Game", GetStopGuessingGameGuessesRule(), async (result) =>
+            {
+                await CloseGanonsTowerGuessingGameGuesses();
+            });
+
+            AddCommand("Declare Ganon's Tower Big Key Guessing Game Winner", GetRevealGuessingGameWinnerRule(), async (result) =>
+            {
+                var winningNumber = (int)result.Semantics[WinningGuessKey].Value;
+                await DeclareGanonsTowerGuessingGameWinner(winningNumber);
+            });
+
+            AddCommand("Track Content", GetTrackContent(), async (result) =>
+            {
+                await AskChatAboutContent();
+            });
         }
     }
 }

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/CheatsModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/CheatsModule.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Speech.Recognition;
 using Microsoft.Extensions.Logging;
@@ -36,59 +37,7 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
         public CheatsModule(Tracker tracker, IItemService itemService, IWorldService worldService, ILogger<CheatsModule> logger)
             : base(tracker, itemService, worldService, logger)
         {
-            if (tracker.World.Config.Race || tracker.World.Config.DisableCheats) return;
 
-            AddCommand("Enable cheats", GetEnableCheatsRule(), (result) =>
-            {
-                _cheatsEnabled = true;
-                Tracker.Say(x => x.Cheats.EnabledCheats);
-            });
-
-            AddCommand("Disable cheats", GetDisableHintsRule(), (result) =>
-            {
-                _cheatsEnabled = false;
-                Tracker.Say(x => x.Cheats.DisabledCheats);
-            });
-
-            AddCommand("Fill rule", FillRule(), (result) =>
-            {
-                var fillType = result.Semantics.ContainsKey(s_fillCheatKey) ? (string)result.Semantics[s_fillCheatKey].Value : s_fillHealthChoices.First();
-                Fill(fillType);
-            });
-
-            AddCommand("Give item", GiveItemRule(), (result) =>
-            {
-                var item = GetItemFromResult(tracker, result, out var itemName);
-                GiveItem(item);
-            });
-
-            AddCommand("Kill player", KillPlayerRule(), (result) =>
-            {
-                if (!PlayerCanCheat()) return;
-
-                if (Tracker.GameService?.TryKillPlayer() == true)
-                {
-                    Tracker.Say(x => x.Cheats.CheatPerformed);
-                }
-                else
-                {
-                    Tracker.Say(x => x.Cheats.CheatFailed);
-                }
-            });
-
-            AddCommand("Setup Crystal Flash", SetupCrystalFlashRule(), (result) =>
-            {
-                if (!PlayerCanCheat()) return;
-
-                if (Tracker.GameService?.TrySetupCrystalFlash() == true)
-                {
-                    Tracker.Say(x => x.Cheats.CheatPerformed);
-                }
-                else
-                {
-                    Tracker.Say(x => x.Cheats.CheatFailed);
-                }
-            });
         }
 
         private bool PlayerCanCheat()
@@ -192,6 +141,7 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
                 .OneOf("cheats", "cheat codes", "sv_cheats");
         }
 
+        [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
         private static GrammarBuilder FillRule()
         {
             var fillChoices = new Choices();
@@ -243,6 +193,64 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
                 .Append("Hey tracker,")
                 .Optional("please", "would you kindly")
                 .OneOf("setup crystal flash requirements", "ready a crystal flash");
+        }
+
+        [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
+        public override void AddCommands()
+        {
+            if (Tracker.World.Config.Race || Tracker.World.Config.DisableCheats) return;
+
+            AddCommand("Enable cheats", GetEnableCheatsRule(), (result) =>
+            {
+                _cheatsEnabled = true;
+                Tracker.Say(x => x.Cheats.EnabledCheats);
+            });
+
+            AddCommand("Disable cheats", GetDisableHintsRule(), (result) =>
+            {
+                _cheatsEnabled = false;
+                Tracker.Say(x => x.Cheats.DisabledCheats);
+            });
+
+            AddCommand("Fill rule", FillRule(), (result) =>
+            {
+                var fillType = result.Semantics.ContainsKey(s_fillCheatKey) ? (string)result.Semantics[s_fillCheatKey].Value : s_fillHealthChoices.First();
+                Fill(fillType);
+            });
+
+            AddCommand("Give item", GiveItemRule(), (result) =>
+            {
+                var item = GetItemFromResult(Tracker, result, out var itemName);
+                GiveItem(item);
+            });
+
+            AddCommand("Kill player", KillPlayerRule(), (result) =>
+            {
+                if (!PlayerCanCheat()) return;
+
+                if (Tracker.GameService?.TryKillPlayer() == true)
+                {
+                    Tracker.Say(x => x.Cheats.CheatPerformed);
+                }
+                else
+                {
+                    Tracker.Say(x => x.Cheats.CheatFailed);
+                }
+            });
+
+            AddCommand("Setup Crystal Flash", SetupCrystalFlashRule(), (result) =>
+            {
+                if (!PlayerCanCheat()) return;
+
+                if (Tracker.GameService?.TrySetupCrystalFlash() == true)
+                {
+                    Tracker.Say(x => x.Cheats.CheatPerformed);
+                }
+                else
+                {
+                    Tracker.Say(x => x.Cheats.CheatFailed);
+                }
+            });
         }
     }
 

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/GoModeModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/GoModeModule.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using Randomizer.Data.Configuration.ConfigFiles;
 using Randomizer.SMZ3.Tracking.Services;
@@ -11,6 +11,7 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
     /// </summary>
     public class GoModeModule : TrackerModule
     {
+        private ResponseConfig _responseConfig;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GoModeModule"/> class.
@@ -23,10 +24,7 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
         public GoModeModule(Tracker tracker, IItemService itemService, IWorldService worldService, ILogger<GoModeModule> logger, ResponseConfig responseConfig)
             : base(tracker, itemService, worldService, logger)
         {
-            AddCommand("Toggle Go Mode", GetGoModeRule(responseConfig.GoModePrompts), (result) =>
-            {
-                tracker.ToggleGoMode(result.Confidence);
-            });
+            _responseConfig = responseConfig;
         }
 
         private GrammarBuilder GetGoModeRule(List<string> prompts)
@@ -34,6 +32,15 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
             return new GrammarBuilder()
                 .Append("Hey tracker,")
                 .OneOf(prompts.ToArray());
+        }
+
+        [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
+        public override void AddCommands()
+        {
+            AddCommand("Toggle Go Mode", GetGoModeRule(_responseConfig.GoModePrompts), (result) =>
+            {
+                Tracker.ToggleGoMode(result.Confidence);
+            });
         }
     }
 }

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/GrammarBuilder.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/GrammarBuilder.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Speech.Recognition;
 
@@ -9,7 +10,7 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
     /// </summary>
     public class GrammarBuilder
     {
-        private readonly System.Speech.Recognition.GrammarBuilder _grammar;
+        private readonly System.Speech.Recognition.GrammarBuilder _grammar = null!;
         private readonly List<string> _elements;
 
         /// <summary>
@@ -18,7 +19,10 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
         /// </summary>
         public GrammarBuilder()
         {
-            _grammar = new();
+            if (OperatingSystem.IsWindows())
+            {
+                _grammar = new();
+            }
             _elements = new();
         }
 
@@ -30,6 +34,10 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
         public GrammarBuilder(IEnumerable<GrammarBuilder> choices)
             : this()
         {
+            if (!OperatingSystem.IsWindows())
+            {
+                return;
+            }
             _grammar.Append(new Choices(choices.Select(x => (System.Speech.Recognition.GrammarBuilder)x).ToArray()));
             foreach (var choice in choices)
                 _elements.Add(choice + "\n");
@@ -63,6 +71,10 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
         /// <returns>This instance.</returns>
         public GrammarBuilder Append(string text)
         {
+            if (!OperatingSystem.IsWindows())
+            {
+                return this;
+            }
             _grammar.Append(text);
             _elements.Add(text);
             return this;
@@ -81,6 +93,10 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
         /// <returns>This instance.</returns>
         public GrammarBuilder Append(string key, Choices choices)
         {
+            if (!OperatingSystem.IsWindows())
+            {
+                return this;
+            }
             _grammar.Append(new SemanticResultKey(key, choices));
             _elements.Add($"<{key}>");
             return this;
@@ -95,6 +111,10 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
         /// <returns>This instance.</returns>
         public GrammarBuilder OneOf(params string[] choices)
         {
+            if (!OperatingSystem.IsWindows())
+            {
+                return this;
+            }
             _grammar.Append(new Choices(choices));
             _elements.Add($"[{string.Join('/', choices)}]");
             return this;
@@ -109,6 +129,10 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
         /// <returns>This instance.</returns>
         public GrammarBuilder Optional(string text)
         {
+            if (!OperatingSystem.IsWindows())
+            {
+                return this;
+            }
             _grammar.Append(text, 0, 1);
             _elements.Add($"({text})");
             return this;
@@ -121,6 +145,10 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
         /// <returns>This instance.</returns>
         public GrammarBuilder Optional(params string[] choices)
         {
+            if (!OperatingSystem.IsWindows())
+            {
+                return this;
+            }
             _grammar.Append(new Choices(choices), 0, 1);
             _elements.Add($"({string.Join('/', choices)})");
             return this;

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/LocationTrackingModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/LocationTrackingModule.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Logging;
 
 using Randomizer.SMZ3.Tracking.Services;
 
@@ -20,68 +21,7 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
         public LocationTrackingModule(Tracker tracker, IItemService itemService, IWorldService worldService, ILogger<LocationTrackingModule> logger)
             : base(tracker, itemService, worldService, logger)
         {
-            AddCommand("Mark item at specific location", GetMarkItemAtLocationRule(), (result) =>
-            {
-                var item = GetItemFromResult(tracker, result, out _);
-                var location = GetLocationFromResult(tracker, result);
-                tracker.MarkLocation(location, item, result.Confidence);
-            });
 
-            AddCommand("Clear specific item location", GetClearLocationRule(), (result) =>
-            {
-                var location = GetLocationFromResult(tracker, result);
-                tracker.Clear(location, result.Confidence);
-            });
-
-            AddCommand("Clear available items in an area", GetClearAreaRule(), (result) =>
-            {
-                if (result.Semantics.ContainsKey(RoomKey))
-                {
-                    var room = GetRoomFromResult(tracker, result);
-                    tracker.ClearArea(room,
-                        trackItems: false,
-                        includeUnavailable: false,
-                        confidence: result.Confidence);
-                }
-                else if (result.Semantics.ContainsKey(DungeonKey))
-                {
-                    var dungeon = GetDungeonFromResult(tracker, result);
-                    tracker.ClearDungeon(dungeon, result.Confidence);
-                }
-                else if (result.Semantics.ContainsKey(RegionKey))
-                {
-                    var region = GetRegionFromResult(tracker, result);
-                    tracker.ClearArea(region,
-                        trackItems:false,
-                        includeUnavailable: false,
-                        confidence: result.Confidence);
-                }
-            });
-
-            AddCommand("Clear all items in an area (including out-of-logic)", GetClearAreaIncludingOutOfLogicRule(), (result) =>
-            {
-                if (result.Semantics.ContainsKey(RoomKey))
-                {
-                    var room = GetRoomFromResult(tracker, result);
-                    tracker.ClearArea(room,
-                        trackItems: false,
-                        includeUnavailable: true,
-                        confidence: result.Confidence);
-                }
-                else if (result.Semantics.ContainsKey(DungeonKey))
-                {
-                    var dungeon = GetDungeonFromResult(tracker, result);
-                    tracker.ClearDungeon(dungeon, result.Confidence);
-                }
-                else if (result.Semantics.ContainsKey(RegionKey))
-                {
-                    var region = GetRegionFromResult(tracker, result);
-                    tracker.ClearArea(region,
-                        trackItems:false,
-                        includeUnavailable: true,
-                        confidence: result.Confidence);
-                }
-            });
         }
 
         private GrammarBuilder GetMarkItemAtLocationRule()
@@ -186,6 +126,73 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
                 .Append(RegionKey, regionNames);
 
             return GrammarBuilder.Combine(clearDungeon, clearRoom, clearRegion);
+        }
+
+        [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
+        public override void AddCommands()
+        {
+            AddCommand("Mark item at specific location", GetMarkItemAtLocationRule(), (result) =>
+            {
+                var item = GetItemFromResult(Tracker, result, out _);
+                var location = GetLocationFromResult(Tracker, result);
+                Tracker.MarkLocation(location, item, result.Confidence);
+            });
+
+            AddCommand("Clear specific item location", GetClearLocationRule(), (result) =>
+            {
+                var location = GetLocationFromResult(Tracker, result);
+                Tracker.Clear(location, result.Confidence);
+            });
+
+            AddCommand("Clear available items in an area", GetClearAreaRule(), (result) =>
+            {
+                if (result.Semantics.ContainsKey(RoomKey))
+                {
+                    var room = GetRoomFromResult(Tracker, result);
+                    Tracker.ClearArea(room,
+                        trackItems: false,
+                        includeUnavailable: false,
+                        confidence: result.Confidence);
+                }
+                else if (result.Semantics.ContainsKey(DungeonKey))
+                {
+                    var dungeon = GetDungeonFromResult(Tracker, result);
+                    Tracker.ClearDungeon(dungeon, result.Confidence);
+                }
+                else if (result.Semantics.ContainsKey(RegionKey))
+                {
+                    var region = GetRegionFromResult(Tracker, result);
+                    Tracker.ClearArea(region,
+                        trackItems:false,
+                        includeUnavailable: false,
+                        confidence: result.Confidence);
+                }
+            });
+
+            AddCommand("Clear all items in an area (including out-of-logic)", GetClearAreaIncludingOutOfLogicRule(), (result) =>
+            {
+                if (result.Semantics.ContainsKey(RoomKey))
+                {
+                    var room = GetRoomFromResult(Tracker, result);
+                    Tracker.ClearArea(room,
+                        trackItems: false,
+                        includeUnavailable: true,
+                        confidence: result.Confidence);
+                }
+                else if (result.Semantics.ContainsKey(DungeonKey))
+                {
+                    var dungeon = GetDungeonFromResult(Tracker, result);
+                    Tracker.ClearDungeon(dungeon, result.Confidence);
+                }
+                else if (result.Semantics.ContainsKey(RegionKey))
+                {
+                    var region = GetRegionFromResult(Tracker, result);
+                    Tracker.ClearArea(region,
+                        trackItems:false,
+                        includeUnavailable: true,
+                        confidence: result.Confidence);
+                }
+            });
         }
     }
 }

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/MultiplayerModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/MultiplayerModule.cs
@@ -257,4 +257,8 @@ public class MultiplayerModule : TrackerModule
         await _multiplayerGameService.TrackDeath();
     }
 
+    public override void AddCommands()
+    {
+
+    }
 }

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/PegWorldModeModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/PegWorldModeModule.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Logging;
 
 using Randomizer.SMZ3.Tracking.Services;
 
@@ -22,13 +23,19 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
         public PegWorldModeModule(Tracker tracker, IItemService itemService, IWorldService worldService, ILogger<PegWorldModeModule> logger)
             : base(tracker, itemService, worldService, logger)
         {
+
+        }
+
+        [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
+        public override void AddCommands()
+        {
             AddCommand("Toggle Peg World mode on", new[] {
                 "Hey tracker, toggle Peg World Mode on",
                 "Hey tracker, we're going to Peg World!",
                 "Hey tracker, let's go to Peg World!"
             }, (result) =>
             {
-                tracker.StartPegWorldMode(result.Confidence);
+                Tracker.StartPegWorldMode(result.Confidence);
             });
 
             AddCommand("Toggle Peg World mode off", new[] {
@@ -39,7 +46,7 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
                 "Hey tracker, release me from Peg World"
             }, (result) =>
             {
-                tracker.StopPegWorldMode(result.Confidence);
+                Tracker.StopPegWorldMode(result.Confidence);
             });
 
             AddCommand("Track Peg World peg", new[] {
@@ -47,9 +54,9 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
                 "Hey tracker, peg."
             }, (result) =>
             {
-                if (tracker.PegsPegged < TotalPegs)
+                if (Tracker.PegsPegged < TotalPegs)
                 {
-                    tracker.Peg(result.Confidence);
+                    Tracker.Peg(result.Confidence);
                 }
             });
         }

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/PersonalityModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/PersonalityModule.cs
@@ -23,25 +23,30 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
         public PersonalityModule(Tracker tracker, IItemService itemService, IWorldService worldService, ILogger<PersonalityModule> logger)
             : base(tracker, itemService, worldService, logger)
         {
-            AddCommand("Ask about tracker's mood", GetMoodRule(), (result) =>
+
+        }
+
+        public override void AddCommands()
+        {
+            AddCommand("Ask about tracker's mood", GetMoodRule(), (_) =>
             {
-                tracker.Say(tracker.Responses.Moods[tracker.Mood]);
+                Tracker.Say(Tracker.Responses.Moods[Tracker.Mood]);
             });
 
-            AddCommand("Hey, ya missed pal", GetYaMissedRule(), (result) =>
+            AddCommand("Hey, ya missed pal", GetYaMissedRule(), (_) =>
             {
-                tracker.Say("Here Mike. This will explain everything.", wait: true);
+                Tracker.Say("Here Mike. This will explain everything.", wait: true);
                 OpenInBrowser(new Uri("https://www.youtube.com/watch?v=5P6UirFDdxM"));
             });
 
-            foreach (var request in tracker.Requests)
+            foreach (var request in Tracker.Requests)
             {
                 if (request.Phrases.Count == 0)
                     continue;
 
-                AddCommand(request.Phrases.First(), GetRequestRule(request.Phrases), (result) =>
+                AddCommand(request.Phrases.First(), GetRequestRule(request.Phrases), (_) =>
                 {
-                    tracker.Say(request.Response);
+                    Tracker.Say(request.Response);
                 });
             }
         }

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/TrackerModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/TrackerModule.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Speech.Recognition;
 
@@ -73,6 +74,8 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
             Logger = logger;
         }
 
+        public abstract void AddCommands();
+
         /// <summary>
         /// Gets a dictionary that contains the rule names and their associated
         /// speech recognition patterns.
@@ -104,6 +107,7 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
         /// <summary>
         /// Gets a list of speech recognition grammars provided by the module.
         /// </summary>
+        [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
         protected IList<Grammar> Grammars { get; }
             = new List<Grammar>();
 
@@ -304,6 +308,11 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
         protected void AddCommand(string ruleName, GrammarBuilder grammarBuilder,
             Action<RecognitionResult> executeCommand)
         {
+            if (!OperatingSystem.IsWindows())
+            {
+                return;
+            }
+
             _syntax.TryAdd(ruleName, grammarBuilder.ToString().Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
 
             try

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/TrackerModuleFactory.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/TrackerModuleFactory.cs
@@ -44,20 +44,25 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
         /// <returns>
         /// A dictionary that contains the loaded speech recognition syntax.
         /// </returns>
-        public IReadOnlyDictionary<string, IEnumerable<string>> LoadAll(Tracker tracker, SpeechRecognitionEngine engine, out bool moduleLoadError)
+        public IReadOnlyDictionary<string, IEnumerable<string>> LoadAll(Tracker tracker, SpeechRecognitionEngine? engine, out bool moduleLoadError)
         {
             moduleLoadError = false;
             _trackerModules = _serviceProvider.GetServices<TrackerModule>();
-            foreach (var module in _trackerModules)
+
+            if (engine != null && OperatingSystem.IsWindows())
             {
-                try
+                foreach (var module in _trackerModules)
                 {
-                    module.LoadInto(engine);
-                }
-                catch (InvalidOperationException e)
-                {
-                    _logger.LogError(e, $"Error with loading module {module.GetType().Name}");
-                    moduleLoadError = true;
+                    try
+                    {
+                        module.AddCommands();
+                        module.LoadInto(engine);
+                    }
+                    catch (InvalidOperationException e)
+                    {
+                        _logger.LogError(e, $"Error with loading module {module.GetType().Name}");
+                        moduleLoadError = true;
+                    }
                 }
             }
 

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/UndoModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/UndoModule.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Logging;
 
 using Randomizer.SMZ3.Tracking.Services;
 
@@ -19,10 +20,7 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
         public UndoModule(Tracker tracker, IItemService itemService, IWorldService worldService, ILogger<UndoModule> logger)
             : base(tracker, itemService, worldService, logger)
         {
-            AddCommand("Undo last operation", GetUndoRule(), (result) =>
-            {
-                tracker.Undo(result.Confidence);
-            });
+
         }
 
         private GrammarBuilder GetUndoRule()
@@ -30,6 +28,15 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
             return new GrammarBuilder()
                 .Append("Hey tracker,")
                 .OneOf("undo that", "control Z", "that's not what I said", "take backsies");
+        }
+
+        [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
+        public override void AddCommands()
+        {
+            AddCommand("Undo last operation", GetUndoRule(), (result) =>
+            {
+                Tracker.Undo(result.Confidence);
+            });
         }
     }
 }

--- a/src/Randomizer.SMZ3/Generation/Smz3GeneratedRomLoader.cs
+++ b/src/Randomizer.SMZ3/Generation/Smz3GeneratedRomLoader.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Randomizer.Data.Configuration.ConfigTypes;
 using Randomizer.Data.Options;
@@ -33,7 +34,7 @@ namespace Randomizer.SMZ3.Generation
         /// the given GeneratedRom
         /// </summary>
         /// <param name="rom"></param>
-        public void LoadGeneratedRom(GeneratedRom rom)
+        public List<World> LoadGeneratedRom(GeneratedRom rom)
         {
             var trackerState = rom.TrackerState;
 
@@ -121,9 +122,9 @@ namespace Randomizer.SMZ3.Generation
                 }
             }
 
-
             _worldAccessor.Worlds = worlds;
             _worldAccessor.World = worlds.First(x => x.IsLocalWorld);
+            return worlds;
         }
     }
 }

--- a/tests/Randomizer.SMZ3.Tests/LogicTests/RandomizerTests.cs
+++ b/tests/Randomizer.SMZ3.Tests/LogicTests/RandomizerTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Text;
 
 using FluentAssertions;
@@ -27,6 +28,12 @@ namespace Randomizer.SMZ3.Tests.LogicTests
         [InlineData("test", 558598333)] // Smz3Randomizer v4.0
         public void StandardFillerWithSameSeedGeneratesSameWorld(string seed, int expectedHash)
         {
+            // Apparently RNG in Linux is different than on Windows...
+            if (OperatingSystem.IsLinux())
+            {
+                expectedHash = 951851411;
+            }
+
             var filler = new StandardFiller(GetLogger<StandardFiller>());
             var randomizer = GetRandomizer();
             var config = new Config();


### PR DESCRIPTION
This adds command line auto tracking to the CrossPlatform app.

So several things are a part of these changes:

- Created an ISpeechRecognitionEngine which has an enabled/disabled implementation for usage between Windows/desktop
- For all of the tracker voice modules (some of which aren't _just_ used for voice stuff), I pulled out all of the add command statements into an abstract method "AddCommands" which is only called on Windows by the TrackerModuleFactory
- I updated a few configs to be saved as enums in the YAML rather than integer. These should be converted when the JSON config gets converted into YAML
- I added an optional setting to automatically track the "hey tracker, take a look at this" commands. I'll add this to the Windows UI in a subsequent pull request