### PR TITLE
Fix entered pendant dungeon line

### DIFF
--- a/src/Randomizer.Data/Configuration/ConfigTypes/AutotrackerConfig.cs
+++ b/src/Randomizer.Data/Configuration/ConfigTypes/AutotrackerConfig.cs
@@ -111,7 +111,7 @@ namespace Randomizer.Data.Configuration.ConfigTypes
         /// Gets the phrases to respond with when entering a pendant dungeon
         /// </summary>
         public SchrodingersString EnterPendantDungeon { get; init; }
-            = new("Ouch. So it's come to this, then?");
+            = new("");
 
         /// <summary>
         /// Entered GT without all crystals

--- a/src/Randomizer.Data/Configuration/Yaml/Sassy/responses.yml
+++ b/src/Randomizer.Data/Configuration/Yaml/Sassy/responses.yml
@@ -973,11 +973,18 @@ AutoTracker:
   - Text: At least use the net, make it interesting.
   EnterPendantDungeon:
   - Text: I hope dipping into this pendant dungeon will be worth it for you.
+    Weight: 0.1
   - Text: I hope you dont have to double or triple dip
-  - Text: Didn't you say that {0} had the {1}? You must be getting desperate.
+    Weight: 0.1
+  - Text: Doesn't {0} have the {1}? You must be getting desperate.
+    Weight: 0.1
+  - Text: Personally I hope this is a waste of time
+    Weight: 0.1
+  - Text: Are you lost? Why are you in a pendant dungeon?
+    Weight: 0.1
   EnteredGTEarly:
   - Text: Are you not capable of collecting everything required to finish this seed?
-  - Text: How did you get into Gannon's tower without all 7 crystals? Surely this isn't legal
+  - Text: How did you get into Gannon's tower without all of the crystals? Surely this isn't legal
   FakeFlippers:
   - Text: Good job on the tech. Was it a first try?
   - Text: How can you swim without the flippers?

--- a/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/EnteredDungeon.cs
+++ b/src/Randomizer.SMZ3.Tracking/AutoTracking/ZeldaStateChecks/EnteredDungeon.cs
@@ -35,17 +35,15 @@ public class EnteredDungeon : IZeldaStateCheck
     /// <returns>True if the check was identified, false otherwise</returns>
     public bool ExecuteCheck(TrackerBase tracker, AutoTrackerZeldaState currentState, AutoTrackerZeldaState prevState)
     {
-        if (currentState.State == 0x07 && (prevState.State == 0x06 || prevState.State == 0x09 || prevState.State == 0x0F || prevState.State == 0x10 || prevState.State == 0x11))
+        if (currentState.State == 0x07 && prevState.State is 0x06 or 0x09 or 0x0F or 0x10 or 0x11)
         {
             // Get the region for the room
             var region = tracker.World.Regions
                 .OfType<Z3Region>()
-                .FirstOrDefault(x => x.StartingRooms.Count == 0 && x.StartingRooms.Contains(currentState.CurrentRoom) && !x.IsOverworld);
-            if (region == null) return false;
+                .FirstOrDefault(x => x.StartingRooms.Count > 0 && x.StartingRooms.Contains(currentState.CurrentRoom) && !x.IsOverworld);
 
             // Get the dungeon info for the room
-            var dungeon = region as IDungeon;
-            if (dungeon == null) return false;
+            if (region is not IDungeon dungeon) return false;
 
             if (!_worldAccessor.World.Config.ZeldaKeysanity && !_enteredDungeons.Contains(region) && dungeon.IsPendantDungeon)
             {
@@ -60,7 +58,7 @@ public class EnteredDungeon : IZeldaStateCheck
                 var clearedCrystalDungeonCount = tracker.World.Dungeons
                     .Count(x => x.DungeonState.Cleared && x.IsCrystalDungeon);
 
-                if (clearedCrystalDungeonCount < 7)
+                if (clearedCrystalDungeonCount < tracker.World.Config.GanonsTowerCrystalCount)
                 {
                     tracker.SayOnce(x => x.AutoTracker.EnteredGTEarly, clearedCrystalDungeonCount);
                 }


### PR DESCRIPTION
Whoops. Apparently this was broken since October of last year with the .net upgrade changes. lol 

I did make it so that Tracker will say something only half of the time when she enters a pendant dungeon as I kind of remember it being a little annoying with things like Thieves Town and Eastern Palace dips not being that unreasonable.