### PR TITLE
Save hints to db

### DIFF
--- a/src/Randomizer.Data/Services/TrackerStateService.cs
+++ b/src/Randomizer.Data/Services/TrackerStateService.cs
@@ -97,17 +97,20 @@ namespace Randomizer.Data.Services
             var hintStates = new List<TrackerHintState>();
             foreach (var hint in worldList.SelectMany(x => x.HintTiles))
             {
-                hintStates.Add(new TrackerHintState()
+                var hintState = new TrackerHintState()
                 {
                     Type = hint.Type,
                     WorldId = hint.WorldId,
                     LocationKey = hint.LocationKey,
                     LocationWorldId = hint.LocationWorldId,
-                    LocationString = hint.Locations == null ? null : string.Join(",", hint.Locations.Select(x => (int)x)),
+                    LocationString =
+                        hint.Locations == null ? null : string.Join(",", hint.Locations.Select(x => (int)x)),
                     Usefulness = hint.Usefulness,
                     MedallionType = hint.MedallionType,
                     HintTileCode = hint.HintTileCode
-                });
+                };
+                hint.State = hintState;
+                hintStates.Add(hintState);
             }
 
             // Add starting equipment, including items that may not be in the world anymore
@@ -185,7 +188,8 @@ namespace Randomizer.Data.Services
                         Locations = hint.LocationString?.Split(",").Select(x => (LocationId)int.Parse(x)),
                         Usefulness = hint.Usefulness,
                         MedallionType = hint.MedallionType,
-                        HintTileCode = hint.HintTileCode
+                        HintTileCode = hint.HintTileCode,
+                        State = hint
                     });
                 world.State = trackerState;
             }

--- a/src/Randomizer.Data/WorldData/World.cs
+++ b/src/Randomizer.Data/WorldData/World.cs
@@ -158,6 +158,7 @@ namespace Randomizer.Data.WorldData
         public LowerNorfairEast LowerNorfairEast { get; }
         public WreckedShip WreckedShip { get; }
         public WorldItemPools ItemPools { get; }
+        public IEnumerable<HintTile> HintTiles { get; set; }
 
         public Location? LastClearedLocation { get; set; }
 

--- a/src/Randomizer.SMZ3/Contracts/IGameHintService.cs
+++ b/src/Randomizer.SMZ3/Contracts/IGameHintService.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Randomizer.Data.WorldData;
 using Randomizer.Shared.Enums;
+using Randomizer.Shared.Models;
 
 namespace Randomizer.SMZ3.Contracts
 {
@@ -21,7 +22,7 @@ namespace Randomizer.SMZ3.Contracts
         /// <param name="playthrough">The initial playthrough with all of the spheres</param>
         /// <param name="seed">Seed number for shuffling and randomization</param>
         /// <returns>A collection of strings to use for the in game hints</returns>
-        IEnumerable<string> GetInGameHints(World hintPlayerWorld, ICollection<World> allWorlds, Playthrough playthrough, int seed);
+        void GetInGameHints(World hintPlayerWorld, List<World> allWorlds, Playthrough playthrough, int seed);
 
         /// <summary>
         /// Retrieves the usefulness of a particular location in a seed
@@ -30,7 +31,9 @@ namespace Randomizer.SMZ3.Contracts
         /// <param name="allWorlds">All worlds that are a part of the seed</param>
         /// <param name="playthrough">The initial playthrough with all of the spheres</param>
         /// <returns>How useful the location is</returns>
-        LocationUsefulness GetLocationUsefulness(Location location, ICollection<World> allWorlds,
+        LocationUsefulness GetLocationUsefulness(Location location, List<World> allWorlds,
             Playthrough playthrough);
+
+        string? GetHintTileText(HintTile tile, World hintPlayerWorld, List<World> worlds);
     }
 }

--- a/src/Randomizer.SMZ3/FileData/GetPatchesRequest.cs
+++ b/src/Randomizer.SMZ3/FileData/GetPatchesRequest.cs
@@ -36,11 +36,6 @@ public class GetPatchesRequest
     public required Random Random { get; init; }
 
     /// <summary>
-    /// Hints to be added as hint tiles
-    /// </summary>
-    public IEnumerable<string> Hints { get; init; } = new List<string>();
-
-    /// <summary>
     /// The PlandoConfig being used to specify data about the world
     /// </summary>
     public PlandoConfig PlandoConfig { get; init; } = new();

--- a/src/Randomizer.SMZ3/Generation/GameHintService.cs
+++ b/src/Randomizer.SMZ3/Generation/GameHintService.cs
@@ -335,7 +335,7 @@ namespace Randomizer.SMZ3.Generation
         /// </summary>
         private HintTile GetLocationHint(World hintPlayerWorld, List<World> allWorlds, List<Location> importantLocations, List<Location> locations, string? areaName = null)
         {
-            var typeAndKey = GetHintTileTypeAndKey(hintPlayerWorld, locations);
+            var typeAndKey = GetHintTileTypeAndKey(locations, areaName);
 
             return new HintTile()
             {
@@ -344,7 +344,7 @@ namespace Randomizer.SMZ3.Generation
                 LocationKey = typeAndKey.Item2,
                 LocationWorldId = locations.First().World.Id,
                 Locations = locations.Select(x => x.Id),
-                Usefulness = CheckIfLocationsAreImportant(allWorlds, importantLocations, locations)
+                Usefulness = locations.Count > 1 ? CheckIfLocationsAreImportant(allWorlds, importantLocations, locations) : null
             };
         }
 
@@ -471,11 +471,15 @@ namespace Randomizer.SMZ3.Generation
             return hints;
         }
 
-        private (HintTileType, string) GetHintTileTypeAndKey(World hintPlayerWorld, List<Location> locations)
+        private (HintTileType, string) GetHintTileTypeAndKey(List<Location> locations, string? areaName)
         {
             if (locations.Count == 1)
             {
                 return (HintTileType.Location, locations.First().Name);
+            }
+            else if (!string.IsNullOrEmpty(areaName))
+            {
+                return (HintTileType.LocationGroup, areaName);
             }
             else
             {

--- a/src/Randomizer.SMZ3/Generation/GameHintService.cs
+++ b/src/Randomizer.SMZ3/Generation/GameHintService.cs
@@ -10,12 +10,13 @@ using Randomizer.Data.WorldData.Regions;
 using Randomizer.Data.WorldData.Regions.Zelda;
 using Randomizer.Shared;
 using Randomizer.Shared.Enums;
+using Randomizer.Shared.Models;
 using Randomizer.SMZ3.Contracts;
 
 namespace Randomizer.SMZ3.Generation
 {
 
-    public delegate string? Hint();
+    public delegate HintTile? Hint();
 
     /// <summary>
     /// Service for generating hints for the player
@@ -87,7 +88,7 @@ namespace Randomizer.SMZ3.Generation
             _random = new Random();
         }
 
-        public LocationUsefulness GetLocationUsefulness(Location location, ICollection<World> allWorlds,
+        public LocationUsefulness GetLocationUsefulness(Location location, List<World> allWorlds,
             Playthrough playthrough)
         {
             var importantLocations = GetImportantLocations(allWorlds);
@@ -102,13 +103,17 @@ namespace Randomizer.SMZ3.Generation
         /// <param name="playthrough">The initial playthrough with all of the spheres</param>
         /// <param name="seed">Seed number for shuffling and randomization</param>
         /// <returns>A collection of strings to use for the in game hints</returns>
-        public IEnumerable<string> GetInGameHints(World hintPlayerWorld, ICollection<World> allWorlds, Playthrough playthrough, int seed)
+        public void GetInGameHints(World hintPlayerWorld, List<World> allWorlds, Playthrough playthrough, int seed)
         {
+            if (hintPlayerWorld.Config.UniqueHintCount <= 0)
+            {
+                return;
+            }
             _random = new Random(seed).Sanitize();
 
             var allHints = new List<Hint>();
 
-            var importantLocations = GetImportantLocations(allWorlds);
+            var importantLocations = GetImportantLocations(allWorlds).ToList();
 
             allHints.AddRange(GetProgressionItemHints(hintPlayerWorld, playthrough.Spheres, 5));
             allHints.AddRange(GetDungeonHints(hintPlayerWorld, allWorlds, importantLocations));
@@ -117,26 +122,39 @@ namespace Randomizer.SMZ3.Generation
 
             allHints = allHints.Shuffle(_random);
 
-            var hintLines = new List<string>();
+            var selectedHints = new List<HintTile>();
 
-            while (hintLines.Count < 15 && allHints.Any())
+            // Get the number of requested hints
+            while (selectedHints.Count < hintPlayerWorld.Config.UniqueHintCount && allHints.Any())
             {
                 var hint = allHints.First();
                 allHints.Remove(hint);
                 var hintLine = hint.Invoke();
-                if (!string.IsNullOrEmpty(hintLine) && !hintLines.Contains(hintLine))
+                if (hintLine != null)
                 {
-                    hintLines.Add(hintLine);
+                    selectedHints.Add(hintLine);
                 }
             }
 
-            _logger.LogDebug("Possible in game hints");
-            foreach (var hint in hintLines)
+            var worldHintTiles = new List<HintTile>();
+
+            // Assign each hint to a tile
+            var hintLocations = HintLocations.Shuffle(_random);
+            var hintIndex = 0;
+            foreach (var hintLocation in hintLocations)
             {
-                _logger.LogDebug("{Hint}", hint);
+                worldHintTiles.Add(selectedHints[hintIndex].GetHintTile(hintLocation));
+                hintIndex = (hintIndex + 1) % selectedHints.Count;
             }
 
-            return hintLines;
+            _logger.LogDebug("Hints: ");
+            foreach (var hint in worldHintTiles)
+            {
+                var hintText = GetHintTileText(hint, hintPlayerWorld, allWorlds);
+                _logger.LogDebug("{Hint}", hintText);
+            }
+
+            hintPlayerWorld.HintTiles = worldHintTiles;
         }
 
         /// <summary>
@@ -149,23 +167,29 @@ namespace Randomizer.SMZ3.Generation
             var progressionLocations = spheres
                 .SelectMany(x => x.Locations)
                 .Where(x => x.Item.World == hintPlayerWorld && x.Item.Progression &&
-                            !x.Item.Type.IsInAnyCategory(ItemCategory.Junk, ItemCategory.Scam));
+                            !x.Item.Type.IsInAnyCategory(ItemCategory.Junk, ItemCategory.Scam)).ToList();
             progressionLocations =
-                progressionLocations.TakeLast(progressionLocations.Count() / 2).Shuffle(_random).Take(count);
+                progressionLocations.TakeLast(progressionLocations.Count() / 2).Shuffle(_random).Take(count).ToList();
 
             return progressionLocations.Select(x => new Hint(() => GetProgressionItemHint(x)));
 
-            string? GetProgressionItemHint(Location location)
+            HintTile GetProgressionItemHint(Location location)
             {
-                return _gameLines.HintLocationHasItem?.Format(GetLocationName(hintPlayerWorld, location),
-                    GetItemName(hintPlayerWorld, location.Item));
+                return new HintTile()
+                {
+                    Type = HintTileType.Location,
+                    WorldId = hintPlayerWorld.Id,
+                    LocationKey = GetLocationName(hintPlayerWorld, location),
+                    LocationWorldId = location.World.Id,
+                    Locations = new List<LocationId>() { location.Id },
+                };
             }
         }
 
         /// <summary>
         /// Retrives hints stating how important dungeons are to beating the game
         /// </summary>
-        private IEnumerable<Hint> GetDungeonHints(World hintPlayerWorld, ICollection<World> allWorlds, IEnumerable<Location> importantLocations)
+        private IEnumerable<Hint> GetDungeonHints(World hintPlayerWorld, List<World> allWorlds, List<Location> importantLocations)
         {
             // For keysanity/multiworld check all dungeons, otherwise check non-crystal dungeons
             var dungeons = hintPlayerWorld.Dungeons
@@ -179,135 +203,129 @@ namespace Randomizer.SMZ3.Generation
 
             return hints;
 
-            string? GetDungeonHint(IDungeon dungeon)
+            HintTile GetDungeonHint(IDungeon dungeon)
             {
                 var dungeonRegion = (Region)dungeon;
-                var usefulness = CheckIfLocationsAreImportant(allWorlds, importantLocations, dungeonRegion.Locations.Where(x => x.Type != LocationType.NotInDungeon));
-                var dungeonName = GetDungeonName(hintPlayerWorld, dungeon, dungeonRegion);
-
-                if (usefulness == LocationUsefulness.Mandatory)
+                var locations = dungeonRegion.Locations.Where(x => x.Type != LocationType.NotInDungeon).ToList();
+                var usefulness = CheckIfLocationsAreImportant(allWorlds, importantLocations, locations);
+                return new HintTile()
                 {
-                    return _gameLines.HintLocationIsMandatory?.Format(dungeonName);
-                }
-                else if (usefulness == LocationUsefulness.NiceToHave)
-                {
-                    return _gameLines.HintLocationHasUsefulItem?.Format(dungeonName);
-                }
-                else if (usefulness == LocationUsefulness.Sword)
-                {
-                    return _gameLines.HintLocationHasSword?.Format(dungeonName);
-                }
-                else
-                {
-                    return _gameLines.HintLocationEmpty?.Format(dungeonName);
-                }
+                    Type = HintTileType.Dungeon,
+                    WorldId = hintPlayerWorld.Id,
+                    LocationKey = dungeon.DungeonName,
+                    LocationWorldId = locations.First().World.Id,
+                    Locations = locations.Select(x => x.Id),
+                    Usefulness = usefulness
+                };
             }
         }
 
         /// <summary>
         /// Retrieves hints for out of the way locations and rooms to the pool of hints
         /// </summary>
-        private IEnumerable<Hint> GetLocationHints(World hintPlayerWorld, ICollection<World> allWorlds, IEnumerable<Location> importantLocations)
+        private IEnumerable<Hint> GetLocationHints(World hintPlayerWorld, List<World> allWorlds, List<Location> importantLocations)
         {
             var hints = new List<Hint>();
 
             hints.Add(() => GetLocationHint(hintPlayerWorld, allWorlds, importantLocations,
-                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.PinkBrinstarWaterwayEnergyTank)));
+                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.PinkBrinstarWaterwayEnergyTank).ToList()));
 
             // Wrecked pool
             hints.Add(() => GetLocationHint(hintPlayerWorld, allWorlds, importantLocations,
-                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.WreckedShipEnergyTank)));
+                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.WreckedShipEnergyTank).ToList()));
 
             // Shaktool
             hints.Add(() => GetLocationHint(hintPlayerWorld, allWorlds, importantLocations,
-                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.InnerMaridiaSpringBall)));
+                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.InnerMaridiaSpringBall).ToList()));
 
             hints.Add(() => GetLocationHint(hintPlayerWorld, allWorlds, importantLocations,
-                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.InnerMaridiaPlasma)));
+                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.InnerMaridiaPlasma).ToList()));
 
             hints.Add(() => GetLocationHint(hintPlayerWorld, allWorlds, importantLocations,
-                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.Sahasrahla)));
+                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.Sahasrahla).ToList()));
 
             hints.Add(() => GetLocationHint(hintPlayerWorld, allWorlds, importantLocations,
-                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.MasterSwordPedestal)));
+                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.MasterSwordPedestal).ToList()));
 
             hints.Add(() => GetLocationHint(hintPlayerWorld, allWorlds, importantLocations,
-                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.KingZora)));
+                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.KingZora).ToList()));
 
             hints.Add(() => GetLocationHint(hintPlayerWorld, allWorlds, importantLocations,
-                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.Catfish)));
+                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.Catfish).ToList()));
 
             hints.Add(() => GetLocationHint(hintPlayerWorld, allWorlds, importantLocations,
-                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.TowerOfHeraBigKeyChest)));
+                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.TowerOfHeraBigKeyChest).ToList()));
 
             hints.Add(() => GetLocationHint(hintPlayerWorld, allWorlds, importantLocations,
-                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.RedBrinstarXRayScope)));
+                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.RedBrinstarXRayScope).ToList()));
 
             hints.Add(() => GetLocationHint(hintPlayerWorld, allWorlds, importantLocations,
-                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.PinkBrinstarHoptank)));
+                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.PinkBrinstarHoptank).ToList()));
 
             hints.Add(() => GetLocationHint(hintPlayerWorld, allWorlds, importantLocations,
-                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.EtherTablet)));
+                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.EtherTablet).ToList()));
 
             hints.Add(() => GetLocationHint(hintPlayerWorld, allWorlds, importantLocations,
-                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.BombosTablet)));
+                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.BombosTablet).ToList()));
 
             hints.Add(() => GetLocationHint(hintPlayerWorld, allWorlds, importantLocations,
-                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.CrateriaSuper)));
+                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.CrateriaSuper).ToList()));
 
             hints.Add(() => GetLocationHint(hintPlayerWorld, allWorlds, importantLocations,
-                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.SpikeCave)));
+                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.SpikeCave).ToList()));
 
             hints.Add(() => GetLocationHint(hintPlayerWorld, allWorlds, importantLocations,
-                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.SwampPalaceWestChest or LocationId.SwampPalaceBigKeyChest), "The left side of swamp palace"));
+                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.SwampPalaceWestChest or LocationId.SwampPalaceBigKeyChest).ToList(), "The left side of swamp palace"));
 
             hints.Add(() => GetLocationHint(hintPlayerWorld, allWorlds, importantLocations,
-                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.WreckedShipGravitySuit or LocationId.WreckedShipBowlingAlleyTop or LocationId.WreckedShipBowlingAlleyBottom), "Wrecked Ship post Chozo concert area"));
+                hintPlayerWorld.Locations.Where(x =>
+                    x.Id is LocationId.WreckedShipGravitySuit or LocationId.WreckedShipBowlingAlleyTop
+                        or LocationId.WreckedShipBowlingAlleyBottom).ToList(), "Wrecked Ship post Chozo concert area"));
 
             hints.Add(() => GetLocationHint(hintPlayerWorld, allWorlds, importantLocations,
-                hintPlayerWorld.DarkWorldNorthEast.PyramidFairy.Locations));
+                hintPlayerWorld.DarkWorldNorthEast.PyramidFairy.Locations.ToList()));
 
             hints.Add(() => GetLocationHint(hintPlayerWorld, allWorlds, importantLocations,
-                hintPlayerWorld.DarkWorldSouth.HypeCave.Locations));
+                hintPlayerWorld.DarkWorldSouth.HypeCave.Locations.ToList()));
 
             hints.Add(() => GetLocationHint(hintPlayerWorld, allWorlds, importantLocations,
-                hintPlayerWorld.DarkWorldDeathMountainEast.HookshotCave.Locations));
+                hintPlayerWorld.DarkWorldDeathMountainEast.HookshotCave.Locations.ToList()));
 
             hints.Add(() => GetLocationHint(hintPlayerWorld, allWorlds, importantLocations,
-                hintPlayerWorld.LightWorldDeathMountainEast.ParadoxCave.Locations));
+                hintPlayerWorld.LightWorldDeathMountainEast.ParadoxCave.Locations.ToList()));
 
             hints.Add(() => GetLocationHint(hintPlayerWorld, allWorlds, importantLocations,
-                hintPlayerWorld.UpperNorfairCrocomire.Locations));
+                hintPlayerWorld.UpperNorfairCrocomire.Locations.ToList()));
 
             hints.Add(() => GetLocationHint(hintPlayerWorld, allWorlds, importantLocations,
-                hintPlayerWorld.InnerMaridia.LeftSandPit.Locations));
+                hintPlayerWorld.InnerMaridia.LeftSandPit.Locations.ToList()));
 
             hints.Add(() => GetLocationHint(hintPlayerWorld, allWorlds, importantLocations,
-                hintPlayerWorld.InnerMaridia.RightSandPit.Locations));
+                hintPlayerWorld.InnerMaridia.RightSandPit.Locations.ToList()));
 
             hints.Add(() => GetLocationHint(hintPlayerWorld, allWorlds, importantLocations,
-                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.InnerMaridiaAqueductLeft or LocationId.InnerMaridiaAqueductRight), "Inner Maridia Aqueduct"));
+                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.InnerMaridiaAqueductLeft or LocationId.InnerMaridiaAqueductRight).ToList(), "Inner Maridia Aqueduct"));
 
             hints.Add(() => GetLocationHint(hintPlayerWorld, allWorlds, importantLocations,
-                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.Blacksmith or LocationId.PurpleChest), "Smith chain"));
+                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.Blacksmith or LocationId.PurpleChest).ToList(), "Smith chain"));
 
             hints.Add(() => GetLocationHint(hintPlayerWorld, allWorlds, importantLocations,
-                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.CrateriaGauntletEnergyTank or LocationId.CrateriaGauntletShaftLeft or LocationId.CrateriaGauntletShaftRight), "Crateria gauntlet"));
+                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.CrateriaGauntletEnergyTank or LocationId.CrateriaGauntletShaftLeft or LocationId.CrateriaGauntletShaftRight).ToList(), "Crateria gauntlet"));
 
             hints.Add(() => GetLocationHint(hintPlayerWorld, allWorlds, importantLocations,
-                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.FluteSpot)));
+                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.FluteSpot).ToList()));
 
             hints.Add(() => GetLocationHint(hintPlayerWorld, allWorlds, importantLocations,
-                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.MagicBat)));
+                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.MagicBat).ToList()));
 
             hints.Add(() => GetLocationHint(hintPlayerWorld, allWorlds, importantLocations,
-                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.PotionShop)));
+                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.PotionShop).ToList()));
 
             hints.Add(() => GetLocationHint(hintPlayerWorld, allWorlds, importantLocations,
-                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.GreenBrinstarEarlySupersBottom or LocationId.GreenBrinstarEarlySupersTop or LocationId.GreenBrinstarReserveTankChozo or LocationId.GreenBrinstarReserveTankHidden or LocationId.GreenBrinstarReserveTankVisible), "Green Brinstar machball hall"));
+                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.GreenBrinstarEarlySupersBottom or LocationId.GreenBrinstarEarlySupersTop or LocationId.GreenBrinstarReserveTankChozo or LocationId.GreenBrinstarReserveTankHidden or LocationId.GreenBrinstarReserveTankVisible).ToList(), "Green Brinstar machball hall"));
 
             hints.Add(() => GetLocationHint(hintPlayerWorld, allWorlds, importantLocations,
-                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.GreenBrinstarEtecoonSuper or LocationId.GreenBrinstarEtecoonEnergyTank or LocationId.GreenBrinstarMainShaft), "Green Brinstar bottom left area"));
+                hintPlayerWorld.Locations.Where(x => x.Id is LocationId.GreenBrinstarEtecoonSuper or LocationId.GreenBrinstarEtecoonEnergyTank or LocationId.GreenBrinstarMainShaft).ToList(), "Green Brinstar bottom left area"));
 
             return hints;
         }
@@ -315,64 +333,42 @@ namespace Randomizer.SMZ3.Generation
         /// <summary>
         /// Adds a hint for a given set of location(s) to the list of hints
         /// </summary>
-        private string? GetLocationHint(World hintPlayerWorld, ICollection<World> allWorlds, IEnumerable<Location> importantLocations, IEnumerable<Location> locations, string? areaName = null)
+        private HintTile GetLocationHint(World hintPlayerWorld, List<World> allWorlds, List<Location> importantLocations, List<Location> locations, string? areaName = null)
         {
-            // If we only have a single location, just say what item is there
-            if (locations.Count() == 1)
-            {
-                areaName = areaName == null
-                    ? GetLocationName(hintPlayerWorld, locations.First())
-                    : $"{areaName}{GetMultiworldSuffix(hintPlayerWorld, locations.First().World)}";
+            var typeAndKey = GetHintTileTypeAndKey(hintPlayerWorld, locations);
 
-                return  _gameLines.HintLocationHasItem?.Format(areaName,
-                    GetItemName(hintPlayerWorld, locations.First().Item));
-            }
-
-            var usefulness = CheckIfLocationsAreImportant(allWorlds, importantLocations, locations);
-
-            areaName = areaName == null
-                ? GetLocationsName(hintPlayerWorld, locations)
-                : $"{areaName}{GetMultiworldSuffix(hintPlayerWorld, locations.First().World)}";
-
-            if (usefulness == LocationUsefulness.Mandatory)
+            return new HintTile()
             {
-                return _gameLines.HintLocationIsMandatory?.Format(areaName);
-            }
-            else if (usefulness == LocationUsefulness.NiceToHave)
-            {
-                return _gameLines.HintLocationHasUsefulItem?.Format(areaName);
-            }
-            else if (usefulness == LocationUsefulness.Sword)
-            {
-                return _gameLines.HintLocationHasSword?.Format(areaName);
-            }
-            else
-            {
-                return _gameLines.HintLocationEmpty?.Format(areaName);
-            }
+                Type = typeAndKey.Item1,
+                WorldId = hintPlayerWorld.Id,
+                LocationKey = typeAndKey.Item2,
+                LocationWorldId = locations.First().World.Id,
+                Locations = locations.Select(x => x.Id),
+                Usefulness = CheckIfLocationsAreImportant(allWorlds, importantLocations, locations)
+            };
         }
 
         /// <summary>
         /// Checks how useful a location is based on if the seed can be completed if we remove those
         /// locations from the playthrough and if the items there are at least slightly useful
         /// </summary>
-        private LocationUsefulness CheckIfLocationsAreImportant(IEnumerable<World> allWorlds, IEnumerable<Location> importantLocations, IEnumerable<Location> locations)
+        private LocationUsefulness CheckIfLocationsAreImportant(List<World> allWorlds, IEnumerable<Location> importantLocations, List<Location> locations)
         {
             var worldLocations = importantLocations.Except(locations).ToList();
             try
             {
                 var spheres = Playthrough.GenerateSpheres(worldLocations);
-                var sphereLocations = spheres.SelectMany(x => x.Locations);
+                var sphereLocations = spheres.SelectMany(x => x.Locations).ToList();
 
-                var canBeatGT = CheckSphereLocationCount(sphereLocations, locations, LocationId.GanonsTowerMoldormChest, allWorlds.Count());
-                var canBeatKraid = CheckSphereLocationCount(sphereLocations, locations, LocationId.KraidsLairVariaSuit, allWorlds.Count());
-                var canBeatPhantoon = CheckSphereLocationCount(sphereLocations, locations, LocationId.WreckedShipEastSuper, allWorlds.Count());
-                var canBeatDraygon = CheckSphereLocationCount(sphereLocations, locations, LocationId.InnerMaridiaSpaceJump, allWorlds.Count());
-                var canBeatRidley = CheckSphereLocationCount(sphereLocations, locations, LocationId.LowerNorfairRidleyTank, allWorlds.Count());
+                var canBeatGT = CheckSphereLocationCount(sphereLocations, locations, LocationId.GanonsTowerMoldormChest, allWorlds.Count);
+                var canBeatKraid = CheckSphereLocationCount(sphereLocations, locations, LocationId.KraidsLairVariaSuit, allWorlds.Count);
+                var canBeatPhantoon = CheckSphereLocationCount(sphereLocations, locations, LocationId.WreckedShipEastSuper, allWorlds.Count);
+                var canBeatDraygon = CheckSphereLocationCount(sphereLocations, locations, LocationId.InnerMaridiaSpaceJump, allWorlds.Count);
+                var canBeatRidley = CheckSphereLocationCount(sphereLocations, locations, LocationId.LowerNorfairRidleyTank, allWorlds.Count);
                 var allCrateriaBosSKeys = CheckSphereCrateriaBossKeys(sphereLocations);
 
                 // Make sure all players have the silver arrows
-                if (sphereLocations.Count(x => x.Item.Type == ItemType.SilverArrows) < allWorlds.Count())
+                if (sphereLocations.Count(x => x.Item.Type == ItemType.SilverArrows) < allWorlds.Count)
                 {
                     return LocationUsefulness.Mandatory;
                 }
@@ -437,7 +433,7 @@ namespace Randomizer.SMZ3.Generation
         /// <summary>
         /// Checks if the crateria boss keycard is found in the spheres for all players
         /// </summary>
-        private bool CheckSphereCrateriaBossKeys(IEnumerable<Location> sphereLocations)
+        private bool CheckSphereCrateriaBossKeys(List<Location> sphereLocations)
         {
             var numKeysanity = sphereLocations.Select(x => x.World).Distinct().Count(x => x.Config.MetroidKeysanity);
             var numCratieriaBossKeys = sphereLocations.Select(x => x.Item.Type).Count(x => x == ItemType.CardMaridiaBoss);
@@ -451,23 +447,35 @@ namespace Randomizer.SMZ3.Generation
             hints.Add(() =>
             {
                 var mmMedallion = hintPlayerWorld.MiseryMire.Medallion;
-                return _gameLines.HintDungeonMedallion?.Format(hintPlayerWorld.MiseryMire.Metadata.Name, GetItemName(mmMedallion));
+                return new HintTile()
+                {
+                    Type = HintTileType.Requirement,
+                    WorldId = hintPlayerWorld.Id,
+                    LocationKey = hintPlayerWorld.MiseryMire.Name,
+                    MedallionType = mmMedallion
+                };
             });
 
             hints.Add(() =>
             {
                 var trMedallion = hintPlayerWorld.TurtleRock.Medallion;
-                return _gameLines.HintDungeonMedallion?.Format(hintPlayerWorld.TurtleRock.Metadata.Name, GetItemName(trMedallion));
+                return new HintTile()
+                {
+                    Type = HintTileType.Requirement,
+                    WorldId = hintPlayerWorld.Id,
+                    LocationKey = hintPlayerWorld.TurtleRock.Name,
+                    MedallionType = trMedallion
+                };
             });
 
             return hints;
         }
 
-        private string GetLocationsName(World hintPlayerWorld, IEnumerable<Location> locations)
+        private (HintTileType, string) GetHintTileTypeAndKey(World hintPlayerWorld, List<Location> locations)
         {
-            if (locations.Count() == 1)
+            if (locations.Count == 1)
             {
-                return GetLocationName(hintPlayerWorld, locations.First());
+                return (HintTileType.Location, locations.First().Name);
             }
             else
             {
@@ -475,14 +483,11 @@ namespace Randomizer.SMZ3.Generation
 
                 if (room != null && locations.All(x => x.Room == room))
                 {
-                    var roomInfo = _metadataService.Room(room);
-                    var name = roomInfo?.Name ?? room.Name;
-                    return $"{name}{GetMultiworldSuffix(hintPlayerWorld, locations.First().World)}";
+                    return (HintTileType.Room, room.Name);
                 }
                 else
                 {
-                    var name = _metadataService.Region(locations.First().Region).Name;
-                    return $"{name}{GetMultiworldSuffix(hintPlayerWorld, locations.First().World)}";
+                    return (HintTileType.Region, locations.First().Region.Name);
                 }
             }
         }
@@ -490,6 +495,18 @@ namespace Randomizer.SMZ3.Generation
         private string GetDungeonName(World hintPlayerWorld, IDungeon dungeon, Region region)
         {
             var dungeonName = _metadataService.Dungeon(dungeon).Name.ToString();
+            return $"{dungeonName}{GetMultiworldSuffix(hintPlayerWorld, region.World)}";
+        }
+
+        private string GetRoomName(World hintPlayerWorld, Room room)
+        {
+            var roomName = _metadataService.Room(room)?.Name.ToString() ?? room.Name;
+            return $"{roomName}{GetMultiworldSuffix(hintPlayerWorld, room.World)}";
+        }
+
+        private string GetRegionName(World hintPlayerWorld, Region region)
+        {
+            var dungeonName = _metadataService.Region(region).Name.ToString();
             return $"{dungeonName}{GetMultiworldSuffix(hintPlayerWorld, region.World)}";
         }
 
@@ -543,7 +560,7 @@ namespace Randomizer.SMZ3.Generation
             }
         }
 
-        private IEnumerable<Location> GetImportantLocations(IEnumerable<World> allWorlds)
+        private IEnumerable<Location> GetImportantLocations(List<World> allWorlds)
         {
             // Get the first accessible ammo locations to make sure early ammo isn't considered mandatory when there
             // are others available
@@ -575,6 +592,70 @@ namespace Randomizer.SMZ3.Generation
                                 ItemCategory.Keycard) || l.Item.Type is ItemType.Super or ItemType.PowerBomb or ItemType.ProgressiveSword or ItemType.SilverArrows)
                 .Concat(ammoLocations)
                 .Distinct();
+        }
+
+        public string? GetHintTileText(HintTile tile, World hintPlayerWorld, List<World> worlds)
+        {
+            if (tile.Type == HintTileType.Requirement && tile.MedallionType != null)
+            {
+                var dungeon = _metadataService.Dungeons.FirstOrDefault(x => x.Dungeon == tile.LocationKey);
+                var dungeonName = dungeon?.Name.ToString() ?? tile.LocationKey;
+                var itemName = GetItemName(tile.MedallionType.Value);
+                return _gameLines.HintDungeonMedallion?.Format(dungeonName, itemName);
+            }
+            else if (tile.Type == HintTileType.Location && tile.Locations?.Any() == true)
+            {
+                var world = worlds.First(x => x.Id == tile.LocationWorldId);
+                var location = world.FindLocation(tile.Locations.First());
+                var areaName = GetLocationName(hintPlayerWorld, location);
+                return  _gameLines.HintLocationHasItem?.Format(areaName,
+                    GetItemName(hintPlayerWorld, location.Item));
+            }
+            else
+            {
+                var areaName = tile.LocationKey;
+                var world = worlds.First(x => x.Id == tile.LocationWorldId);
+
+                if (tile.Type == HintTileType.Region)
+                {
+                    var region = world.Regions.First(x => x.Name == areaName);
+                    areaName = GetRegionName(hintPlayerWorld, region);
+                }
+                else if (tile.Type == HintTileType.Dungeon)
+                {
+                    var region = world.Regions.First(x => x.Name == areaName);
+                    var dungeon = world.Dungeons.First(x => x.DungeonName == areaName);
+                    areaName = GetDungeonName(hintPlayerWorld, dungeon, region);
+                }
+                else if (tile.Type == HintTileType.Room)
+                {
+                    var room = world.Rooms.First(x => x.Name == areaName);
+                    areaName = GetRoomName(hintPlayerWorld, room);
+                }
+                else if (tile.Type == HintTileType.LocationGroup)
+                {
+                    areaName = $"{areaName}{GetMultiworldSuffix(hintPlayerWorld, world)}";
+                }
+
+                var usefulness = tile.Usefulness;
+
+                if (usefulness == LocationUsefulness.Mandatory)
+                {
+                    return _gameLines.HintLocationIsMandatory?.Format(areaName);
+                }
+                else if (usefulness == LocationUsefulness.NiceToHave)
+                {
+                    return _gameLines.HintLocationHasUsefulItem?.Format(areaName);
+                }
+                else if (usefulness == LocationUsefulness.Sword)
+                {
+                    return _gameLines.HintLocationHasSword?.Format(areaName);
+                }
+                else
+                {
+                    return _gameLines.HintLocationEmpty?.Format(areaName);
+                }
+            }
         }
 
 

--- a/src/Randomizer.SMZ3/Generation/RomTextService.cs
+++ b/src/Randomizer.SMZ3/Generation/RomTextService.cs
@@ -8,16 +8,19 @@ using Microsoft.Extensions.Logging;
 using Randomizer.Data.Options;
 using Randomizer.Data.WorldData.Regions;
 using Randomizer.Shared;
+using Randomizer.SMZ3.Contracts;
 
 namespace Randomizer.SMZ3.Generation;
 
 public class RomTextService
 {
     private readonly ILogger<RomTextService> _logger;
+    private readonly IGameHintService _gameHintService;
 
-    public RomTextService(ILogger<RomTextService> logger)
+    public RomTextService(ILogger<RomTextService> logger, IGameHintService gameHintService)
     {
         _logger = logger;
+        _gameHintService = gameHintService;
     }
 
     public async Task<string> WriteSpoilerLog(RandomizerOptions options, SeedData seed, Config config, string folderPath, string fileSuffix)
@@ -210,9 +213,11 @@ public class RomTextService
                 log.AppendLine();
             }
 
-            foreach (var hint in worldGenerationData.Hints)
+            foreach (var hint in worldGenerationData.World.HintTiles)
             {
-                log.AppendLine(hint);
+                var hintText = _gameHintService.GetHintTileText(hint, worldGenerationData.World,
+                    seed.WorldGenerationData.Worlds.ToList());
+                log.AppendLine($"{hint.HintTileCode} - {hintText}");
             }
             log.AppendLine();
         }

--- a/src/Randomizer.SMZ3/Generation/Smz3GeneratedRomLoader.cs
+++ b/src/Randomizer.SMZ3/Generation/Smz3GeneratedRomLoader.cs
@@ -48,6 +48,7 @@ namespace Randomizer.SMZ3.Generation
             _randomizerContext.Entry(trackerState).Collection(x => x.DungeonStates).Load();
             _randomizerContext.Entry(trackerState).Collection(x => x.BossStates).Load();
             _randomizerContext.Entry(trackerState).Collection(x => x.History).Load();
+            _randomizerContext.Entry(trackerState).Collection(x => x.Hints).Load();
 
             var configs = Config.FromConfigString(rom.Settings);
             var worlds = configs.Select(config => new World(config, config.PlayerName, config.Id, config.PlayerGuid, config.Id == trackerState.LocalWorldId, _metadata, trackerState)).ToList();

--- a/src/Randomizer.SMZ3/Generation/Smz3MultiplayerRomGenerator.cs
+++ b/src/Randomizer.SMZ3/Generation/Smz3MultiplayerRomGenerator.cs
@@ -69,17 +69,17 @@ public class Smz3MultiplayerRomGenerator : ISeededRandomizer
         foreach (var world in worlds.OrderBy(x => x.Id))
         {
             var hints = world.Config.MultiplayerPlayerGenerationData!.Hints;
+            world.HintTiles = hints;
             var patches = _patcherService.GetPatches(new GetPatchesRequest()
             {
                 World = world,
                 Worlds = worlds,
                 SeedGuid = seedData.Guid,
                 Seed = seedNumber,
-                Random = new Random(seedNumber % 1000 + world.Id).Sanitize(),
-                Hints = hints
+                Random = new Random(seedNumber % 1000 + world.Id).Sanitize()
             });
 
-            var worldGenerationData = new WorldGenerationData(world, patches, hints);
+            var worldGenerationData = new WorldGenerationData(world, patches);
             seedData.WorldGenerationData.Add(worldGenerationData);
         }
 

--- a/src/Randomizer.SMZ3/Generation/Smz3Randomizer.cs
+++ b/src/Randomizer.SMZ3/Generation/Smz3Randomizer.cs
@@ -122,17 +122,16 @@ namespace Randomizer.SMZ3.Generation
             var patchSeed = rng.Next();
             foreach (var world in worlds)
             {
-                var hints = _hintService.GetInGameHints(world, worlds, playthrough, rng.Next());
+                _hintService.GetInGameHints(world, worlds, playthrough, rng.Next());
                 var patches = _patcherService.GetPatches(new GetPatchesRequest()
                 {
                     World = world,
                     Worlds = worlds,
                     SeedGuid = seedData.Guid,
                     Seed = primaryConfig.Race ? 0 : seedNumber,
-                    Random = new Random(patchSeed).Sanitize(),
-                    Hints = hints
+                    Random = new Random(patchSeed).Sanitize()
                 });
-                var worldGenerationData = new WorldGenerationData(world, patches, hints);
+                var worldGenerationData = new WorldGenerationData(world, patches);
                 _logger.LogInformation("Patch created for world {WorldId}", world.Id);
                 seedData.WorldGenerationData.Add(worldGenerationData);
             }

--- a/src/Randomizer.SMZ3/Generation/WorldGenerationData.cs
+++ b/src/Randomizer.SMZ3/Generation/WorldGenerationData.cs
@@ -18,16 +18,14 @@ public class WorldGenerationData
         Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
     };
 
-    public WorldGenerationData(World world, Dictionary<int, byte[]>? patches = null, IEnumerable<string>? hints = null)
+    public WorldGenerationData(World world, Dictionary<int, byte[]>? patches = null)
     {
         World = world;
         Patches = patches ?? new Dictionary<int, byte[]>();
-        Hints = hints ?? new List<string>();
     }
 
     public World World { get; }
     public Dictionary<int, byte[]> Patches { get; }
-    public IEnumerable<string> Hints { get; }
     public Config Config => World.Config;
     public bool IsLocalWorld => World.IsLocalWorld;
 
@@ -37,7 +35,7 @@ public class WorldGenerationData
             .Select(x => new PlayerGenerationLocationData(x.Id, x.Item.World.Id, x.Item.Type)).ToList();
         var dungeonData = World.Dungeons
             .Select(x => new PlayerGenerationDungeonData(x.DungeonName, x.DungeonRewardType, x.Medallion)).ToList();
-        return new MultiplayerPlayerGenerationData(World.Guid, World.Id, locationItems, dungeonData, Hints.ToList());
+        return new MultiplayerPlayerGenerationData(World.Guid, World.Id, locationItems, dungeonData, World.HintTiles.ToList());
     }
 
 

--- a/src/Randomizer.Shared/Enums/HintState.cs
+++ b/src/Randomizer.Shared/Enums/HintState.cs
@@ -1,0 +1,8 @@
+namespace Randomizer.Shared.Enums;
+
+public enum HintState
+{
+    Default,
+    Viewed,
+    Cleared
+}

--- a/src/Randomizer.Shared/Enums/HintTileType.cs
+++ b/src/Randomizer.Shared/Enums/HintTileType.cs
@@ -1,0 +1,11 @@
+namespace Randomizer.Shared.Enums;
+
+public enum HintTileType
+{
+    Location,
+    Dungeon,
+    Region,
+    Room,
+    LocationGroup,
+    Requirement
+}

--- a/src/Randomizer.Shared/Migrations/20231119163811_SaveHintTiles.Designer.cs
+++ b/src/Randomizer.Shared/Migrations/20231119163811_SaveHintTiles.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Randomizer.Shared.Models;
 
@@ -10,9 +11,11 @@ using Randomizer.Shared.Models;
 namespace Randomizer.Shared.Migrations
 {
     [DbContext(typeof(RandomizerContext))]
-    partial class RandomizerContextModelSnapshot : ModelSnapshot
+    [Migration("20231119163811_SaveHintTiles")]
+    partial class SaveHintTiles
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "7.0.9");

--- a/src/Randomizer.Shared/Migrations/20231119163811_SaveHintTiles.cs
+++ b/src/Randomizer.Shared/Migrations/20231119163811_SaveHintTiles.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Randomizer.Shared.Migrations
+{
+    /// <inheritdoc />
+    public partial class SaveHintTiles : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "TrackerHintStates",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    TrackerStateId = table.Column<long>(type: "INTEGER", nullable: true),
+                    Type = table.Column<int>(type: "INTEGER", nullable: false),
+                    WorldId = table.Column<int>(type: "INTEGER", nullable: false),
+                    LocationKey = table.Column<string>(type: "TEXT", nullable: false),
+                    LocationWorldId = table.Column<int>(type: "INTEGER", nullable: true),
+                    LocationString = table.Column<string>(type: "TEXT", nullable: true),
+                    Usefulness = table.Column<int>(type: "INTEGER", nullable: true),
+                    MedallionType = table.Column<byte>(type: "INTEGER", nullable: true),
+                    HintTileCode = table.Column<string>(type: "TEXT", nullable: false),
+                    HintState = table.Column<int>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TrackerHintStates", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_TrackerHintStates_TrackerStates_TrackerStateId",
+                        column: x => x.TrackerStateId,
+                        principalTable: "TrackerStates",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TrackerHintStates_TrackerStateId",
+                table: "TrackerHintStates",
+                column: "TrackerStateId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "TrackerHintStates");
+        }
+    }
+}

--- a/src/Randomizer.Shared/Models/HintTile.cs
+++ b/src/Randomizer.Shared/Models/HintTile.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using Randomizer.Shared.Enums;
+
+namespace Randomizer.Shared.Models;
+
+public class HintTile
+{
+    public HintTileType Type { get; set; }
+    public int WorldId { get; set; }
+    public string LocationKey { get; set; } = "";
+    public int? LocationWorldId { get; set; }
+    public IEnumerable<LocationId>? Locations { get; set; }
+    public LocationUsefulness? Usefulness { get; set; }
+    public ItemType? MedallionType { get; set; }
+    public string HintTileCode { get; set; } = "";
+    public TrackerHintState? State { get; set; }
+
+    public HintTile GetHintTile(string code)
+    {
+        var clone = MemberwiseClone() as HintTile;
+        clone!.HintTileCode = code;
+        return clone;
+    }
+}

--- a/src/Randomizer.Shared/Models/RandomizerContext.cs
+++ b/src/Randomizer.Shared/Models/RandomizerContext.cs
@@ -34,6 +34,7 @@ namespace Randomizer.Shared.Models {
             modelBuilder.Entity<TrackerState>().HasMany(x => x.MarkedLocations).WithOne(x => x.TrackerState!).OnDelete(DeleteBehavior.Cascade);
             modelBuilder.Entity<TrackerState>().HasMany(x => x.BossStates).WithOne(x => x.TrackerState!).OnDelete(DeleteBehavior.Cascade);
             modelBuilder.Entity<TrackerState>().HasMany(x => x.History).WithOne(x => x.TrackerState!).OnDelete(DeleteBehavior.Cascade);
+            modelBuilder.Entity<TrackerState>().HasMany(x => x.Hints).WithOne(x => x.TrackerState!).OnDelete(DeleteBehavior.Cascade);
             modelBuilder.Entity<MultiplayerGameDetails>().HasOne(x => x.GeneratedRom);
 
             base.OnModelCreating(modelBuilder);
@@ -49,6 +50,7 @@ namespace Randomizer.Shared.Models {
         public DbSet<TrackerMarkedLocation> TrackerMarkedLocations { get; set; }
         public DbSet<TrackerBossState> TrackerBossStates { get; set; }
         public DbSet<TrackerHistoryEvent> TrackerHistoryEvents { get; set; }
+        public DbSet<TrackerHintState> TrackerHintStates { get; set; }
         public DbSet<MultiplayerGameDetails> MultiplayerGames { get; set; }
 
 #if DEBUG

--- a/src/Randomizer.Shared/Models/TrackerHintState.cs
+++ b/src/Randomizer.Shared/Models/TrackerHintState.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Randomizer.Shared.Enums;
+
+namespace Randomizer.Shared.Models;
+
+public class TrackerHintState
+{
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    [Key]
+    public long Id { get; set; }
+    public TrackerState? TrackerState { get; set; }
+    public HintTileType Type { get; set; }
+    public int WorldId { get; set; }
+    public string LocationKey { get; set; } = string.Empty;
+    public int? LocationWorldId { get; set; }
+    public string? LocationString { get; set; }
+    public LocationUsefulness? Usefulness { get; set; }
+    public ItemType? MedallionType { get; set; }
+    public string HintTileCode { get; set; } = string.Empty;
+    public HintState HintState { get; set; }
+
+}

--- a/src/Randomizer.Shared/Models/TrackerState.cs
+++ b/src/Randomizer.Shared/Models/TrackerState.cs
@@ -26,6 +26,7 @@ namespace Randomizer.Shared.Models
         public ICollection<TrackerMarkedLocation> MarkedLocations { get; set; } = new List<TrackerMarkedLocation>();
         public ICollection<TrackerBossState> BossStates { get; set; } = new List<TrackerBossState>();
         public ICollection<TrackerHistoryEvent> History { get; set; } = new List<TrackerHistoryEvent>();
+        public ICollection<TrackerHintState> Hints { get; set; } = new List<TrackerHintState>();
     }
 
 }

--- a/src/Randomizer.Shared/Multiplayer/MultiplayerPlayerGenerationData.cs
+++ b/src/Randomizer.Shared/Multiplayer/MultiplayerPlayerGenerationData.cs
@@ -5,6 +5,7 @@ using System.IO.Compression;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
+using Randomizer.Shared.Models;
 
 namespace Randomizer.Shared.Multiplayer;
 
@@ -16,7 +17,7 @@ public class MultiplayerPlayerGenerationData
     };
 
     public MultiplayerPlayerGenerationData(string playerGuid, int worldId, List<PlayerGenerationLocationData> locations,
-        List<PlayerGenerationDungeonData> dungeons, List<string> hints)
+        List<PlayerGenerationDungeonData> dungeons, List<HintTile> hints)
     {
         PlayerGuid = playerGuid;
         WorldId = worldId;
@@ -29,7 +30,7 @@ public class MultiplayerPlayerGenerationData
     public int WorldId { get; }
     public List<PlayerGenerationLocationData> Locations { get; }
     public List<PlayerGenerationDungeonData> Dungeons { get; }
-    public List<string> Hints { get; }
+    public List<HintTile> Hints { get; }
 
     /// <summary>
     /// Converts the generation data into a compressed string of the json


### PR DESCRIPTION
This change is to change the way hints are generated so that they can be saved to the database. This is being done so tracker can know what hints were generated as well as allow it to remember the state of whether a hint has been viewed or cleared.

I'll make the UI for keeping track of hints and auto detection of reading hints in another PR.