### PR TITLE
Fix usb2snes fxpak pro issue on Linux

### DIFF
--- a/src/Randomizer.App/Randomizer.App.csproj
+++ b/src/Randomizer.App/Randomizer.App.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net7.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>chozo20.ico</ApplicationIcon>
-    <Version>9.7.2</Version>
+    <Version>9.7.3</Version>
     <Title>SMZ3 Cas' Randomizer</Title>
     <AssemblyTitle>SMZ3 Cas' Randomizer</AssemblyTitle>
     <Authors>Vivelin</Authors>


### PR DESCRIPTION
So recently I figured out that SMZ3 Cas' had an issue with autotracking with QUSB2SNES and the Fx Pak Pro on Linux. Linux + QUSB2SNES + RetroArch works fine. Windows + QUSB2SNES + Fx Pak Pro also work just fine.

Turns out, for whatever reason, for read requests of more than 128 bytes on Linux from the Fx Pak Pro, it splits out the requests into 128 byte chunks that are sent over multiple responses. No where is this documented. :) 