### PR TITLE
Add MSU creator to horizontal MSU display

### DIFF
--- a/src/Randomizer.App/Windows/MsuTrackWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/MsuTrackWindow.xaml.cs
@@ -63,17 +63,7 @@ public partial class MsuTrackWindow : Window, IDisposable
 
         if (_options == null || _currentTrack == null || _currentMsu == null) return;
 
-        if (_options!.GeneralOptions.MsuTrackDisplayStyle == MsuTrackDisplayStyle.Horizontal)
-        {
-            MsuPanel.Visibility = Visibility.Collapsed;
-            AlbumPanel.Visibility = Visibility.Collapsed;
-            ArtistPanel.Visibility = Visibility.Collapsed;
-            SongPanel.Visibility = Visibility.Collapsed;
-            HorizontalTextBlock.Visibility = Visibility.Visible;
-            InfoTextBlock.Visibility = Visibility.Collapsed;
-            HorizontalTextBlock.Text = _outputText;
-        }
-        else
+        if (_options.GeneralOptions.MsuTrackDisplayStyle == MsuTrackDisplayStyle.Vertical)
         {
             MsuPanel.Visibility = Visibility.Visible;
             var creator = string.IsNullOrEmpty(_currentTrack.MsuCreator)
@@ -101,6 +91,16 @@ public partial class MsuTrackWindow : Window, IDisposable
 
             HorizontalTextBlock.Visibility = Visibility.Collapsed;
             InfoTextBlock.Visibility = Visibility.Collapsed;
+        }
+        else
+        {
+            MsuPanel.Visibility = Visibility.Collapsed;
+            AlbumPanel.Visibility = Visibility.Collapsed;
+            ArtistPanel.Visibility = Visibility.Collapsed;
+            SongPanel.Visibility = Visibility.Collapsed;
+            HorizontalTextBlock.Visibility = Visibility.Visible;
+            InfoTextBlock.Visibility = Visibility.Collapsed;
+            HorizontalTextBlock.Text = _outputText;
         }
 
         _cts.Cancel();

--- a/src/Randomizer.Data/Options/MsuTrackDisplayStyle.cs
+++ b/src/Randomizer.Data/Options/MsuTrackDisplayStyle.cs
@@ -8,7 +8,7 @@ public enum MsuTrackDisplayStyle
     /// Original horizontal style: displays the current track without MSU pack
     /// info if artist information is available.
     /// </summary>
-    [Description("Original: \"album - track (artist)\" or \"track - MSU pack name\"")]
+    [Description("Original: \"Cave Story+ - Pulse (Danny Baranowsky)\" or \"Track #5 from Sound of Silence\"")]
     Horizontal,
 
     /// <summary>
@@ -20,13 +20,13 @@ public enum MsuTrackDisplayStyle
     /// <summary>
     /// Horizontal style: displays the current track with MSU pack info.
     /// </summary>
-    [Description("Single line: \"album: track - artist (MSU: name by creator)\"")]
+    [Description("Single line: \"Cave Story+: Pulse - Danny Baranowsky (MSU: DBstyle by Vivelin)\"")]
     HorizonalWithMsu,
 
     /// <summary>
     /// Expanded sentence-style: displays track and MSU pack info in a single
     /// (long) line.
     /// </summary>
-    [Description("Sentence: \"track by artist from album album from MSU pack name by creator\"")]
+    [Description("Sentence: \"Pulse by Danny Baranowsky from album Cave Story+ from MSU pack DBstyle by Vivelin\"")]
     SentenceStyle,
 }

--- a/src/Randomizer.Data/Options/MsuTrackDisplayStyle.cs
+++ b/src/Randomizer.Data/Options/MsuTrackDisplayStyle.cs
@@ -1,7 +1,32 @@
-﻿namespace Randomizer.Data.Options;
+﻿using System.ComponentModel;
+
+namespace Randomizer.Data.Options;
 
 public enum MsuTrackDisplayStyle
 {
+    /// <summary>
+    /// Original horizontal style: displays the current track without MSU pack
+    /// info if artist information is available.
+    /// </summary>
+    [Description("Original: \"album - track (artist)\" or \"track - MSU pack name\"")]
     Horizontal,
-    Vertical
+
+    /// <summary>
+    /// Vertical style: separate lines for separate tracks, with MSU pack info.
+    /// </summary>
+    [Description("Multiple lines: MSU/album/song/artist")]
+    Vertical,
+
+    /// <summary>
+    /// Horizontal style: displays the current track with MSU pack info.
+    /// </summary>
+    [Description("Single line: \"album: track - artist (MSU: name by creator)\"")]
+    HorizonalWithMsu,
+
+    /// <summary>
+    /// Expanded sentence-style: displays track and MSU pack info in a single
+    /// (long) line.
+    /// </summary>
+    [Description("Sentence: \"track by artist from album album from MSU pack name by creator\"")]
+    SentenceStyle,
 }

--- a/src/Randomizer.SMZ3.Tracking/MsuDisplayTextBuilder.cs
+++ b/src/Randomizer.SMZ3.Tracking/MsuDisplayTextBuilder.cs
@@ -1,0 +1,181 @@
+﻿using System.Text;
+
+using MSURandomizerLibrary.Configs;
+
+namespace Randomizer.SMZ3.Tracking;
+
+/// <summary>
+/// Provides a fluent interface for building MSU display text.
+/// </summary>
+public class MsuDisplayTextBuilder
+{
+    private readonly StringBuilder _builder = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MsuDisplayTextBuilder"/>
+    /// class.
+    /// </summary>
+    /// <param name="track">The track to be formatted.</param>
+    /// <param name="msu">The MSU to be formatted.</param>
+    public MsuDisplayTextBuilder(Track track, Msu msu)
+    {
+        Track = track;
+        Msu = msu;
+    }
+
+    /// <summary>
+    /// Gets or sets the Track to be formatted.
+    /// </summary>
+    public Track Track { get; set; }
+
+    /// <summary>
+    /// Gets or sets the MSU to be formatted.
+    /// </summary>
+    public Msu Msu { get; set; }
+
+    /// <summary>
+    /// Adds the album name in the specified format if it is available.
+    /// </summary>
+    /// <param name="format">
+    /// The format string, where <c>{0}</c> will be replaced with the album
+    /// name.
+    /// </param>
+    /// <param name="fallback">
+    /// The text to add if the album name is not available.
+    /// </param>
+    /// <returns>
+    /// This instance with the formatted album name added if it is available.
+    /// </returns>
+    public MsuDisplayTextBuilder AddAlbum(string format, string? fallback = "")
+    {
+        if (!string.IsNullOrWhiteSpace(Track.DisplayAlbum))
+            _builder.AppendFormat(format, Track.DisplayAlbum);
+        else
+            _builder.Append(fallback);
+
+        return this;
+    }
+
+    /// <summary>
+    /// Adds the artist name in the specified format if it is available.
+    /// </summary>
+    /// <param name="format">
+    /// The format string, where <c>{0}</c> will be replaced with the artist
+    /// name.
+    /// </param>
+    /// <param name="fallback">
+    /// The text to add if the artist name is not available.
+    /// </param>
+    /// <returns>
+    /// This instance with the formatted artist name added if it is available.
+    /// </returns>
+    public MsuDisplayTextBuilder AddArtist(string format, string? fallback = "")
+    {
+        if (!string.IsNullOrWhiteSpace(Track.DisplayArtist))
+            _builder.AppendFormat(format, Track.DisplayArtist);
+        else
+            _builder.Append(fallback);
+
+        return this;
+    }
+
+    /// <summary>
+    /// Adds the song name in the specified format if it is available.
+    /// </summary>
+    /// <param name="format">
+    /// The format string, where <c>{0}</c> will be replaced with the song name.
+    /// </param>
+    /// <param name="fallback">
+    /// The text to add if the song name is not available.
+    /// </param>
+    /// <returns>
+    /// This instance with the formatted song name added if it is available.
+    /// </returns>
+    public MsuDisplayTextBuilder AddTrackTitle(string format, string? fallback = "")
+    {
+        if (!string.IsNullOrWhiteSpace(Track.SongName))
+            _builder.AppendFormat(format, Track.SongName);
+        else
+            _builder.Append(fallback);
+
+        return this;
+    }
+
+    /// <summary>
+    /// Adds the MSU pack name and author together in the specified format if it
+    /// is available.
+    /// </summary>
+    /// <param name="format">
+    /// The format string, where <c>{0}</c> will be replaced with the MSU pack
+    /// name and author.
+    /// </param>
+    /// <param name="fallback">
+    /// The text to add if the MSU pack name or creator are not available.
+    /// </param>
+    /// <returns>
+    /// This instance with the formatted MSU pack name and author added if it is
+    /// available.
+    /// </returns>
+    public MsuDisplayTextBuilder AddMsuNameAndCreator(string format, string? fallback = "")
+    {
+        var fullName = Track.GetMsuName();
+        if (!string.IsNullOrWhiteSpace(fullName))
+            _builder.AppendFormat(format, fullName);
+        else
+            _builder.Append(fallback);
+
+        return this;
+    }
+
+    /// <summary>
+    /// Adds the MSU pack name in the specified format if it is available.
+    /// </summary>
+    /// <param name="format">
+    /// The format string, where <c>{0}</c> will be replaced with the MSU pack
+    /// name.
+    /// </param>
+    /// <param name="fallback">
+    /// The text to add if the MSU pack name is not available.
+    /// </param>
+    /// <returns>
+    /// This instance with the formatted MSU pack name added if it is available.
+    /// </returns>
+    public MsuDisplayTextBuilder AddMsuName(string format, string? fallback = "")
+    {
+        if (!string.IsNullOrWhiteSpace(Track.MsuName))
+            _builder.AppendFormat(format, Track.MsuName);
+        else
+            _builder.Append(fallback);
+
+        return this;
+    }
+
+    /// <summary>
+    /// Adds the MSU author in the specified format if it is available.
+    /// </summary>
+    /// <param name="format">
+    /// The format string, where <c>{0}</c> will be replaced with the MSU
+    /// author.
+    /// </param>
+    /// <param name="fallback">
+    /// The text to add if the MSU author is not available.
+    /// </param>
+    /// <returns>
+    /// This instance with the formatted MSU author added if it is available.
+    /// </returns>
+    public MsuDisplayTextBuilder AddMsuCreator(string format, string? fallback = "")
+    {
+        if (!string.IsNullOrWhiteSpace(Track.MsuCreator))
+            _builder.AppendFormat(format, Track.MsuCreator);
+        else
+            _builder.Append(fallback);
+
+        return this;
+    }
+
+    /// <summary>
+    /// Returns the formatted MSU display text.
+    /// </summary>
+    /// <returns>A string containing the formatted text.</returns>
+    public override string ToString() => _builder.ToString().Trim();
+}

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/MsuModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/MsuModule.cs
@@ -144,23 +144,7 @@ public class MsuModule : TrackerModule, IDisposable
         var options = TrackerBase.Options;
         if (options.MsuTrackDisplayStyle == MsuTrackDisplayStyle.Horizontal)
         {
-            if (!string.IsNullOrEmpty(_currentTrack.DisplayAlbum) || !string.IsNullOrEmpty(_currentTrack.DisplayArtist))
-            {
-                var album = string.IsNullOrEmpty(_currentTrack.DisplayAlbum)
-                    ? ""
-                    : $"{_currentTrack.DisplayAlbum} - ";
-                var artist = string.IsNullOrEmpty(_currentTrack.DisplayArtist)
-                    ? ""
-                    : $" ({_currentTrack.DisplayArtist})";
-                return $"{album}{_currentTrack.SongName}{artist}";
-            }
-            else
-            {
-                var msu = string.IsNullOrEmpty(_currentTrack.MsuName)
-                    ? _currentMsu.DisplayName
-                    : _currentTrack.MsuName;
-                return $"{_currentTrack.SongName} from {msu}";
-            }
+            return _currentTrack.GetDisplayText(includeMsu: true);
         }
         else
         {


### PR DESCRIPTION
I really kind of want to see the MSU pack name/author in the on-screen info. I've wanted this for longer, since the track info itself isn't always enough to find out which pack it's from, but now that the bad/weird pack has a YAML, I figured I might as well just make the change myself.

I was about to complicate the MSU track output text function with some sort of "MsuDisplayTextBuilder" class when I realized the MSU rando lib already has a `Track.GetDisplayText(bool)` function that does exactly that. The formatting is slightly different, but I figured that's probably not a huge deal.

If it is, let me know, and I'll overcomplicate things anyway. In case we need more control over the formatting or something.