### PR TITLE
Fix timer reset not working after tracking & undoing

### DIFF
--- a/src/Randomizer.SMZ3.Tracking/Tracker.cs
+++ b/src/Randomizer.SMZ3.Tracking/Tracker.cs
@@ -2074,7 +2074,7 @@ public sealed class Tracker : TrackerBase, IDisposable
     {
         if (region != CurrentRegion)
         {
-            if (resetTime && History.GetHistory().Count == 0)
+            if (resetTime && !History.GetHistory().Any(x => x is { LocationId: not null, IsUndone: false }))
             {
                 ResetTimer(true);
             }


### PR DESCRIPTION
Fixes #432 

Also shouldn't cause problems with tracking content as it only looks for valid locations in the history.