### PR TITLE
Add loading bar while loading sprites

### DIFF
--- a/src/TrackerCouncil.Smz3.UI/Services/MainWindowService.cs
+++ b/src/TrackerCouncil.Smz3.UI/Services/MainWindowService.cs
@@ -164,6 +164,7 @@ public class MainWindowService(
         {
             await spriteService.LoadSpritesAsync();
             trackerSpriteService.LoadSprites();
+            _model.IsLoadingSprites = false;
             return;
         }
 
@@ -212,6 +213,7 @@ public class MainWindowService(
 
         await spriteService.LoadSpritesAsync();
         trackerSpriteService.LoadSprites();
+        _model.IsLoadingSprites = false;
     }
 
     public async Task<string?> InstallWindowsUpdate(string url)

--- a/src/TrackerCouncil.Smz3.UI/ViewModels/MainWindowViewModel.cs
+++ b/src/TrackerCouncil.Smz3.UI/ViewModels/MainWindowViewModel.cs
@@ -11,6 +11,7 @@ public partial class MainWindowViewModel : ViewModelBase
 
     [Reactive] public partial bool DisplayNewVersionBanner { get; set; }
     [Reactive] public partial bool DisplayDownloadLink { get; set; }
+    [Reactive] public partial bool IsLoadingSprites { get; set; } = true;
 
     public string NewVersionGitHubUrl { get; set; } = "";
     public string? NewVersionDownloadUrl { get; set; }

--- a/src/TrackerCouncil.Smz3.UI/Views/MainWindow.axaml
+++ b/src/TrackerCouncil.Smz3.UI/Views/MainWindow.axaml
@@ -18,7 +18,7 @@
     <Design.DataContext>
         <!-- This only sets the DataContext for the previewer in an IDE,
              to set the actual DataContext for runtime, set the DataContext property in code (look at App.axaml.cs) -->
-        <viewModels:MainWindowViewModel DisplayNewVersionBanner="True" DisplayDownloadLink="True" />
+        <viewModels:MainWindowViewModel DisplayNewVersionBanner="True" DisplayDownloadLink="True" IsLoadingSprites="True" />
     </Design.DataContext>
 
   <LayoutTransformControl x:Name="MainLayout">
@@ -57,7 +57,11 @@
         </StackPanel>
 
       </controls:HeaderFooter>
-      <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Top">
+      <StackPanel Grid.Row="1" Margin="10" VerticalAlignment="Center" IsVisible="{Binding IsLoadingSprites}">
+        <TextBlock>Loading...</TextBlock>
+        <ProgressBar IsIndeterminate="True"></ProgressBar>
+      </StackPanel>
+      <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Top" IsVisible="{Binding !IsLoadingSprites}">
         <Button Margin="0 5 5 0" Name="MenuButton" Click="OptionsMenuItem_OnClick">
           <Button.Styles>
             <Style Selector="Button">
@@ -85,7 +89,7 @@
           <avalonia:MaterialIcon Kind="AboutCircle" Width="25" Height="25"/>
         </Button>
       </StackPanel>
-      <TabControl Grid.Row="1">
+      <TabControl Grid.Row="1" IsVisible="{Binding !IsLoadingSprites}">
         <TabItem Header="Singleplayer">
           <views:SoloRomListPanel Name="SoloRomListPanel"></views:SoloRomListPanel>
         </TabItem>


### PR DESCRIPTION
I believe this should fix skennedy's issue here: https://github.com/TheTrackerCouncil/SMZ3Randomizer/issues/759. Waiting to officially close that out until after skennedy can verify something for me.

From my testing, it looks like the tracker profiles are some of the last things to load, causing it to not show the options when you open. I thought about trying to refresh the combo box after the data loaded, but I think this could apply to other things. For example, you could open tracker without them loaded, or you can try to generate a seed potentially without the sprites loaded potentially. This seemed like the most reliable way to go.

<img width="907" height="760" alt="image" src="https://github.com/user-attachments/assets/a21e789a-b749-43d4-9779-43431d610f82" />
