### PR TITLE
Fix manual super missile placement

### DIFF
--- a/src/Randomizer.SMZ3/Generation/StandardFiller.cs
+++ b/src/Randomizer.SMZ3/Generation/StandardFiller.cs
@@ -180,7 +180,15 @@ namespace Randomizer.SMZ3.Generation
                 {
                     var itemType = (ItemType)value;
 
-                    if (progressionItems.Any(x => x.Type == itemType))
+                    if (niceItems.Any(x => x.Type == itemType))
+                    {
+                        placedItems.Add(FillItemAtLocation(niceItems, itemType, location));
+                    }
+                    else if (junkItems.Any(x => x.Type == itemType))
+                    {
+                        placedItems.Add(FillItemAtLocation(junkItems, itemType, location));
+                    }
+                    else if (progressionItems.Any(x => x.Type == itemType))
                     {
                         //var location = worlds[0].Locations.First(x => x.Id == locationId);
                         var itemsRequired = Logic.GetMissingRequiredItems(location, new Progression(), out _);
@@ -194,14 +202,6 @@ namespace Randomizer.SMZ3.Generation
                         {
                             throw new RandomizerGenerationException($"{itemType} was selected as the item for {location}, but it is required to get there.");
                         }
-                    }
-                    else if (niceItems.Any(x => x.Type == itemType))
-                    {
-                        placedItems.Add(FillItemAtLocation(niceItems, itemType, location));
-                    }
-                    else if (junkItems.Any(x => x.Type == itemType))
-                    {
-                        placedItems.Add(FillItemAtLocation(junkItems, itemType, location));
                     }
                 }
             }


### PR DESCRIPTION
Phiggle found an issue where if you manually place a super missile at a location, the generator will crash. This is because when it places a super missile at a given location, it pulls from the progression list of items. When it tries to place a super missile in sphere 1, it also tries to pull from the list of progression items.