### PR TITLE
Multiworld Updates

### DIFF
--- a/src/Randomizer.App/Windows/MultiplayerConnectWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/MultiplayerConnectWindow.xaml.cs
@@ -37,6 +37,7 @@ namespace Randomizer.App.Windows
         private readonly ILogger _logger;
         private readonly string _version;
         private readonly ICommunicator _communicator;
+        private string _previousError = "";
 
         public MultiplayerConnectWindow(MultiplayerClientService multiplayerClientService, ILogger<MultiplayerConnectWindow> logger, ICommunicator communicator)
         {
@@ -57,6 +58,11 @@ namespace Randomizer.App.Windows
 
         private void MultiplayerClientServiceError(string error, Exception? exception)
         {
+            if (!Dispatcher.CheckAccess())
+            {
+                Dispatcher.Invoke(() => MultiplayerClientServiceError(error, exception));
+                return;
+            }
             DisplayError(error);
         }
 
@@ -80,6 +86,7 @@ namespace Randomizer.App.Windows
             if (!Dispatcher.CheckAccess())
             {
                 Dispatcher.Invoke(MultiplayerClientServiceGameJoined);
+                return;
             }
             DialogResult = true;
             Close();
@@ -182,6 +189,12 @@ namespace Randomizer.App.Windows
 
         private void DisplayError(string message)
         {
+            if (message == _previousError)
+            {
+                return;
+            }
+
+            _previousError = message;
             if (Dispatcher.CheckAccess())
             {
                 MessageBox.Show(this, message, "SMZ3 Cas' Randomizer", MessageBoxButton.OK, MessageBoxImage.Error);

--- a/src/Randomizer.Data/WorldData/World.cs
+++ b/src/Randomizer.Data/WorldData/World.cs
@@ -99,6 +99,7 @@ namespace Randomizer.Data.WorldData
         public string Player { get; }
         public string Guid { get; }
         public int Id { get; }
+        public bool HasCompleted { get; set; }
         public bool IsLocalWorld { get; set; }
         public IEnumerable<Region> Regions { get; }
         public IEnumerable<Room> Rooms { get; }

--- a/src/Randomizer.Multiplayer.Client/GameServices/MultiworldGameService.cs
+++ b/src/Randomizer.Multiplayer.Client/GameServices/MultiworldGameService.cs
@@ -13,12 +13,10 @@ namespace Randomizer.Multiplayer.Client.GameServices;
 public class MultiworldGameService : MultiplayerGameTypeService
 {
     private ITrackerStateService _trackerStateService;
-    private ILogger<MultiworldGameService> _logger;
 
-    public MultiworldGameService(Smz3Randomizer randomizer, Smz3MultiplayerRomGenerator multiplayerRomGenerator,  MultiplayerClientService client, ITrackerStateService trackerStateService, ILogger<MultiworldGameService> logger) : base(randomizer, multiplayerRomGenerator, client)
+    public MultiworldGameService(Smz3Randomizer randomizer, Smz3MultiplayerRomGenerator multiplayerRomGenerator,  MultiplayerClientService client, ITrackerStateService trackerStateService, ILogger<MultiplayerGameTypeService> logger) : base(randomizer, multiplayerRomGenerator, client, logger)
     {
         _trackerStateService = trackerStateService;
-        _logger = logger;
     }
 
     /// <summary>

--- a/src/Randomizer.Multiplayer.Client/MultiplayerClientService.cs
+++ b/src/Randomizer.Multiplayer.Client/MultiplayerClientService.cs
@@ -704,7 +704,7 @@ public class MultiplayerClientService
         }
 
         Players?.Add(playerState);
-        PlayerUpdated?.Invoke(playerState, previous, playerState.Guid == CurrentGameGuid);
+        PlayerUpdated?.Invoke(playerState, previous, playerState.Guid == CurrentPlayerGuid);
     }
 
     private bool VerifyConnection()

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/GameService.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/GameService.cs
@@ -542,7 +542,8 @@ public class GameService : TrackerModule, IGameService
 
         var otherCollectedItems = WorldService.Worlds.SelectMany(x => x.Locations)
             .Where(x => x.State.ItemWorldId == TrackerBase.World.Id && x.State.WorldId != TrackerBase.World.Id &&
-                        x.State.Autotracked).Select(x => (x.State.Item, x.State.WorldId)).ToList();
+                        x.State.Autotracked && (!x.World.HasCompleted || !x.Item.Type.IsInCategory(ItemCategory.IgnoreOnMultiplayerCompletion)))
+            .Select(x => (x.State.Item, x.State.WorldId)).ToList();
 
         foreach (var item in previouslyGiftedItems)
         {

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/MultiplayerModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/MultiplayerModule.cs
@@ -88,7 +88,14 @@ public class MultiplayerModule : TrackerModule
         if (TrackerBase.AutoTracker?.HasValidState != true) return;
         if (args.PlayerId == null || args.ItemsToGive == null || args.ItemsToGive.Count == 0 || args.IsLocalPlayer) return;
         var items = args.ItemsToGive.Select(x => ItemService.FirstOrDefault(x)).NonNull().ToList();
+
+        Logger.LogInformation("Giving player {Count} items", items.Count());
         TrackerBase.GameService!.TryGiveItems(items, args.PlayerId.Value);
+
+        if ((args.DidForfeit || args.DidComplete) && WorldService.Worlds.Any(x => x.Id == args.PlayerId))
+        {
+            WorldService.Worlds.First(x => x.Id == args.PlayerId).HasCompleted = true;
+        }
 
         foreach (var locationState in args.UpdatedLocationStates)
         {

--- a/src/Randomizer.Shared/Enums/ItemCategory.cs
+++ b/src/Randomizer.Shared/Enums/ItemCategory.cs
@@ -82,5 +82,10 @@
         /// This is one of the bottle item types
         /// </summary>
         Bottle,
+
+        /// <summary>
+        /// If this should not be given out when completing multiplayer games
+        /// </summary>
+        IgnoreOnMultiplayerCompletion,
     }
 }

--- a/src/Randomizer.Shared/Enums/ItemType.cs
+++ b/src/Randomizer.Shared/Enums/ItemType.cs
@@ -345,35 +345,35 @@ namespace Randomizer.Shared
         HeartContainerRefill = 0x3F,
 
         [Description("Three Bombs")]
-        [ItemCategory(ItemCategory.Zelda, ItemCategory.Scam, ItemCategory.Junk, ItemCategory.Plentiful)]
+        [ItemCategory(ItemCategory.Zelda, ItemCategory.Scam, ItemCategory.Junk, ItemCategory.Plentiful, ItemCategory.IgnoreOnMultiplayerCompletion)]
         ThreeBombs = 0x28,
 
         [Description("Single Arrow")]
-        [ItemCategory(ItemCategory.Zelda, ItemCategory.Scam, ItemCategory.Junk)]
+        [ItemCategory(ItemCategory.Zelda, ItemCategory.Scam, ItemCategory.Junk, ItemCategory.IgnoreOnMultiplayerCompletion)]
         Arrow = 0x43,
 
         [Description("Ten Arrows")]
-        [ItemCategory(ItemCategory.Zelda, ItemCategory.Scam, ItemCategory.Junk)]
+        [ItemCategory(ItemCategory.Zelda, ItemCategory.Scam, ItemCategory.Junk, ItemCategory.IgnoreOnMultiplayerCompletion)]
         TenArrows = 0x44,
 
         [Description("One Rupee")]
-        [ItemCategory(ItemCategory.Zelda, ItemCategory.Scam, ItemCategory.Junk)]
+        [ItemCategory(ItemCategory.Zelda, ItemCategory.Scam, ItemCategory.Junk, ItemCategory.IgnoreOnMultiplayerCompletion)]
         OneRupee = 0x34,
 
         [Description("Five Rupees")]
-        [ItemCategory(ItemCategory.Zelda, ItemCategory.Scam, ItemCategory.Junk)]
+        [ItemCategory(ItemCategory.Zelda, ItemCategory.Scam, ItemCategory.Junk, ItemCategory.IgnoreOnMultiplayerCompletion)]
         FiveRupees = 0x35,
 
         [Description("Twenty Rupees")]
-        [ItemCategory(ItemCategory.Zelda, ItemCategory.Scam, ItemCategory.Junk, ItemCategory.Plentiful)]
+        [ItemCategory(ItemCategory.Zelda, ItemCategory.Scam, ItemCategory.Junk, ItemCategory.Plentiful, ItemCategory.IgnoreOnMultiplayerCompletion)]
         TwentyRupees = 0x36,
 
         [Description("Twenty Rupees")]
-        [ItemCategory(ItemCategory.Zelda, ItemCategory.Scam, ItemCategory.Junk)]
+        [ItemCategory(ItemCategory.Zelda, ItemCategory.Scam, ItemCategory.Junk, ItemCategory.IgnoreOnMultiplayerCompletion)]
         TwentyRupees2 = 0x47,
 
         [Description("Fifty Rupees")]
-        [ItemCategory(ItemCategory.Zelda, ItemCategory.Scam, ItemCategory.Junk)]
+        [ItemCategory(ItemCategory.Zelda, ItemCategory.Scam, ItemCategory.Junk, ItemCategory.IgnoreOnMultiplayerCompletion)]
         FiftyRupees = 0x41,
 
         [Description("One Hundred Rupees")]


### PR DESCRIPTION
- When a player completes the game, it will avoid sending absolutely useless items to prevent the item received spam (closes #436)
- Fixed an issue where players would receive their own items when completing the game
- Fixed an issue where sometimes the randomizer would crash when receiving an error when the connection is lost with the server
- Prevented repeated error spam when the connection is lost with the server