### PR TITLE
GT Game and Enum Dropdown Updates

### DIFF
--- a/src/Randomizer.App/EnumDescriptionBindingSourceExtension.cs
+++ b/src/Randomizer.App/EnumDescriptionBindingSourceExtension.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Linq;
+using System.Windows.Markup;
+using Randomizer.Shared;
+
+namespace Randomizer.App
+{
+    public class EnumDescriptionBindingSourceExtension : MarkupExtension
+    {
+        private Type? _enumType;
+
+        public EnumDescriptionBindingSourceExtension()
+        {
+        }
+
+        public EnumDescriptionBindingSourceExtension(Type enumType)
+        {
+            EnumType = enumType;
+        }
+
+        public Type? EnumType
+        {
+            get => _enumType;
+            set
+            {
+                if (value != _enumType)
+                {
+                    if (null != value)
+                    {
+                        var enumType = Nullable.GetUnderlyingType(value) ?? value;
+                        if (!enumType.IsEnum)
+                            throw new ArgumentException("Type must be for an Enum.");
+                    }
+
+                    _enumType = value;
+                }
+            }
+        }
+
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            if (null == _enumType)
+                throw new InvalidOperationException("The EnumType must be specified.");
+
+            var actualEnumType = Nullable.GetUnderlyingType(_enumType) ?? _enumType;
+            var enumValues = Enum.GetValues(actualEnumType);
+            var descriptions = enumValues.Cast<Enum>().Select(x => x.GetDescription());
+
+            if (actualEnumType == _enumType)
+                return descriptions;
+
+            var tempArray = new string[enumValues.Length + 1];
+            enumValues.CopyTo(tempArray, 1);
+            return tempArray;
+        }
+    }
+}

--- a/src/Randomizer.App/EnumDescriptionConverter.cs
+++ b/src/Randomizer.App/EnumDescriptionConverter.cs
@@ -11,13 +11,21 @@ namespace Randomizer.App
 {
     public class EnumDescriptionConverter : IValueConverter
     {
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
         {
-            var enumValue = (Enum)value;
+            var enumValue = (Enum)value!;
             return enumValue.GetDescription();
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-            => throw new NotImplementedException();
+        public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            var enumValues = Enum.GetValues(targetType);
+            if (value == null)
+            {
+                return enumValues.GetValue(0)!;
+            }
+            var descriptions = enumValues.Cast<Enum>().ToDictionary(x => x.GetDescription() as object, x => x);
+            return descriptions[value];
+        }
     }
 }

--- a/src/Randomizer.App/Randomizer.App.csproj
+++ b/src/Randomizer.App/Randomizer.App.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net7.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>chozo20.ico</ApplicationIcon>
-    <Version>9.5.2</Version>
+    <Version>9.5.3</Version>
     <Title>SMZ3 Cas' Randomizer</Title>
     <AssemblyTitle>SMZ3 Cas' Randomizer</AssemblyTitle>
     <Authors>Vivelin</Authors>

--- a/src/Randomizer.App/Windows/GenerateRomWindow.xaml
+++ b/src/Randomizer.App/Windows/GenerateRomWindow.xaml
@@ -65,8 +65,8 @@
                         Margin="0,0,0,10">
                 <StackPanel>
                   <controls:LabeledControl Text="Keysanity:">
-                    <ComboBox SelectedItem="{Binding KeysanityMode}"
-                              ItemsSource="{Binding Source={local:EnumBindingSource {x:Type shared:KeysanityMode}}}"
+                    <ComboBox SelectedItem="{Binding KeysanityMode, Converter={StaticResource EnumDescriptionConverter}}"
+                              ItemsSource="{Binding Source={local:EnumDescriptionBindingSource {x:Type shared:KeysanityMode}}}"
                               HorizontalAlignment="Left"
                               MinWidth="75" />
                   </controls:LabeledControl>
@@ -75,8 +75,8 @@
                     IsEnabled="{Binding DisabledInMultiplayer, Mode=OneTime, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Window}}"
                     Margin="0,0,0,3">
                     <StackPanel Orientation="Vertical">
-                      <ComboBox SelectedItem="{Binding ItemPlacementRule}"
-                                ItemsSource="{Binding Source={local:EnumBindingSource {x:Type shared:ItemPlacementRule}}}"
+                      <ComboBox SelectedItem="{Binding ItemPlacementRule, Converter={StaticResource EnumDescriptionConverter}}"
+                                ItemsSource="{Binding Source={local:EnumDescriptionBindingSource {x:Type shared:ItemPlacementRule}}}"
                                 HorizontalAlignment="Left"
                                 MinWidth="75" />
                       <TextBlock TextWrapping="Wrap" Margin="0 0 0 5">
@@ -234,8 +234,8 @@
                   <controls:LabeledControl Text="Wall jump difficulty:"
                                            ToolTip="The kind of wall jumps you're expected to be able to do."
                                            Margin="0,4,0,0">
-                    <ComboBox SelectedItem="{Binding WallJumpDifficulty}"
-                              ItemsSource="{Binding Source={local:EnumBindingSource {x:Type shared:WallJumpDifficulty}}}"
+                    <ComboBox SelectedItem="{Binding WallJumpDifficulty, Converter={StaticResource EnumDescriptionConverter}}"
+                              ItemsSource="{Binding Source={local:EnumDescriptionBindingSource {x:Type shared:WallJumpDifficulty}}}"
                               HorizontalAlignment="Left"
                               MinWidth="75" />
                   </controls:LabeledControl>
@@ -291,29 +291,29 @@
               </controls:LabeledControl>
 
               <controls:LabeledControl Text="Heart color:">
-                <ComboBox SelectedItem="{Binding HeartColor}"
-                          ItemsSource="{Binding Source={local:EnumBindingSource {x:Type options:HeartColor}}}"
+                <ComboBox SelectedItem="{Binding HeartColor, Converter={StaticResource EnumDescriptionConverter}}"
+                          ItemsSource="{Binding Source={local:EnumDescriptionBindingSource {x:Type options:HeartColor}}}"
                           HorizontalAlignment="Left"
                           MinWidth="75" />
               </controls:LabeledControl>
 
               <controls:LabeledControl Text="ALttP Menu speed:">
-                <ComboBox SelectedItem="{Binding MenuSpeed}"
-                          ItemsSource="{Binding Source={local:EnumBindingSource {x:Type options:MenuSpeed}}}"
+                <ComboBox SelectedItem="{Binding MenuSpeed, Converter={StaticResource EnumDescriptionConverter}}"
+                          ItemsSource="{Binding Source={local:EnumDescriptionBindingSource {x:Type options:MenuSpeed}}}"
                           HorizontalAlignment="Left"
                           MinWidth="75" />
               </controls:LabeledControl>
 
               <controls:LabeledControl Text="Low health beep speed:">
-                <ComboBox SelectedItem="{Binding LowHealthBeepSpeed}"
-                          ItemsSource="{Binding Source={local:EnumBindingSource {x:Type options:LowHealthBeepSpeed}}}"
+                <ComboBox SelectedItem="{Binding LowHealthBeepSpeed, Converter={StaticResource EnumDescriptionConverter}}"
+                          ItemsSource="{Binding Source={local:EnumDescriptionBindingSource {x:Type options:LowHealthBeepSpeed}}}"
                           HorizontalAlignment="Left"
                           MinWidth="75" />
               </controls:LabeledControl>
 
               <controls:LabeledControl Text="Zelda Item Drops:">
-                <ComboBox SelectedItem="{Binding ZeldaDrops}"
-                          ItemsSource="{Binding Source={local:EnumBindingSource {x:Type options:ZeldaDrops}}}"
+                <ComboBox SelectedItem="{Binding ZeldaDrops, Converter={StaticResource EnumDescriptionConverter}}"
+                          ItemsSource="{Binding Source={local:EnumDescriptionBindingSource {x:Type options:ZeldaDrops}}}"
                           HorizontalAlignment="Left"
                           MinWidth="75" />
               </controls:LabeledControl>

--- a/src/Randomizer.App/Windows/MultiplayerConnectWindow.xaml
+++ b/src/Randomizer.App/Windows/MultiplayerConnectWindow.xaml
@@ -86,8 +86,8 @@
 
         <controls:LabeledControl Text="Game Mode:" IsTabStop="False">
           <StackPanel Orientation="Vertical">
-            <ComboBox SelectedItem="{Binding MultiplayerGameType}"
-                      ItemsSource="{Binding Source={local:EnumBindingSource {x:Type shared:MultiplayerGameType}}}"
+            <ComboBox SelectedItem="{Binding MultiplayerGameType, Converter={StaticResource EnumDescriptionConverter}}"
+                      ItemsSource="{Binding Source={local:EnumDescriptionBindingSource {x:Type shared:MultiplayerGameType}}}"
                       HorizontalAlignment="Left"
                       MinWidth="75"
                       Margin="5 0 0 0 "

--- a/src/Randomizer.App/Windows/OptionsWindow.xaml
+++ b/src/Randomizer.App/Windows/OptionsWindow.xaml
@@ -178,8 +178,8 @@
                     <ColumnDefinition Width="*" />
                   </Grid.ColumnDefinitions>
 
-                  <ComboBox SelectedItem="{Binding LaunchButtonOption}"
-                            ItemsSource="{Binding Source={app:EnumBindingSource {x:Type options:LaunchButtonOptions}}}"
+                  <ComboBox SelectedItem="{Binding LaunchButtonOption, Converter={StaticResource EnumDescriptionConverter}}"
+                            ItemsSource="{Binding Source={app:EnumDescriptionBindingSource {x:Type options:LaunchButtonOptions}}}"
                             MinWidth="75">
                   </ComboBox>
                 </Grid>
@@ -214,8 +214,8 @@
                     <ColumnDefinition Width="*" />
                   </Grid.ColumnDefinitions>
 
-                  <ComboBox SelectedItem="{Binding TrackerVoiceFrequency}"
-                            ItemsSource="{Binding Source={app:EnumBindingSource {x:Type enums:TrackerVoiceFrequency}}}"
+                  <ComboBox SelectedItem="{Binding TrackerVoiceFrequency, Converter={StaticResource EnumDescriptionConverter}}"
+                            ItemsSource="{Binding Source={app:EnumDescriptionBindingSource {x:Type enums:TrackerVoiceFrequency}}}"
                             MinWidth="75">
                   </ComboBox>
                 </Grid>
@@ -239,8 +239,8 @@
                     <ColumnDefinition Width="*" />
                   </Grid.ColumnDefinitions>
 
-                  <ComboBox SelectedItem="{Binding AutoTrackerDefaultConnectionType}"
-                            ItemsSource="{Binding Source={app:EnumBindingSource {x:Type options:EmulatorConnectorType}}}"
+                  <ComboBox SelectedItem="{Binding AutoTrackerDefaultConnectionType, Converter={StaticResource EnumDescriptionConverter}}"
+                            ItemsSource="{Binding Source={app:EnumDescriptionBindingSource {x:Type options:EmulatorConnectorType}}}"
                             MinWidth="75">
                   </ComboBox>
                 </Grid>
@@ -253,8 +253,8 @@
 
               <controls:LabeledControl Text="Current song display style:"
                                        ToolTip="Changes the orientation of the information displayed in the current song window and the written text file with the current song.">
-                <ComboBox SelectedItem="{Binding MsuTrackDisplayStyle}"
-                          ItemsSource="{Binding Source={app:EnumBindingSource {x:Type options:MsuTrackDisplayStyle}}}"
+                <ComboBox SelectedItem="{Binding MsuTrackDisplayStyle, Converter={StaticResource EnumDescriptionConverter}}"
+                          ItemsSource="{Binding Source={app:EnumDescriptionBindingSource {x:Type options:MsuTrackDisplayStyle}}}"
                           MinWidth="75">
                 </ComboBox>
               </controls:LabeledControl>
@@ -349,6 +349,20 @@
                   <TextBlock VerticalAlignment="Center"
                              Margin="3,0,0,0">minutes</TextBlock>
                 </StackPanel>
+              </controls:LabeledControl>
+
+              <controls:LabeledControl Text="GT Guessing Game Style:"
+                                       ToolTip="How the winner(s) of the GT guessing game should be determined">
+                <Grid>
+                  <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                  </Grid.ColumnDefinitions>
+
+                  <ComboBox SelectedItem="{Binding GanonsTowerGuessingGameStyle, Converter={StaticResource EnumDescriptionConverter}}"
+                            ItemsSource="{Binding Source={app:EnumDescriptionBindingSource {x:Type enums:GanonsTowerGuessingGameStyle}}}"
+                            MinWidth="75">
+                  </ComboBox>
+                </Grid>
               </controls:LabeledControl>
 
               <CheckBox x:Name="EnableChatPolls"

--- a/src/Randomizer.App/Windows/SpriteWindow.xaml
+++ b/src/Randomizer.App/Windows/SpriteWindow.xaml
@@ -37,8 +37,8 @@
         <StackPanel Grid.Column="1" Orientation="Vertical" Margin="10 0 0 0">
           <TextBlock>Filter</TextBlock>
           <ComboBox Name="SpriteFilterComboBox"
-                    SelectedItem="{Binding SpriteFilter}"
-                    ItemsSource="{Binding Source={app:EnumBindingSource {x:Type options:SpriteFilter}}}"
+                    SelectedItem="{Binding SpriteFilter, Converter={StaticResource EnumDescriptionConverter}}"
+                    ItemsSource="{Binding Source={app:EnumDescriptionBindingSource {x:Type options:SpriteFilter}}}"
                     HorizontalAlignment="Left"
                     MinWidth="125"
                     SelectionChanged="SpriteFilterComboBox_OnSelectionChanged">

--- a/src/Randomizer.Data/Configuration/ConfigTypes/ChatConfig.cs
+++ b/src/Randomizer.Data/Configuration/ConfigTypes/ChatConfig.cs
@@ -136,6 +136,17 @@ namespace Randomizer.Data.Configuration.ConfigTypes
 
         /// <summary>
         /// Gets the phrases to respond with when the guessing game has
+        /// concluded.
+        /// </summary>
+        /// <remarks>
+        /// <c>{0}</c> is a placeholder for the correct number. <c>{1}</c> is a placeholder for the guessed number,
+        /// <c>{2}</c> is a placeholder for the names of the winners.
+        /// </remarks>
+        public SchrodingersString DeclareGuessingGameClosestButNotOverWinner { get; init; }
+            = new("The winners who guessed closest to the number of {0} without going over are {1}.");
+
+        /// <summary>
+        /// Gets the phrases to respond with when the guessing game has
         /// concluded and nobody won.
         /// </summary>
         /// <remarks>

--- a/src/Randomizer.Data/Configuration/Yaml/Sassy/responses.yml
+++ b/src/Randomizer.Data/Configuration/Yaml/Sassy/responses.yml
@@ -816,6 +816,10 @@ Chat:
   - Text: 'The winners are {1}.'
   - Text: '{1} guessed number {0}.'
   - Text: '{1} performed the miraculous feat of having correctly guessed the number {0}.'
+  DeclareGuessingGameClosestButNotOverWinner:
+  - Text: 'The winners are {2}.'
+  - Text: '{2} guessed number {1}, which is close enough to give it to them, I guess.'
+  - Text: '{2} performed the miraculous feat of guessing closest to the number {0}.'
   NobodyWonGuessingGame:
   - Text: Nobody guessed number {0}.
   - Text: Nobody guessed {0}.

--- a/src/Randomizer.Data/Options/GeneralOptions.cs
+++ b/src/Randomizer.Data/Options/GeneralOptions.cs
@@ -179,6 +179,11 @@ namespace Randomizer.Data.Options
         /// </summary>
         public bool AutoSaveLookAtEvents { get; set; } = true;
 
+        /// <summary>
+        /// How winners should be determined for the GT guessing game
+        /// </summary>
+        public GanonsTowerGuessingGameStyle GanonsTowerGuessingGameStyle { get; set; }
+
         public event PropertyChangedEventHandler? PropertyChanged;
 
         public bool Validate()
@@ -205,7 +210,8 @@ namespace Randomizer.Data.Options
             UndoExpirationTime = UndoExpirationTime,
             MsuTrackDisplayStyle = MsuTrackDisplayStyle,
             MsuTrackOutputPath = MsuTrackOutputPath,
-            AutoSaveLookAtEvents = AutoSaveLookAtEvents
+            AutoSaveLookAtEvents = AutoSaveLookAtEvents,
+            GanonsTowerGuessingGameStyle = GanonsTowerGuessingGameStyle
         };
 
         protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)

--- a/src/Randomizer.Data/Options/TrackerOptions.cs
+++ b/src/Randomizer.Data/Options/TrackerOptions.cs
@@ -115,5 +115,10 @@ namespace Randomizer.Data
         /// Automatically tracks the map and other "hey tracker, look at this" events when viewing
         /// </summary>
         public bool AutoSaveLookAtEvents { get; set; }
+
+        /// <summary>
+        /// How winners should be determined for the GT guessing game
+        /// </summary>
+        public GanonsTowerGuessingGameStyle GanonsTowerGuessingGameStyle { get; set; }
     }
 }

--- a/src/Randomizer.Shared/Enums/GanonsTowerGuessingGameStyle.cs
+++ b/src/Randomizer.Shared/Enums/GanonsTowerGuessingGameStyle.cs
@@ -1,0 +1,12 @@
+﻿using System.ComponentModel;
+
+namespace Randomizer.Shared.Enums;
+
+public enum GanonsTowerGuessingGameStyle
+{
+    [Description("Exact guesses only")]
+    RequireExact,
+
+    [Description("Closest without going over")]
+    ClosestWithoutGoingOver
+}


### PR DESCRIPTION
- Requires GT number guesses to be the only part of a message
- Introduces an option for the GT guessing game for winners to be determined by who is the closest without going over
- I also noticed my previous change broke the look of some of the enum dropdowns. (I now remember why I did them the weird way I did before.) I created a new binding source and updated the description field so that the dropdown text can have spaces and whatnot and still work.