### PR TITLE
Fix crystal dungeon tracker hints

### DIFF
--- a/src/Randomizer.App/Randomizer.App.csproj
+++ b/src/Randomizer.App/Randomizer.App.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net7.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>chozo20.ico</ApplicationIcon>
-    <Version>9.7.1</Version>
+    <Version>9.7.2</Version>
     <Title>SMZ3 Cas' Randomizer</Title>
     <AssemblyTitle>SMZ3 Cas' Randomizer</AssemblyTitle>
     <Authors>Vivelin</Authors>

--- a/src/Randomizer.Data/WorldData/Location.cs
+++ b/src/Randomizer.Data/WorldData/Location.cs
@@ -281,6 +281,20 @@ namespace Randomizer.Data.WorldData
         }
 
         /// <summary>
+        /// Returns if the item is potentially important, but not necessarily required
+        /// </summary>
+        /// <param name="keysanity">The keysanity mode. If not specified, it'll use the item's world</param>
+        /// <returns></returns>
+        public bool IsPotentiallyImportant(KeysanityMode? keysanity = null)
+        {
+            keysanity ??= Item.World.Config.KeysanityMode;
+            return Item.Progression
+                || (Item.IsDungeonItem && keysanity is KeysanityMode.Both or KeysanityMode.Zelda)
+                || (Item.IsKeycard && keysanity is KeysanityMode.Both or KeysanityMode.SuperMetroid);
+        }
+
+
+        /// <summary>
         /// Returns a string that represents the location.
         /// </summary>
         /// <returns>A string that represents this location.</returns>

--- a/src/Randomizer.SMZ3.Tracking/VoiceCommands/SpoilerModule.cs
+++ b/src/Randomizer.SMZ3.Tracking/VoiceCommands/SpoilerModule.cs
@@ -118,7 +118,12 @@ namespace Randomizer.SMZ3.Tracking.VoiceCommands
             }
             else if (TrackerBase.HintsEnabled)
             {
-                var usefulness = _gameHintService.GetUsefulness(locations.ToList(), WorldService.Worlds, !TrackerBase.World.Config.ZeldaKeysanity);
+                Reward? areaReward = null;
+                if (area is IHasReward { RewardType: RewardType.CrystalRed or RewardType.CrystalBlue } rewardArea)
+                {
+                    areaReward = rewardArea.Reward;
+                }
+                var usefulness = _gameHintService.GetUsefulness(locations.ToList(), WorldService.Worlds, areaReward);
                 if (usefulness == LocationUsefulness.Mandatory)
                 {
                     TrackerBase.Say(x => x.Hints.AreaHasSomethingMandatory, area.GetName());

--- a/src/Randomizer.SMZ3/Contracts/IGameHintService.cs
+++ b/src/Randomizer.SMZ3/Contracts/IGameHintService.cs
@@ -39,9 +39,9 @@ namespace Randomizer.SMZ3.Contracts
         /// </summary>
         /// <param name="locations">The location to check</param>
         /// <param name="allWorlds">All worlds that are a part of the seed</param>
-        /// <param name="ignoreRewards">Ignore dungeon rewards</param>
+        /// <param name="ignoredReward">Dungeon reward to ignore</param>
         /// <returns>How useful the locations are</returns>
-        LocationUsefulness GetUsefulness(List<Location> locations, List<World> allWorlds, bool ignoreRewards);
+        LocationUsefulness GetUsefulness(List<Location> locations, List<World> allWorlds, Reward? ignoredReward);
 
         /// <summary>
         /// Retrieves the text that could be displayed on one of the hint tiles in a player's

--- a/src/Randomizer.SMZ3/Contracts/IGameHintService.cs
+++ b/src/Randomizer.SMZ3/Contracts/IGameHintService.cs
@@ -39,8 +39,9 @@ namespace Randomizer.SMZ3.Contracts
         /// </summary>
         /// <param name="locations">The location to check</param>
         /// <param name="allWorlds">All worlds that are a part of the seed</param>
+        /// <param name="ignoreRewards">Ignore dungeon rewards</param>
         /// <returns>How useful the locations are</returns>
-        LocationUsefulness GetUsefulness(List<Location> locations, List<World> allWorlds);
+        LocationUsefulness GetUsefulness(List<Location> locations, List<World> allWorlds, bool ignoreRewards);
 
         /// <summary>
         /// Retrieves the text that could be displayed on one of the hint tiles in a player's

--- a/src/Randomizer.SMZ3/Generation/GameHintService.cs
+++ b/src/Randomizer.SMZ3/Generation/GameHintService.cs
@@ -14,6 +14,7 @@ using Randomizer.Shared;
 using Randomizer.Shared.Enums;
 using Randomizer.Shared.Models;
 using Randomizer.SMZ3.Contracts;
+using Randomizer.SMZ3.Infrastructure;
 
 namespace Randomizer.SMZ3.Generation
 {
@@ -62,12 +63,14 @@ namespace Randomizer.SMZ3.Generation
         private readonly IMetadataService _metadataService;
         private readonly GameLinesConfig _gameLines;
         private readonly HintTileConfig _hintTileConfig;
+        private readonly PlaythroughService _playthroughService;
         private Random _random;
 
-        public GameHintService(Configs configs, IMetadataService metadataService, ILogger<GameHintService> logger)
+        public GameHintService(Configs configs, IMetadataService metadataService, ILogger<GameHintService> logger, PlaythroughService playthroughService)
         {
             _gameLines = configs.GameLines;
             _logger = logger;
+            _playthroughService = playthroughService;
             _hintTileConfig = configs.HintTileConfig;
             _metadataService = metadataService;
             _random = new Random();
@@ -168,7 +171,7 @@ namespace Randomizer.SMZ3.Generation
             return locationUsefulness.MaxBy(x => (int)x.Usefulness);
         }
 
-        public LocationUsefulness GetUsefulness(List<Location> locations, List<World> allWorlds)
+        public LocationUsefulness GetUsefulness(List<Location> locations, List<World> allWorlds, bool ignoreRewards)
         {
             var importantLocations = GetImportantLocations(allWorlds);
 
@@ -181,7 +184,7 @@ namespace Randomizer.SMZ3.Generation
                 return LocationUsefulness.Useless;
             }
 
-            return CheckIfLocationsAreImportant(allWorlds, importantLocations, locations);
+            return CheckIfLocationsAreImportant(allWorlds, importantLocations, locations, ignoreRewards);
         }
 
         /// <summary>
@@ -379,12 +382,17 @@ namespace Randomizer.SMZ3.Generation
         /// Checks how useful a location is based on if the seed can be completed if we remove those
         /// locations from the playthrough and if the items there are at least slightly useful
         /// </summary>
-        private LocationUsefulness CheckIfLocationsAreImportant(List<World> allWorlds, IEnumerable<Location> importantLocations, List<Location> locations)
+        private LocationUsefulness CheckIfLocationsAreImportant(List<World> allWorlds, IEnumerable<Location> importantLocations, List<Location> locations, bool ignoreRewards = false)
         {
             var worldLocations = importantLocations.Except(locations).ToList();
             try
             {
-                var spheres = Playthrough.GenerateSpheres(worldLocations);
+                var localWorld = allWorlds.First(x => x.Id == locations.First().World.Id);
+                var locationIds = locations.Select(x => x.Id).ToHashSet();
+                var rewards = ignoreRewards
+                    ? localWorld.Dungeons.Where(x => x.DungeonRewardType is RewardType.CrystalBlue or RewardType.CrystalRed && x.BossLocationId != null && locationIds.Contains(x.BossLocationId.Value)).Select(x => x.DungeonReward!).ToList()
+                    : null;
+                var spheres = _playthroughService.GenerateSpheres(worldLocations, rewards);
                 var sphereLocations = spheres.SelectMany(x => x.Locations).ToList();
 
                 var canBeatGT = CheckSphereLocationCount(sphereLocations, locations, LocationId.GanonsTowerMoldormChest, allWorlds.Count);
@@ -420,7 +428,7 @@ namespace Randomizer.SMZ3.Generation
                     }
                     var currentCrystalCount = world.Dungeons.Count(d =>
                         d.IsCrystalDungeon && sphereLocations.Any(l =>
-                            l.World.Id == world.Id && l.Id == s_dungeonBossLocations[d.GetType()]));
+                            l.World.Id == world.Id && l.Id == s_dungeonBossLocations[d.GetType()])) + (rewards?.Count ?? 0);
                     if (currentCrystalCount < numCrystalsNeeded)
                     {
                         return LocationUsefulness.Mandatory;
@@ -595,7 +603,7 @@ namespace Randomizer.SMZ3.Generation
         {
             // Get the first accessible ammo locations to make sure early ammo isn't considered mandatory when there
             // are others available
-            var spheres = Playthrough.GenerateSpheres(allWorlds.SelectMany(x => x.Locations));
+            var spheres = _playthroughService.GenerateSpheres(allWorlds.SelectMany(x => x.Locations));
             var ammoItemTypes = new List<ItemType>()
             {
                 ItemType.Missile,

--- a/src/Randomizer.SMZ3/Generation/Smz3MultiplayerRomGenerator.cs
+++ b/src/Randomizer.SMZ3/Generation/Smz3MultiplayerRomGenerator.cs
@@ -9,6 +9,7 @@ using Randomizer.Data.WorldData;
 using Randomizer.Shared;
 using Randomizer.SMZ3.Contracts;
 using Randomizer.SMZ3.FileData;
+using Randomizer.SMZ3.Infrastructure;
 
 namespace Randomizer.SMZ3.Generation;
 
@@ -19,14 +20,16 @@ public class Smz3MultiplayerRomGenerator : ISeededRandomizer
     private readonly IWorldAccessor _worldAccessor;
     private readonly ILogger<Smz3MultiplayerRomGenerator> _logger;
     private readonly IPatcherService _patcherService;
+    private readonly PlaythroughService _playthroughService;
 
     public Smz3MultiplayerRomGenerator(MultiplayerFillerFactory fillerFactory, IWorldAccessor worldAccessor,
-        ILogger<Smz3MultiplayerRomGenerator> logger, IPatcherService patcherService)
+        ILogger<Smz3MultiplayerRomGenerator> logger, IPatcherService patcherService, PlaythroughService playthroughService)
     {
         _fillerFactory = fillerFactory;
         _worldAccessor = worldAccessor;
         _logger = logger;
         _patcherService = patcherService;
+        _playthroughService = playthroughService;
     }
 
     public SeedData GenerateSeed(Config config, CancellationToken cancellationToken = default) =>
@@ -52,7 +55,7 @@ public class Smz3MultiplayerRomGenerator : ISeededRandomizer
 
         var filler = _fillerFactory.Create();
         filler.Fill(worlds, primaryConfig, cancellationToken);
-        var playthrough = Playthrough.Generate(worlds, primaryConfig);
+        var playthrough = _playthroughService.Generate(worlds, primaryConfig);
 
         var seedData = new SeedData
         (

--- a/src/Randomizer.SMZ3/Generation/Smz3Plandomizer.cs
+++ b/src/Randomizer.SMZ3/Generation/Smz3Plandomizer.cs
@@ -10,6 +10,7 @@ using Randomizer.Data.WorldData;
 using Randomizer.Shared;
 using Randomizer.SMZ3.Contracts;
 using Randomizer.SMZ3.FileData;
+using Randomizer.SMZ3.Infrastructure;
 
 namespace Randomizer.SMZ3.Generation
 {
@@ -19,14 +20,16 @@ namespace Randomizer.SMZ3.Generation
         private readonly IWorldAccessor _worldAccessor;
         private readonly ILogger<Smz3Plandomizer> _logger;
         private readonly IPatcherService _patcherService;
+        private readonly PlaythroughService _playthroughService;
 
         public Smz3Plandomizer(PlandoFillerFactory fillerFactory, IWorldAccessor worldAccessor,
-            ILogger<Smz3Plandomizer> logger, IPatcherService patcherService)
+            ILogger<Smz3Plandomizer> logger, IPatcherService patcherService, PlaythroughService playthroughService)
         {
             _fillerFactory = fillerFactory;
             _worldAccessor = worldAccessor;
             _logger = logger;
             _patcherService = patcherService;
+            _playthroughService = playthroughService;
         }
 
         public SeedData GenerateSeed(Config config, CancellationToken cancellationToken = default)
@@ -45,7 +48,7 @@ namespace Randomizer.SMZ3.Generation
             Playthrough playthrough;
             try
             {
-                playthrough = Playthrough.Generate(worlds, config);
+                playthrough = _playthroughService.Generate(worlds, config);
             }
             catch (RandomizerGenerationException ex)
             {

--- a/src/Randomizer.SMZ3/Generation/Smz3Randomizer.cs
+++ b/src/Randomizer.SMZ3/Generation/Smz3Randomizer.cs
@@ -11,6 +11,7 @@ using Randomizer.Shared;
 using Randomizer.Shared.Enums;
 using Randomizer.SMZ3.Contracts;
 using Randomizer.SMZ3.FileData;
+using Randomizer.SMZ3.Infrastructure;
 
 namespace Randomizer.SMZ3.Generation
 {
@@ -20,14 +21,16 @@ namespace Randomizer.SMZ3.Generation
         private readonly ILogger<Smz3Randomizer> _logger;
         private readonly IGameHintService _hintService;
         private readonly IPatcherService _patcherService;
+        private readonly PlaythroughService _playthroughService;
 
         public Smz3Randomizer(IFiller filler, IWorldAccessor worldAccessor, IGameHintService gameHintGenerator,
-            ILogger<Smz3Randomizer> logger, IPatcherService patcherService)
+            ILogger<Smz3Randomizer> logger, IPatcherService patcherService, PlaythroughService playthroughService)
         {
             Filler = filler;
             _worldAccessor = worldAccessor;
             _logger = logger;
             _patcherService = patcherService;
+            _playthroughService = playthroughService;
             _hintService = gameHintGenerator;
         }
 
@@ -99,7 +102,7 @@ namespace Randomizer.SMZ3.Generation
             Filler.SetRandom(rng);
             Filler.Fill(worlds, primaryConfig, cancellationToken);
 
-            var playthrough = Playthrough.Generate(worlds, primaryConfig);
+            var playthrough = _playthroughService.Generate(worlds, primaryConfig);
             var seedData = new SeedData
             (
                 guid: Guid.NewGuid().ToString("N"),

--- a/src/Randomizer.SMZ3/Infrastructure/PlaythroughService.cs
+++ b/src/Randomizer.SMZ3/Infrastructure/PlaythroughService.cs
@@ -1,0 +1,154 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using Randomizer.Data.Options;
+using Randomizer.Data.WorldData;
+using Randomizer.Data.WorldData.Regions;
+using Randomizer.Shared;
+
+namespace Randomizer.SMZ3.Infrastructure;
+
+public class PlaythroughService
+{
+    private ILogger<PlaythroughService> _logger;
+
+    public PlaythroughService(ILogger<PlaythroughService> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Simulates a rough playthrough and returns a value indicating whether
+    /// the playthrough is likely possible.
+    /// </summary>
+    /// <param name="worlds">A list of the worlds to play through.</param>
+    /// <param name="config">The config used to generate the worlds.</param>
+    /// <param name="playthrough">
+    /// If this method returns <see langword="true"/>, the generated
+    /// playthrough; otherwise, <see langword="null"/>.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if the playthrough is possible; otherwise,
+    /// <see langword="false"/>.
+    /// </returns>
+    public bool TryGenerate(IReadOnlyCollection<World> worlds, Config config, [MaybeNullWhen(true)] out Playthrough? playthrough)
+    {
+        try
+        {
+            playthrough = Generate(worlds, config);
+            return true;
+        }
+        catch (RandomizerGenerationException)
+        {
+            playthrough = null;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Simulates a rough playthrough of the specified worlds.
+    /// </summary>
+    /// <param name="worlds">A list of the worlds to play through.</param>
+    /// <param name="config">The config used to generate the worlds.</param>
+    /// <returns>A new <see cref="Playthrough"/>.</returns>
+    /// <exception cref="RandomizerGenerationException">
+    /// The seed is likely impossible.
+    /// </exception>
+    public Playthrough Generate(IReadOnlyCollection<World> worlds, Config config)
+    {
+        var spheres = GenerateSpheres(worlds.SelectMany(x => x.Locations));
+        return new Playthrough(config, spheres);
+    }
+
+    /// <summary>
+    /// Returns a list of all of the spheres for a given set of locations
+    /// </summary>
+    /// <param name="allLocations">List of locations to iterate through</param>
+    /// <param name="defaultRewards"></param>
+    /// <returns>A list of the spheres</returns>
+    /// <exception cref="RandomizerGenerationException">When not all locations are </exception>
+    public IEnumerable<Playthrough.Sphere> GenerateSpheres(IEnumerable<Location> allLocations, List<Reward>? defaultRewards = null)
+    {
+        var worlds = allLocations.Select(x => x.Region.World).Distinct();
+
+        defaultRewards ??= new List<Reward>();
+
+        var spheres = new List<Playthrough.Sphere>();
+        var locations = new List<Location>();
+        var items = new List<Item>();
+
+        var allRewards = worlds.SelectMany(w => w.Regions).OfType<IHasReward>().Select(x => x.Reward);
+        var regions = new List<Region>();
+        var rewards = defaultRewards;
+
+        var allBosses = worlds.SelectMany(w => w.GoldenBosses);
+        var bossRegions = worlds.SelectMany(w => w.GoldenBosses).Select(x => x.Region).Cast<IHasBoss>();
+        var bosses = new List<Boss>();
+
+        foreach (var world in worlds)
+        {
+            if (!world.Config.MetroidKeysanity)
+            {
+                var keycards = world.ItemPools.Keycards;
+                items.AddRange(keycards);
+            }
+
+            items.AddRange(ItemSettingOptions.GetStartingItemTypes(world.Config).Select(x => new Item(x, world)));
+        }
+
+        var initInventoryCount = items.Count;
+        var totalItemCount = allLocations.Select(x => x.Item).Count();
+        var prevRewardCount = 0;
+        while (items.Count - initInventoryCount < totalItemCount)
+        {
+            var sphere = new Playthrough.Sphere();
+
+            var tempProgression = new Progression(items, new List<Reward>(), new List<Boss>());
+            rewards = defaultRewards.Concat(allRewards.Where(x => x.Region.CanComplete(tempProgression))).ToList();
+            bosses = bossRegions.Where(x => x.CanBeatBoss(tempProgression)).Select(x => x.Boss).ToList();
+
+            var accessibleLocations = allLocations.Where(l => l.IsAvailable(new Progression(items.Where(i => i.World == l.World), rewards.Where(r => r.World == l.World), bosses.Where(b => b.World == l.World))));
+            var newLocations = accessibleLocations.Except(locations).ToList();
+            var newItems = newLocations.Select(l => l.Item).ToList();
+
+            locations.AddRange(newLocations);
+            items.AddRange(newItems);
+
+            _logger.LogDebug("Sphere {Number}: {ItemCount} new items | {RewardCount} new rewards", spheres.Count + 1, newItems.Count, rewards.Count - prevRewardCount);
+
+            if (!newItems.Any() && prevRewardCount == rewards.Count)
+            {
+                /* With no new items added we might have a problem, so list inaccessable items */
+                var inaccessibleLocations = allLocations.Where(l => !locations.Contains(l)).ToList();
+
+                _logger.LogDebug("Inaccesible locations: {}", string.Join(", ", inaccessibleLocations.Select(x => x.Id.ToString())));
+
+                // If there are a large number of inaccessible locations, throw an error if we can't beat the game
+                // We determine this on if all players can beat all 4 golden bosses, access the
+                if (inaccessibleLocations.Select(l => l.Item).Count() >= (15 * worlds.Count()))
+                {
+                    var vitalLocations = allLocations.Where(x => x.Id is LocationId.GanonsTowerMoldormChest or LocationId.KraidsLairVariaSuit or LocationId.WreckedShipEastSuper or LocationId.InnerMaridiaSpaceJump or LocationId.LowerNorfairRidleyTank).ToList();
+                    var crateriaBossKeys = items.Count(x => x.Type == ItemType.CardCrateriaBoss);
+                    if (accessibleLocations.Count(x => vitalLocations.Contains(x)) != vitalLocations.Count() || crateriaBossKeys != worlds.Count())
+                    {
+                        throw new RandomizerGenerationException("Too many inaccessible items, seed likely impossible.");
+                    }
+                }
+
+                sphere.InaccessibleLocations.AddRange(inaccessibleLocations);
+                break;
+            }
+
+            sphere.Locations.AddRange(newLocations);
+            sphere.Items.AddRange(newItems);
+            spheres.Add(sphere);
+            prevRewardCount = rewards.Count;
+
+            if (spheres.Count > 100)
+                throw new RandomizerGenerationException("Too many spheres, seed likely impossible.");
+        }
+
+        return spheres;
+    }
+}

--- a/src/Randomizer.SMZ3/Infrastructure/PlaythroughService.cs
+++ b/src/Randomizer.SMZ3/Infrastructure/PlaythroughService.cs
@@ -68,15 +68,18 @@ public class PlaythroughService
     /// <param name="defaultRewards"></param>
     /// <returns>A list of the spheres</returns>
     /// <exception cref="RandomizerGenerationException">When not all locations are </exception>
-    public IEnumerable<Playthrough.Sphere> GenerateSpheres(IEnumerable<Location> allLocations, List<Reward>? defaultRewards = null)
+    public IEnumerable<Playthrough.Sphere> GenerateSpheres(IEnumerable<Location> allLocations, Reward? defaultReward = null)
     {
         var worlds = allLocations.Select(x => x.Region.World).Distinct();
-
-        defaultRewards ??= new List<Reward>();
 
         var spheres = new List<Playthrough.Sphere>();
         var locations = new List<Location>();
         var items = new List<Item>();
+        var defaultRewards = new List<Reward>();
+        if (defaultReward != null)
+        {
+            defaultRewards.Add(defaultReward);
+        }
 
         var allRewards = worlds.SelectMany(w => w.Regions).OfType<IHasReward>().Select(x => x.Reward);
         var regions = new List<Region>();
@@ -105,7 +108,7 @@ public class PlaythroughService
             var sphere = new Playthrough.Sphere();
 
             var tempProgression = new Progression(items, new List<Reward>(), new List<Boss>());
-            rewards = defaultRewards.Concat(allRewards.Where(x => x.Region.CanComplete(tempProgression))).ToList();
+            rewards = allRewards.Where(x => x.Region.CanComplete(tempProgression)).Concat(defaultRewards).ToList();
             bosses = bossRegions.Where(x => x.CanBeatBoss(tempProgression)).Select(x => x.Boss).ToList();
 
             var accessibleLocations = allLocations.Where(l => l.IsAvailable(new Progression(items.Where(i => i.World == l.World), rewards.Where(r => r.World == l.World), bosses.Where(b => b.World == l.World))));

--- a/src/Randomizer.SMZ3/Playthrough.cs
+++ b/src/Randomizer.SMZ3/Playthrough.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Microsoft.Extensions.Logging;
 using Randomizer.Data.WorldData.Regions;
 using Randomizer.Data.WorldData;
 using Randomizer.Shared;
@@ -23,138 +24,6 @@ namespace Randomizer.SMZ3
 
         public IReadOnlyList<Sphere> Spheres { get; }
 
-        public static bool IsImportant(Location location, KeysanityMode keysanity)
-            => location.Item.Progression
-            || (location.Item.IsDungeonItem && keysanity is KeysanityMode.Both or KeysanityMode.Zelda)
-            || (location.Item.IsKeycard && keysanity is KeysanityMode.Both or KeysanityMode.SuperMetroid);
-
-        /// <summary>
-        /// Simulates a rough playthrough and returns a value indicating whether
-        /// the playthrough is likely possible.
-        /// </summary>
-        /// <param name="worlds">A list of the worlds to play through.</param>
-        /// <param name="config">The config used to generate the worlds.</param>
-        /// <param name="playthrough">
-        /// If this method returns <see langword="true"/>, the generated
-        /// playthrough; otherwise, <see langword="null"/>.
-        /// </param>
-        /// <returns>
-        /// <see langword="true"/> if the playthrough is possible; otherwise,
-        /// <see langword="false"/>.
-        /// </returns>
-        public static bool TryGenerate(IReadOnlyCollection<World> worlds, Config config, [MaybeNullWhen(true)] out Playthrough? playthrough)
-        {
-            try
-            {
-                playthrough = Generate(worlds, config);
-                return true;
-            }
-            catch (RandomizerGenerationException)
-            {
-                playthrough = null;
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Simulates a rough playthrough of the specified worlds.
-        /// </summary>
-        /// <param name="worlds">A list of the worlds to play through.</param>
-        /// <param name="config">The config used to generate the worlds.</param>
-        /// <returns>A new <see cref="Playthrough"/>.</returns>
-        /// <exception cref="RandomizerGenerationException">
-        /// The seed is likely impossible.
-        /// </exception>
-        public static Playthrough Generate(IReadOnlyCollection<World> worlds, Config config)
-        {
-            var spheres = GenerateSpheres(worlds.SelectMany(x => x.Locations));
-            return new Playthrough(config, spheres);
-        }
-
-        /// <summary>
-        /// Returns a list of all of the spheres for a given set of locations
-        /// </summary>
-        /// <param name="allLocations">List of locations to iterate through</param>
-        /// <returns>A list of the spheres</returns>
-        /// <exception cref="RandomizerGenerationException">When not all locations are </exception>
-        public static IEnumerable<Sphere> GenerateSpheres(IEnumerable<Location> allLocations)
-        {
-            var worlds = allLocations.Select(x => x.Region.World).Distinct();
-
-            var spheres = new List<Sphere>();
-            var locations = new List<Location>();
-            var items = new List<Item>();
-
-            var allRewards = worlds.SelectMany(w => w.Regions).OfType<IHasReward>().Select(x => x.Reward);
-            var regions = new List<Region>();
-            var rewards = new List<Reward>();
-
-            var allBosses = worlds.SelectMany(w => w.GoldenBosses);
-            var bossRegions = worlds.SelectMany(w => w.GoldenBosses).Select(x => x.Region).Cast<IHasBoss>();
-            var bosses = new List<Boss>();
-
-            foreach (var world in worlds)
-            {
-                if (!world.Config.MetroidKeysanity)
-                {
-                    var keycards = world.ItemPools.Keycards;
-                    items.AddRange(keycards);
-                }
-
-                items.AddRange(ItemSettingOptions.GetStartingItemTypes(world.Config).Select(x => new Item(x, world)));
-            }
-
-            var initInventoryCount = items.Count;
-            var totalItemCount = allLocations.Select(x => x.Item).Count();
-            var prevRewardCount = 0;
-            while (items.Count - initInventoryCount < totalItemCount)
-            {
-                var sphere = new Sphere();
-
-                var tempProgression = new Progression(items, new List<Reward>(), new List<Boss>());
-                rewards = allRewards.Where(x => x.Region.CanComplete(tempProgression)).ToList();
-                bosses = bossRegions.Where(x => x.CanBeatBoss(tempProgression)).Select(x => x.Boss).ToList();
-
-                var accessibleLocations = allLocations.Where(l => l.IsAvailable(new Progression(items.Where(i => i.World == l.World), rewards.Where(r => r.World == l.World), bosses.Where(b => b.World == l.World))));
-                var newLocations = accessibleLocations.Except(locations).ToList();
-                var newItems = newLocations.Select(l => l.Item).ToList();
-
-                locations.AddRange(newLocations);
-                items.AddRange(newItems);
-
-                if (!newItems.Any() && prevRewardCount == rewards.Count)
-                {
-                    /* With no new items added we might have a problem, so list inaccessable items */
-                    var inaccessibleLocations = allLocations.Where(l => !locations.Contains(l)).ToList();
-
-                    // If there are a large number of inaccessible locations, throw an error if we can't beat the game
-                    // We determine this on if all players can beat all 4 golden bosses, access the
-                    if (inaccessibleLocations.Select(l => l.Item).Count() >= (15 * worlds.Count()))
-                    {
-                        var vitalLocations = allLocations.Where(x => x.Id is LocationId.GanonsTowerMoldormChest or LocationId.KraidsLairVariaSuit or LocationId.WreckedShipEastSuper or LocationId.InnerMaridiaSpaceJump or LocationId.LowerNorfairRidleyTank).ToList();
-                        var crateriaBossKeys = items.Count(x => x.Type == ItemType.CardCrateriaBoss);
-                        if (accessibleLocations.Count(x => vitalLocations.Contains(x)) != vitalLocations.Count() || crateriaBossKeys != worlds.Count())
-                        {
-                            throw new RandomizerGenerationException("Too many inaccessible items, seed likely impossible.");
-                        }
-                    }
-
-                    sphere.InaccessibleLocations.AddRange(inaccessibleLocations);
-                    break;
-                }
-
-                sphere.Locations.AddRange(newLocations);
-                sphere.Items.AddRange(newItems);
-                spheres.Add(sphere);
-                prevRewardCount = rewards.Count;
-
-                if (spheres.Count > 100)
-                    throw new RandomizerGenerationException("Too many spheres, seed likely impossible.");
-            }
-
-            return spheres;
-        }
-
         public List<Dictionary<string, string>> GetPlaythroughText()
         {
             return Spheres.Select(x =>
@@ -169,7 +38,7 @@ namespace Randomizer.SMZ3
                         text.Add($"Inaccessible Item: {location}", $"{location.Item.Name}");
                 }
 
-                foreach (var location in x.Locations.Where(l => IsImportant(l, Config.KeysanityMode)))
+                foreach (var location in x.Locations.Where(l => l.IsPotentiallyImportant(Config.KeysanityMode)))
                 {
                     if (Config.MultiWorld)
                         text.Add($"{location} ({location.Region.World.Player})", $"{location.Item.Name} ({location.Item.World.Player})");

--- a/src/Randomizer.SMZ3/RandomizerServiceCollectionExtensions.cs
+++ b/src/Randomizer.SMZ3/RandomizerServiceCollectionExtensions.cs
@@ -9,6 +9,7 @@ using Randomizer.SMZ3.Contracts;
 using Randomizer.SMZ3.FileData.Patches;
 using Randomizer.SMZ3.Generation;
 using Randomizer.SMZ3.Infrastructure;
+using SQLitePCL;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -26,6 +27,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<SpritePatcherService>();
             services.AddSingleton<RomTextService>();
             services.AddTransient<RomLauncherService>();
+            services.AddTransient<PlaythroughService>();
             return services;
         }
 

--- a/src/Randomizer.Tools/Program.cs
+++ b/src/Randomizer.Tools/Program.cs
@@ -13,6 +13,7 @@ using Randomizer.Shared.Enums;
 using Randomizer.SMZ3;
 using Randomizer.SMZ3.Contracts;
 using Randomizer.SMZ3.Generation;
+using Randomizer.SMZ3.Infrastructure;
 using Serilog;
 using Serilog.Events;
 
@@ -83,13 +84,14 @@ namespace Randomizer.Tools
             var treeJunk = 0;
 
             var hintService = s_services.GetRequiredService<IGameHintService>();
+            var playthroughService = s_services.GetRequiredService<PlaythroughService>();
 
             Parallel.For(0, count, new ParallelOptions() { MaxDegreeOfParallelism = 12 }, (_, _) =>
             {
                 try
                 {
                     var seed = s_services.GetRequiredService<Smz3Randomizer>().GenerateSeed(config);
-                    var playthrough = Playthrough.Generate(seed.WorldGenerationData.Select(x => x.World).ToList(), config);
+                    var playthrough = playthroughService.Generate(seed.WorldGenerationData.Select(x => x.World).ToList(), config);
                     stats.Add(new StatsDetails
                     {
                         NumSpheres = playthrough.Spheres.Count,

--- a/tests/Randomizer.SMZ3.Tests/LogicTests/RandomizerTests.cs
+++ b/tests/Randomizer.SMZ3.Tests/LogicTests/RandomizerTests.cs
@@ -176,6 +176,7 @@ namespace Randomizer.SMZ3.Tests.LogicTests
                 .AddSingleton<IMetadataService, MetadataService>()
                 .AddSingleton<IGameHintService, GameHintService>()
                 .AddSingleton<IPatcherService, PatcherService>()
+                .AddTransient<PlaythroughService>()
                 .AddConfigs()
                 .BuildServiceProvider();
 
@@ -183,7 +184,8 @@ namespace Randomizer.SMZ3.Tests.LogicTests
             return new Smz3Randomizer(filler, new WorldAccessor(),
                 serviceProvider.GetRequiredService<IGameHintService>(),
                 GetLogger<Smz3Randomizer>(),
-                serviceProvider.GetRequiredService<IPatcherService>());
+                serviceProvider.GetRequiredService<IPatcherService>(),
+                serviceProvider.GetRequiredService<PlaythroughService>());
         }
     }
 }


### PR DESCRIPTION
Basically, when asking tracker if there is anything in the crystal dungeon, it was factoring in getting the crystal itself, so crystal dungeons would always say that they are required. Hint tiles avoided this by not giving hints around crystal dungeons unless you're playing keysanity.

For this, when generating the playthrough for tracker hints, she'll basically act like you have the crystal to prevent this from happening. Even if you ask for hints before completing the dungeon, she'll say something like "If it didn't have a crystal, you could skip it." For pendant dungeons, the hints factor in whether you've got the pendant or not, even for downstream locations. So if ped has something, she'll say that the dungeon is required until you beat the dungeon. After that, she'll say that it has nothing in it.