### PR TITLE
Fix issues with settings strings in with multiworlds & plandos

### DIFF
--- a/src/Randomizer.App/Windows/MultiplayerStatusWindow.xaml.cs
+++ b/src/Randomizer.App/Windows/MultiplayerStatusWindow.xaml.cs
@@ -206,6 +206,8 @@ namespace Randomizer.App.Windows
         {
             if (ParentPanel.ShowGenerateRomWindow(null, true) != true) return;
             var config = ParentPanel.Options.ToConfig();
+            config.Seed = ""; // Not currently supported in multiplayer
+            config.SettingsString = ""; // Not currently supported in multiplayer
             config.PlayerGuid = _multiplayerClientService.CurrentPlayerGuid!;
             config.PlayerName = _multiplayerClientService.LocalPlayer!.PlayerName;
             config.PhoneticName = _multiplayerClientService.LocalPlayer!.PhoneticName;

--- a/src/Randomizer.Data/Options/PlandoConfig.cs
+++ b/src/Randomizer.Data/Options/PlandoConfig.cs
@@ -31,6 +31,7 @@ namespace Randomizer.Data.Options
         /// <param name="world">The world instance to export to a config.</param>
         public PlandoConfig(World world)
         {
+            Seed = world.Config.Seed;
             KeysanityMode = world.Config.KeysanityMode;
             GanonsTowerCrystalCount = world.Config.GanonCrystalCount;
             GanonCrystalCount = world.Config.GanonCrystalCount;
@@ -59,6 +60,8 @@ namespace Randomizer.Data.Options
         /// </summary>
         [YamlIgnore]
         public string FileName { get; set; } = "";
+
+        public string Seed { get; set; } = "";
 
         /// <summary>
         /// Gets or sets a value indicating whether Keysanity should be enabled.

--- a/src/Randomizer.Data/Options/PlandoTextConfig.cs
+++ b/src/Randomizer.Data/Options/PlandoTextConfig.cs
@@ -1,4 +1,6 @@
-﻿namespace Randomizer.Data.Options;
+﻿using YamlDotNet.Serialization;
+
+namespace Randomizer.Data.Options;
 
 public class PlandoTextConfig
 {
@@ -83,6 +85,7 @@ public class PlandoTextConfig
 
     public string? HintTileSouthEastDarkworldCave { get; init; }
 
+    [YamlIgnore]
     public bool HasHintTileText => !string.IsNullOrEmpty(HintTileEasternPalace) ||
                                    !string.IsNullOrEmpty(HintTileTowerOfHeraFloor4) ||
                                    !string.IsNullOrEmpty(HintTileSpectacleRock) ||

--- a/src/Randomizer.SMZ3/Generation/PlandoConfigLoader.cs
+++ b/src/Randomizer.SMZ3/Generation/PlandoConfigLoader.cs
@@ -1,12 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
+﻿using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Randomizer.Data.Options;
 using Randomizer.SMZ3.Contracts;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
 
 namespace Randomizer.SMZ3.Generation
 {
@@ -15,7 +14,10 @@ namespace Randomizer.SMZ3.Generation
         public async Task<PlandoConfig> LoadAsync(string path,
             CancellationToken cancellationToken = default)
         {
-            var serializer = new YamlDotNet.Serialization.Deserializer();
+            var serializer = new DeserializerBuilder()
+                .WithNamingConvention(PascalCaseNamingConvention.Instance)
+                .IgnoreUnmatchedProperties()
+                .Build();
             var yaml = await File.ReadAllTextAsync(path, Encoding.UTF8, cancellationToken);
             var config = serializer.Deserialize<PlandoConfig>(yaml);
             config.FileName = Path.GetFileNameWithoutExtension(path);

--- a/src/Randomizer.SMZ3/Generation/RomGenerationService.cs
+++ b/src/Randomizer.SMZ3/Generation/RomGenerationService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -67,6 +68,10 @@ public class RomGenerationService
     public SeedData GeneratePlandoSeed(RandomizerOptions options, PlandoConfig plandoConfig)
     {
         var config = options.ToConfig();
+        config.Seed = plandoConfig.Seed;
+        config.SettingsString = "";
+        config.ItemOptions = new Dictionary<string, int>();
+        config.LocationItems = new Dictionary<LocationId, int>();
         config.PlandoConfig = plandoConfig;
         config.KeysanityMode = plandoConfig.KeysanityMode;
         config.GanonsTowerCrystalCount = plandoConfig.GanonsTowerCrystalCount;

--- a/src/Randomizer.SMZ3/Generation/Smz3Plandomizer.cs
+++ b/src/Randomizer.SMZ3/Generation/Smz3Plandomizer.cs
@@ -64,6 +64,10 @@ namespace Randomizer.SMZ3.Generation
                 plandoName = Regex.Replace(plandoName, "(^Spoiler_Plando_|_[0-9]+$)", "");
             }
 
+            var seed = string.IsNullOrEmpty(config.Seed) ? plandoName : config.Seed;
+            var seedNumber = ISeededRandomizer.ParseSeed(ref seed);
+            var rng = new Random(seedNumber).Sanitize();
+
             var seedData = new SeedData
             (
                 guid: Guid.NewGuid().ToString("N"),
@@ -83,8 +87,8 @@ namespace Randomizer.SMZ3.Generation
                     World = world,
                     Worlds = worlds,
                     SeedGuid = seedData.Guid,
-                    Seed = 0,
-                    Random = new Random().Sanitize(),
+                    Seed = seedNumber,
+                    Random = rng,
                     PlandoConfig = config.PlandoConfig ?? new PlandoConfig()
                 });
 

--- a/src/Randomizer.SMZ3/Generation/Smz3Randomizer.cs
+++ b/src/Randomizer.SMZ3/Generation/Smz3Randomizer.cs
@@ -40,28 +40,6 @@ namespace Randomizer.SMZ3.Generation
 
         protected IFiller Filler { get; }
 
-        public static int ParseSeed(ref string? input)
-        {
-            int seed;
-            if (string.IsNullOrEmpty(input))
-            {
-                seed = System.Security.Cryptography.RandomNumberGenerator.GetInt32(0, int.MaxValue);
-            }
-            else
-            {
-                input = input.Trim();
-                if (!Parse.AsInteger(input, out seed) // Accept plain ints as seeds (i.e. mostly original behavior)
-                    && !Parse.AsHex(input, out seed)) // Accept hex seeds (e.g. seed as stored in ROM info)
-                {
-                    // When all else fails, accept any other input by hashing it
-                    seed = NonCryptographicHash.Fnv1a(input);
-                }
-            }
-
-            input = seed.ToString("D", CultureInfo.InvariantCulture);
-            return seed;
-        }
-
         public SeedData GenerateSeed(Config config, CancellationToken cancellationToken = default)
             => GenerateSeed(new List<Config> { config }, "", cancellationToken);
 
@@ -72,7 +50,7 @@ namespace Randomizer.SMZ3.Generation
         {
             var primaryConfig = configs.OrderBy(x => x.Id).First();
 
-            var seedNumber = ParseSeed(ref seed);
+            var seedNumber = ISeededRandomizer.ParseSeed(ref seed);
             var rng = new Random(seedNumber);
             primaryConfig.Seed = seedNumber.ToString();
 


### PR DESCRIPTION
Phiggle was running into some issues with plandos where previously entered settings strings would sort of half be pulled in with plandos. The plando would be used for adding items, but tracker would respond as if someone manually placed the items via the generation option. This fixes #467 by clearing out those fields for plandos.

Phiggle also noticed that the hash string at the top would be different each time loaded. I think there are also a few minor things in plandos that would be out of sync slightly. Because of this, I'm adding a new seed value to the plando and using that.

I had a similar issue with multiworlds where the config string was disabled, but it was still being used.