### PR TITLE
Initial auto mark items changes

### DIFF
--- a/src/Randomizer.Abstractions/TrackerBase.cs
+++ b/src/Randomizer.Abstractions/TrackerBase.cs
@@ -749,6 +749,18 @@ public abstract class TrackerBase
     public abstract void UpdateHintTile(PlayerHintTile playerHintTile);
 
     /// <summary>
+    /// Updates the most recently marked locations to be able to clear later
+    /// </summary>
+    /// <param name="locations">List of locations that were just marked</param>
+    public abstract void UpdateLastMarkedLocations(List<Location> locations);
+
+    /// <summary>
+    /// Clears the most recently marked locations
+    /// </summary>
+    /// <param name="confidence">Voice recognition confidence</param>
+    public abstract void ClearLastMarkedLocations(float confidence);
+
+    /// <summary>
     /// Resets the idle timers when tracker will comment on nothing happening
     /// </summary>
     public abstract void RestartIdleTimers();

--- a/src/Randomizer.Data/Configuration/ConfigFiles/ResponseConfig.cs
+++ b/src/Randomizer.Data/Configuration/ConfigFiles/ResponseConfig.cs
@@ -565,6 +565,12 @@ namespace Randomizer.Data.Configuration.ConfigFiles
             = new SchrodingersString("Cleared {0} locations.");
 
         /// <summary>
+        /// Gets the phrases to respond with when trying to clear the last marked locations when there aren't any
+        /// </summary>
+        public SchrodingersString NoMarkedLocations { get; init; }
+            = new SchrodingersString("There are no marked locations to clear");
+
+        /// <summary>
         /// Gets the phrases to respond with when clearing multiple locations
         /// from the same region.
         /// </summary>

--- a/src/Randomizer.Data/Randomizer.Data.csproj
+++ b/src/Randomizer.Data/Randomizer.Data.csproj
@@ -55,9 +55,8 @@
     <EmbeddedResource Include="Configuration\Yaml\Templates\rewards.yml" />
     <EmbeddedResource Include="maps.json" />
     <EmbeddedResource Include="Options\ItemSettingOptions.yml" />
-    <None Remove="WorldData\HintTiles.yml" />
-    <None Remove="Configuration\Yaml\Sassy\hint_tiles.yml" />
     <EmbeddedResource Include="Configuration\Yaml\Sassy\hint_tiles.yml" />
+    <EmbeddedResource Include="WorldData\VisibleItems.yml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Randomizer.Data/WorldData/VisibleItemMetroid.cs
+++ b/src/Randomizer.Data/WorldData/VisibleItemMetroid.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using Randomizer.Shared;
+
+namespace Randomizer.Data.WorldData;
+
+public class VisibleItemMetroid
+{
+    public int Room { get; set; }
+    public int TopLeftX { get; set; }
+    public int TopLeftY { get; set; }
+    public int BottomRightX { get; set; }
+    public int BottomRightY { get; set; }
+    public List<LocationId> Locations { get; set; } = new();
+}

--- a/src/Randomizer.Data/WorldData/VisibleItemZelda.cs
+++ b/src/Randomizer.Data/WorldData/VisibleItemZelda.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+using Randomizer.Shared;
+
+namespace Randomizer.Data.WorldData;
+
+public class VisibleItemZelda
+{
+    public int? Room { get; set; }
+    public int? OverworldScreen { get; set; }
+    public int TopLeftX { get; set; }
+    public int TopLeftY { get; set; }
+    public int BottomRightX { get; set; }
+    public int BottomRightY { get; set; }
+    public List<LocationId> Locations { get; set; } = new();
+}

--- a/src/Randomizer.Data/WorldData/VisibleItems.cs
+++ b/src/Randomizer.Data/WorldData/VisibleItems.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using Randomizer.Data.Options;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Randomizer.Data.WorldData;
+
+public class VisibleItems
+{
+    private static readonly IDeserializer s_deserializer = new DeserializerBuilder()
+        .WithNamingConvention(PascalCaseNamingConvention.Instance)
+        .Build();
+
+    public List<VisibleItemZelda> ZeldaItems { get; set; }
+    public List<VisibleItemMetroid> MetroidItems { get; set; }
+
+    public static VisibleItems GetVisibleItems()
+    {
+        using var stream = Assembly.GetExecutingAssembly()
+            .GetManifestResourceStream("Randomizer.Data.WorldData.VisibleItems.yml") ?? throw new FileNotFoundException("Unable to find ItemSettingOptions.yml file");
+        using var reader = new StreamReader(stream);
+        var ymlText = reader.ReadToEnd();
+        return s_deserializer.Deserialize<VisibleItems>(ymlText);
+    }
+}

--- a/src/Randomizer.Data/WorldData/VisibleItems.yml
+++ b/src/Randomizer.Data/WorldData/VisibleItems.yml
@@ -1,0 +1,57 @@
+﻿ZeldaItems:
+  - Room: 0
+    OverworldScreen: 48
+    TopLeftX: 60
+    TopLeftY: 3620
+    BottomRightX: 228
+    BottomRightY: 3850
+    Locations:
+      - DesertLedge
+  - Room: 0
+    OverworldScreen: 53
+    TopLeftX: 2820
+    TopLeftY: 3256
+    BottomRightX: 3080
+    BottomRightY: 3480
+    Locations:
+      - LakeHyliaIsland
+  - Room: 0
+    OverworldScreen: 3
+    TopLeftX: 1944
+    TopLeftY: 230
+    BottomRightX: 2209
+    BottomRightY: 466
+    Locations:
+      - SpectacleRock
+  - Room: 234
+    OverworldScreen: 0
+    TopLeftX: 5192
+    TopLeftY: 7408
+    BottomRightX: 5288
+    BottomRightY: 7465
+    Locations:
+      - SpectacleRockCave
+  - Room: 0
+    OverworldScreen: 5
+    TopLeftX: 3395
+    TopLeftY: 142
+    BottomRightX: 3450
+    BottomRightY: 161
+    Locations:
+      - FloatingIsland
+  - Room: 226
+    OverworldScreen: 0
+    TopLeftX: 1408
+    TopLeftY: 7490
+    BottomRightX: 1456
+    BottomRightY: 7544
+    Locations:
+      - LumberjackTree
+MetroidItems:
+  - Room: 14
+    TopLeftX: 37
+    TopLeftY: 106
+    BottomRightX: 91
+    BottomRightY: 153
+    Locations:
+      - UpperNorfairCrocomireEscape

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/MetroidStateChecks/VisibleItemMetroidCheck.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/MetroidStateChecks/VisibleItemMetroidCheck.cs
@@ -1,0 +1,63 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Randomizer.Abstractions;
+using Randomizer.Data.Tracking;
+using Randomizer.Data.WorldData;
+
+namespace Randomizer.SMZ3.Tracking.AutoTracking.MetroidStateChecks;
+
+public class VisibleItemMetroidCheck : IMetroidStateCheck
+{
+    public Dictionary<int, List<VisibleItemMetroid>> Items;
+
+    public VisibleItemMetroidCheck()
+    {
+        var visibleItems = VisibleItems.GetVisibleItems().MetroidItems;
+        Items = visibleItems.Select(x => x.Room)
+            .ToDictionary(s => s, s => visibleItems.Where(i => i.Room == s).ToList());
+    }
+
+    public bool ExecuteCheck(TrackerBase tracker, AutoTrackerMetroidState currentState,
+        AutoTrackerMetroidState prevState)
+    {
+        if (Items.TryGetValue(currentState.CurrentRoom, out var visibleItems))
+        {
+            var locations = visibleItems.Where(x =>
+                    currentState.IsSamusInArea(x.TopLeftX, x.BottomRightX, x.TopLeftY, x.BottomRightY))
+                .SelectMany(x => x.Locations)
+                .Select(x => tracker.World.FindLocation(x))
+                .ToList();
+
+            if (!locations.Any())
+            {
+                return false;
+            }
+
+            if (locations.All(x => x.State.Cleared || x.State.Autotracked || x.State.MarkedItem == x.State.Item))
+            {
+                Items.Remove(currentState.CurrentRoom);
+                return false;
+            }
+
+            tracker.AutoTracker!.SetLatestViewAction(() =>
+            {
+                var toClearLocations = locations.Where(x => x.State is { Cleared: false, Autotracked: false } &&
+                                                            x.State.MarkedItem != x.State.Item).ToList();
+                foreach (var location in toClearLocations)
+                {
+                    tracker.MarkLocation(location, location.Item);
+                }
+
+                if (toClearLocations.Any())
+                {
+                    tracker.UpdateLastMarkedLocations(toClearLocations);
+                }
+
+                Items.Remove(currentState.CurrentRoom);
+            });
+
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/VisibleItemZeldaCheck.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/VisibleItemZeldaCheck.cs
@@ -1,0 +1,82 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Randomizer.Abstractions;
+using Randomizer.Data.Tracking;
+using Randomizer.Data.WorldData;
+
+namespace Randomizer.SMZ3.Tracking.AutoTracking.ZeldaStateChecks;
+
+public class VisibleItemZeldaCheck : IZeldaStateCheck
+{
+    public Dictionary<int, List<VisibleItemZelda>> OverworldVisibleItems;
+    public Dictionary<int, List<VisibleItemZelda>> UnderworldVisibleItems;
+
+    public VisibleItemZeldaCheck()
+    {
+        var visibleItems = VisibleItems.GetVisibleItems().ZeldaItems;
+        OverworldVisibleItems = visibleItems.Where(x => x.OverworldScreen > 0)
+            .Select(x => (int)x.OverworldScreen!)
+            .ToDictionary(s => s, s => visibleItems.Where(i => i.OverworldScreen == s).ToList());
+        UnderworldVisibleItems = visibleItems.Where(x => x.OverworldScreen is null or 0)
+            .Select(x => (int)x.Room!)
+            .ToDictionary(r => r, r => visibleItems.Where(i => i.Room == r).ToList());
+    }
+
+    public bool ExecuteCheck(TrackerBase tracker, AutoTrackerZeldaState currentState, AutoTrackerZeldaState prevState)
+    {
+        if (currentState.OverworldScreen > 0 && OverworldVisibleItems.TryGetValue(currentState.OverworldScreen, out var visibleItems))
+        {
+            var locations = visibleItems.Where(x =>
+                    currentState.IsWithinRegion(x.TopLeftX, x.TopLeftY, x.BottomRightX, x.BottomRightY))
+                .SelectMany(x => x.Locations)
+                .Select(x => tracker.World.FindLocation(x))
+                .ToList();
+
+            return CheckItems(locations, OverworldVisibleItems, currentState, tracker);
+        }
+        else if (currentState.OverworldScreen == 0 && UnderworldVisibleItems.TryGetValue(currentState.CurrentRoom, out visibleItems))
+        {
+            var locations = visibleItems.Where(x =>
+                    currentState.IsWithinRegion(x.TopLeftX, x.TopLeftY, x.BottomRightX, x.BottomRightY))
+                .SelectMany(x => x.Locations)
+                .Select(x => tracker.World.FindLocation(x))
+                .ToList();
+
+            return CheckItems(locations, UnderworldVisibleItems, currentState, tracker);
+        }
+        return false;
+    }
+
+    private bool CheckItems(List<Location> locations, Dictionary<int, List<VisibleItemZelda>> items, AutoTrackerZeldaState currentState, TrackerBase tracker)
+    {
+        if (!locations.Any())
+        {
+            return false;
+        }
+
+        if (locations.All(x => x.State.Cleared || x.State.Autotracked || x.State.MarkedItem == x.State.Item))
+        {
+            items.Remove(currentState.CurrentRoom);
+            return false;
+        }
+
+        tracker.AutoTracker!.SetLatestViewAction(() =>
+        {
+            var toClearLocations = locations.Where(x => x.State is { Cleared: false, Autotracked: false } &&
+                                                        x.State.MarkedItem != x.State.Item).ToList();
+            foreach (var location in toClearLocations)
+            {
+                tracker.MarkLocation(location, location.Item);
+            }
+
+            if (toClearLocations.Any())
+            {
+                tracker.UpdateLastMarkedLocations(toClearLocations);
+            }
+
+            items.Remove(currentState.CurrentRoom);
+        });
+
+        return true;
+    }
+}

--- a/src/Randomizer.SMZ3.Tracking/Tracker.cs
+++ b/src/Randomizer.SMZ3.Tracking/Tracker.cs
@@ -58,6 +58,7 @@ public sealed class Tracker : TrackerBase, IDisposable
     private readonly bool _alternateTracker;
     private readonly HashSet<SchrodingersString> _saidLines = new();
     private IEnumerable<ItemType>? _previousMissingItems;
+    private List<Location> _lastMarkedLocations;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Tracker"/> class.
@@ -2193,6 +2194,21 @@ public sealed class Tracker : TrackerBase, IDisposable
         }
 
         OnHintTileUpdated(new HintTileUpdatedEventArgs(hintTile));
+    }
+
+    public override void UpdateLastMarkedLocations(List<Location> locations)
+    {
+        _lastMarkedLocations = locations;
+    }
+
+    public override void ClearLastMarkedLocations(float confidence)
+    {
+        if (_lastMarkedLocations.Count == 0)
+        {
+            Say(x => x.NoMarkedLocations);
+            return;
+        }
+        Clear(_lastMarkedLocations, confidence);
     }
 
     /// <summary>

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/LocationTrackingModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/LocationTrackingModule.cs
@@ -70,6 +70,18 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
         }
 
         [SupportedOSPlatform("windows")]
+        private GrammarBuilder GetClearMarkedLocationsRule()
+        {
+            return new GrammarBuilder()
+                .Append("Hey tracker,")
+                .Append("clear")
+                .OneOf("that", "those")
+                .Optional("last", "recent")
+                .Append("marked")
+                .OneOf("location", "locations");
+        }
+
+        [SupportedOSPlatform("windows")]
         private GrammarBuilder GetClearLocationRule()
         {
             var locationNames = GetLocationNames();
@@ -197,6 +209,11 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
                         includeUnavailable: true,
                         confidence: result.Confidence);
                 }
+            });
+
+            AddCommand("Clear recent marked locations", GetClearMarkedLocationsRule(), (result) =>
+            {
+                TrackerBase.ClearLastMarkedLocations(result.Confidence);
             });
         }
     }


### PR DESCRIPTION
There are definitely some visible items I missed, and there's going to need to be some additional stuff added on the Metroid side. For example, probably no need to mark the old tourian launch pad when you have the speed booster as you're likely rocketing up to get the item. Also probably probably shouldn't mark the post Chozo concert speed booster item unless you've destroyed the egg or whatever it is around the item.

But, this is a start for some of the most common marked locations, and I'll probably add some other basic ones to the list this week. (It just dawned on me I left out the library, for example.)

Closes #275 