### PR TITLE
Sass on marking/tracking pre-configured locations

### DIFF
--- a/src/Randomizer.Abstractions/TrackerBase.cs
+++ b/src/Randomizer.Abstractions/TrackerBase.cs
@@ -3,6 +3,7 @@ using Randomizer.Data;
 using Randomizer.Data.Configuration;
 using Randomizer.Data.Configuration.ConfigFiles;
 using Randomizer.Data.Configuration.ConfigTypes;
+using Randomizer.Data.Options;
 using Randomizer.Data.Tracking;
 using Randomizer.Data.WorldData;
 using Randomizer.Data.WorldData.Regions;
@@ -199,6 +200,11 @@ public abstract class TrackerBase
     /// Gets a string describing tracker's mood.
     /// </summary>
     public string Mood { get; protected set; } = "";
+
+    /// <summary>
+    /// Gets the config used to generate the local seed.
+    /// </summary>
+    public Config? LocalConfig { get; protected set; }
 
     /// <summary>
     /// Get if the Tracker has been updated since it was last saved

--- a/src/Randomizer.App/Randomizer.App.csproj
+++ b/src/Randomizer.App/Randomizer.App.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net7.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>chozo20.ico</ApplicationIcon>
-    <Version>9.6.0</Version>
+    <Version>9.6.1.1</Version>
     <Title>SMZ3 Cas' Randomizer</Title>
     <AssemblyTitle>SMZ3 Cas' Randomizer</AssemblyTitle>
     <Authors>Vivelin</Authors>

--- a/src/Randomizer.Data/Configuration/ConfigFiles/ResponseConfig.cs
+++ b/src/Randomizer.Data/Configuration/ConfigFiles/ResponseConfig.cs
@@ -535,6 +535,22 @@ namespace Randomizer.Data.Configuration.ConfigFiles
             = new SchrodingersString("Cleared {0}.");
 
         /// <summary>
+        /// Gets the phrases to respond with when marking an item at a location that was preconfigured.
+        /// </summary>
+        /// <remarks>
+        /// <c>{0}</c> is a placeholder for the name of the location.
+        /// </remarks>
+        public SchrodingersString? LocationMarkedPreConfigured { get; init; }
+
+        /// <summary>
+        /// Gets the phrases to respond with when tracking an item at a location that was preconfigured.
+        /// </summary>
+        /// <remarks>
+        /// <c>{0}</c> is a placeholder for the name of the location.
+        /// </remarks>
+        public SchrodingersString? TrackedPreConfigured { get; init; }
+
+        /// <summary>
         /// Gets the phrases to respond with when marking or tracking an item at
         /// a location, when the seed contains a different item at the same
         /// location.

--- a/src/Randomizer.Data/Configuration/Yaml/Sassy/responses.yml
+++ b/src/Randomizer.Data/Configuration/Yaml/Sassy/responses.yml
@@ -342,6 +342,17 @@ LocationMarkedAsBullshit:
 - Text: Ignoring {0}
 - Text: I hope you didn't waste time going there.
   Weight: 0.2
+LocationMarkedPreConfigured:
+- Text: But you already knew that, didn't you?
+- Text: But you already knew that, right?
+- Text: What a surprise.
+- Text: I wonder who put that there.
+- Text: Wink.
+TrackedPreConfigured:
+- Text: What a surprise.
+- Text: I wonder who put that there.
+- Text: Wow, who knew that would be there.
+- Text: Wink.
 LocationHasDifferentItem:
 - Text: That looks more like something else to me, but whatever.
 - Text: Do you even know what you're talking about? Oh well.


### PR DESCRIPTION
Just a random idea I've had for a while. Betus can't keep getting away with this.

Or well, I guess he still can. It looks like we only save specific items at locations, but not the other possible options like guaranteeing early boots or something.